### PR TITLE
Supporting basic authorization for websocket

### DIFF
--- a/org.eclipse.paho.client.mqttv3.test/src/test/java/org/eclipse/paho/client/mqttv3/test/WebSocketTest.java
+++ b/org.eclipse.paho.client.mqttv3.test/src/test/java/org/eclipse/paho/client/mqttv3/test/WebSocketTest.java
@@ -243,8 +243,27 @@ public class WebSocketTest {
 	  
   }
 
+  @Test
+  public void testBasicAuth() throws Exception {
+    String methodName = Utility.getMethodName();
+    LoggingUtilities.banner(log, cclass, methodName);
 
+    String userInfo = "username:password";
 
+    String clientId = methodName;
+
+    URI serverURIWithUserInfo = new URI(serverURI.getScheme(),
+            userInfo,
+            serverURI.getHost(),
+            serverURI.getPort(),
+            serverURI.getPath(),
+            serverURI.getQuery(),
+            serverURI.getFragment());
+
+    IMqttClient client = clientFactory.createMqttClient(serverURIWithUserInfo, clientId);
+    client.connect();
+    client.disconnect();
+  }
 
   // -------------------------------------------------------------
   // Helper methods/classes

--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/websocket/WebSocketHandshake.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/websocket/WebSocketHandshake.java
@@ -77,7 +77,7 @@ public class WebSocketHandshake {
 	/**
 	 * Builds and sends the HTTP Header GET Request
 	 * for the socket.
-	 * @param Base64 encoded key
+	 * @param key Base64 encoded key
 	 * @throws IOException
 	 */
 	private void sendHandshakeRequest(String key) throws IOException{
@@ -99,6 +99,12 @@ public class WebSocketHandshake {
 			pw.print("Sec-WebSocket-Key: " + key + LINE_SEPARATOR);
 			pw.print("Sec-WebSocket-Protocol: mqttv3.1" + LINE_SEPARATOR);
 			pw.print("Sec-WebSocket-Version: 13" + LINE_SEPARATOR);
+
+			String userInfo = srvUri.getUserInfo();
+			if(userInfo != null) {
+				pw.print("Authorization: Basic " + Base64.encode(userInfo) + LINE_SEPARATOR);
+			}
+
 			pw.print(LINE_SEPARATOR);
 			pw.flush();
 		} catch (URISyntaxException e) {
@@ -108,7 +114,7 @@ public class WebSocketHandshake {
 	
 	/**
 	 * Receives the Handshake response and verifies that it is valid.
-	 * @param Base64 encoded key
+	 * @param key Base64 encoded key
 	 * @throws IOException
 	 */
 	private void receiveHandshakeResponse(String key) throws IOException {


### PR DESCRIPTION
Basic authorization for websocket

Usage:
For URI, use ws(s)://username:password@host/path

This is done by sending an Authorization header in the initial handshake.

Also modified extracting hostname / port from address, to use the URI class for help, instead of using substrings (which didn't take userinfo into account).

Only added one unit test which verifies that this does not fail when connecting to the test server. I have successfully tested against the server I'm using, which requires basic authentication.
