### PR TITLE
Allow WebSocket query parameters.  Disconnect fix.

### DIFF
--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/MqttConnectOptions.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/MqttConnectOptions.java
@@ -486,6 +486,13 @@ public class MqttConnectOptions {
 	protected static int validateURI(String srvURI) {
 		try {
 			URI vURI = new URI(srvURI);
+			if (vURI.getScheme().equals("ws")){
+				return URI_TYPE_WS;
+			}
+			else if (vURI.getScheme().equals("wss")) {
+				return URI_TYPE_WSS;
+			}
+
 			if (!vURI.getPath().equals("")) {
 				throw new IllegalArgumentException(srvURI);
 			}
@@ -497,12 +504,6 @@ public class MqttConnectOptions {
 			}
 			else if (vURI.getScheme().equals("local")) {
 				return URI_TYPE_LOCAL;
-			}
-			else if (vURI.getScheme().equals("ws")){
-				return URI_TYPE_WS;
-			}
-			else if (vURI.getScheme().equals("wss")) {
-				return URI_TYPE_WSS;
 			}
 			else {
 				throw new IllegalArgumentException(srvURI);
@@ -529,7 +530,7 @@ public class MqttConnectOptions {
 		}
 		this.MqttVersion = MqttVersion;
 	}
-	
+
 	/**
 	 * Returns whether the client will automatically attempt to reconnect to the
 	 * server if the connection is lost

--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/websocket/WebSocketNetworkModule.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/websocket/WebSocketNetworkModule.java
@@ -20,7 +20,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.PipedInputStream;
-import java.net.SocketException;
 import java.nio.ByteBuffer;
 
 import javax.net.SocketFactory;
@@ -35,6 +34,7 @@ public class WebSocketNetworkModule extends TCPNetworkModule {
 	private static final String CLASS_NAME = WebSocketNetworkModule.class.getName();
 	private static final Logger log = LoggerFactory.getLogger(LoggerFactory.MQTT_CLIENT_MSG_CAT, CLASS_NAME);
 		
+	private String uri;
 	private String host;
 	private int port;
 	private PipedInputStream pipedInputStream;
@@ -62,8 +62,9 @@ public class WebSocketNetworkModule extends TCPNetworkModule {
 		}
 	};
 	
-	public WebSocketNetworkModule(SocketFactory factory, String host, int port, String resourceContext){
+	public WebSocketNetworkModule(SocketFactory factory, String uri, String host, int port, String resourceContext){
 		super(factory, host, port, resourceContext);
+		this.uri = uri;
 		this.host = host;
 		this.port = port;
 		this.pipedInputStream = new PipedInputStream();
@@ -73,7 +74,7 @@ public class WebSocketNetworkModule extends TCPNetworkModule {
 	
 	public void start() throws IOException, MqttException {
 		super.start();
-		WebSocketHandshake handshake = new WebSocketHandshake(getSocketInputStream(), getSocketOutputStream(), host, port);
+		WebSocketHandshake handshake = new WebSocketHandshake(getSocketInputStream(), getSocketOutputStream(), uri, host, port);
 		handshake.execute();
 		this.webSocketReceiver = new WebSocketReceiver(getSocketInputStream(), pipedInputStream);
 		webSocketReceiver.start("webSocketReceiver");
@@ -104,7 +105,7 @@ public class WebSocketNetworkModule extends TCPNetworkModule {
 		byte[] rawFrame = frame.encodeFrame();
 		getSocketOutputStream().write(rawFrame);
 		getSocketOutputStream().flush();
-		
+
 		if(webSocketReceiver != null){
 			webSocketReceiver.stop();
 		}

--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/websocket/WebSocketReceiver.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/websocket/WebSocketReceiver.java
@@ -24,10 +24,10 @@ import org.eclipse.paho.client.mqttv3.logging.Logger;
 import org.eclipse.paho.client.mqttv3.logging.LoggerFactory;
 
 public class WebSocketReceiver implements Runnable{
-	
+
 	private static final String CLASS_NAME = WebSocketReceiver.class.getName();
 	private static final Logger log = LoggerFactory.getLogger(LoggerFactory.MQTT_CLIENT_MSG_CAT, CLASS_NAME);
-	
+
 	private boolean running = false;
 	private boolean stopping = false;
 	private Object lifecycle = new Object();
@@ -35,13 +35,13 @@ public class WebSocketReceiver implements Runnable{
 	private Thread receiverThread = null;
 	private volatile boolean receiving;
 	private PipedOutputStream pipedOutputStream;
-	
+
 	public WebSocketReceiver(InputStream input, PipedInputStream pipedInputStream) throws IOException{
 		this.input = input;
 		this.pipedOutputStream = new PipedOutputStream();
 		pipedInputStream.connect(pipedOutputStream);
 	}
-	
+
 	/**
 	 * Starts up the WebSocketReceiver's thread
 	 */
@@ -57,7 +57,7 @@ public class WebSocketReceiver implements Runnable{
 			}
 		}
 	}
-	
+
 	/**
 	 * Stops this WebSocketReceiver's thread.
 	 * This call will block.
@@ -89,7 +89,7 @@ public class WebSocketReceiver implements Runnable{
 
 	public void run() {
 		final String methodName = "run";
-		
+
 		while (running && (input != null)) {
 			try {
 				//@TRACE 852=network read message
@@ -97,43 +97,41 @@ public class WebSocketReceiver implements Runnable{
 				receiving = input.available() > 0;
 				WebSocketFrame incomingFrame = new WebSocketFrame(input);
 				if(!incomingFrame.isCloseFlag()){
-				for(int i = 0; i < incomingFrame.getPayload().length; i++){
-					pipedOutputStream.write(incomingFrame.getPayload()[i]);
-				}
-				
-				pipedOutputStream.flush();
+					for(int i = 0; i < incomingFrame.getPayload().length; i++){
+						pipedOutputStream.write(incomingFrame.getPayload()[i]);
+					}
+
+					pipedOutputStream.flush();
 				} else {
 					if(!stopping){
 						throw new IOException("Server sent a WebSocket Frame with the Stop OpCode");
 					}
 				}
-				
+
 				receiving = false;
-				
+
 			} catch (IOException ex) {
-				// Exception occurred whilst reading the stream. 
-				System.out.println("WebSocketReceiver.java : run(): Exception Occured.");
-				ex.printStackTrace();
-				closeOutputStream();
+				// Exception occurred whilst reading the stream.
+				this.stop();
 			}
 		}
 	}
-	
+
 	private void closeOutputStream(){
 		try {
 			pipedOutputStream.close();
 		} catch (IOException e) {
 		}
 	}
-	
+
 
 	public boolean isRunning() {
 		return running;
 	}
-	
+
 	/**
 	 * Returns the receiving state.
-	 * 
+	 *
 	 * @return true if the receiver is receiving data, false otherwise.
 	 */
 	public boolean isReceiving(){


### PR DESCRIPTION
Added ability to pass a custom HTTP path as well as query parameters
when connecting via WebSockets.
(bug https://bugs.eclipse.org/bugs/show_bug.cgi?id=488345)

Fix for disconnect issue when WebSocket close frame is sent by broker.
Fix existed from previous commit but left Receiver intact.
(bug https://bugs.eclipse.org/bugs/show_bug.cgi?id=488600)

This contribution complies with http://www.eclipse.org/legal/CoO.php
Signed-off-by: John Rotach rotach@amazon.com
