### PR TITLE
Flushing DataOutputStream before calling toByteArray on the underlying ByteArrayOutputStream

### DIFF
--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/wire/MqttSubscribe.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/wire/MqttSubscribe.java
@@ -128,6 +128,7 @@ public class MqttSubscribe extends MqttWireMessage {
 				encodeUTF8(dos,names[i]);
 				dos.writeByte(qos[i]);
 			}
+			dos.flush();
 			return baos.toByteArray();
 		} catch (IOException ex) {
 			throw new MqttException(ex);

--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/wire/MqttUnsubscribe.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/wire/MqttUnsubscribe.java
@@ -104,6 +104,7 @@ public class MqttUnsubscribe extends MqttWireMessage {
 		for (int i=0; i<names.length; i++) {
 			encodeUTF8(dos, names[i]);
 		}
+		dos.flush();
 		return baos.toByteArray();
 	}
 


### PR DESCRIPTION
When a DataOutputStream instance wraps an underlying ByteArrayOutputStream instance,
it is recommended to flush or close the DataOutputStream before invoking the underlying instances's toByteArray(). Also, it is a good practice to call flush/close explicitly as mentioned for example [here](http://stackoverflow.com/questions/2984538/how-to-use-bytearrayoutputstream-and-dataoutputstream-simultaneously-java).
This pull request adds a flush method before calling toByteArray().
Signed-off-by: Wajihulhassan wajih.lums@gmail.com
