### PR TITLE
Fixes #194 - ignore shutdownConnection if ClientComms already closed

### DIFF
--- a/org.eclipse.paho.client.mqttv3/src/main/java-templates/org/eclipse/paho/client/mqttv3/internal/ClientComms.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java-templates/org/eclipse/paho/client/mqttv3/internal/ClientComms.java
@@ -293,7 +293,7 @@ public class ClientComms {
 		// This method could concurrently be invoked from many places only allow it
 		// to run once.
 		synchronized(conLock) {
-			if (stoppingComms || closePending) {
+			if (stoppingComms || closePending || isClosed()) {
 				return;
 			}
 			stoppingComms = true;


### PR DESCRIPTION
it is possible for multiple places to call shutdownConnection

what we have observed is that shutdownConnection can be called,
then close, and then another shutdownConnection

the second shutdownConnection is still being run even though
the ClientComms is now closed (stoppingComms is false because
the original shutdownConnection is done executing and closePending
is false because close was not called as shutdownConnection
was running)

this can cause NPE because close has already destroyed the class

Signed-off-by: Stan Surmay ssurmay@bandwidth.com
