### PR TITLE
Adding UUIDs to test topics to avoid build clashes

### DIFF
--- a/org.eclipse.paho.client.mqttv3.test/src/test/java/org/eclipse/paho/client/mqttv3/test/BasicSSLTest.java
+++ b/org.eclipse.paho.client.mqttv3.test/src/test/java/org/eclipse/paho/client/mqttv3/test/BasicSSLTest.java
@@ -15,15 +15,11 @@ package org.eclipse.paho.client.mqttv3.test;
 
 import java.io.File;
 import java.net.URI;
+import java.util.UUID;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import org.eclipse.paho.client.mqttv3.IMqttClient;
-import org.eclipse.paho.client.mqttv3.IMqttDeliveryToken;
-import org.eclipse.paho.client.mqttv3.MqttCallback;
-import org.eclipse.paho.client.mqttv3.MqttConnectOptions;
-import org.eclipse.paho.client.mqttv3.MqttException;
-import org.eclipse.paho.client.mqttv3.MqttMessage;
 import org.eclipse.paho.client.mqttv3.MqttTopic;
 import org.eclipse.paho.client.mqttv3.test.client.MqttClientFactoryPaho;
 import org.eclipse.paho.client.mqttv3.test.logging.LoggingUtilities;
@@ -51,6 +47,8 @@ public class BasicSSLTest {
   private static MqttClientFactoryPaho clientFactory;
   private static File keystorePath;
   private static int messageSize = 100000;
+  private static String topicPrefix;
+
 
   /**
    * @throws Exception 
@@ -66,6 +64,8 @@ public class BasicSSLTest {
       serverHost = serverURI.getHost();
       clientFactory = new MqttClientFactoryPaho();
       clientFactory.open();
+      topicPrefix = "BasicSSLTest-" + UUID.randomUUID().toString() + "-";
+
     }
     catch (Exception exception) {
       log.log(Level.SEVERE, "caught exception:", exception);
@@ -118,7 +118,7 @@ public class BasicSSLTest {
       log.info("Connecting...(serverURI:" + serverURI + ", ClientId:" + methodName);
       mqttClient.connect();
 
-      String[] topicNames = new String[]{methodName + "/Topic"};
+      String[] topicNames = new String[]{topicPrefix + methodName + "/Topic"};
       int[] topicQos = {2};
       log.info("Subscribing to..." + topicNames[0]);
       mqttClient.subscribe(topicNames, topicQos);
@@ -170,7 +170,7 @@ public class BasicSSLTest {
     IMqttClient[] mqttPublisher = new IMqttClient[4];
     IMqttClient[] mqttSubscriber = new IMqttClient[20];
     try {
-      String[] topicNames = new String[]{methodName + "/Topic"};
+      String[] topicNames = new String[]{topicPrefix + methodName + "/Topic"};
       int[] topicQos = {0};
 
       MqttTopic[] mqttTopic = new MqttTopic[mqttPublisher.length];
@@ -278,7 +278,7 @@ public class BasicSSLTest {
       log.info("Connecting...(serverURI:" + serverURI + ", ClientId:" + methodName);
       mqttClient.connect();
 
-      String[] topicNames = new String[]{methodName + "/Topic"};
+      String[] topicNames = new String[]{topicPrefix + methodName + "/Topic"};
       int[] topicQos = {2};
       log.info("Subscribing to..." + topicNames[0]);
       mqttClient.subscribe(topicNames, topicQos);

--- a/org.eclipse.paho.client.mqttv3.test/src/test/java/org/eclipse/paho/client/mqttv3/test/BasicTest.java
+++ b/org.eclipse.paho.client.mqttv3.test/src/test/java/org/eclipse/paho/client/mqttv3/test/BasicTest.java
@@ -15,6 +15,7 @@ package org.eclipse.paho.client.mqttv3.test;
 
 import java.net.URI;
 import java.util.ArrayList;
+import java.util.UUID;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -47,6 +48,8 @@ public class BasicTest {
 
   private static URI serverURI;
   private static MqttClientFactoryPaho clientFactory;
+  private static String topicPrefix;
+
 
   /**
    * @throws Exception 
@@ -61,6 +64,8 @@ public class BasicTest {
       serverURI = TestProperties.getServerURI();
       clientFactory = new MqttClientFactoryPaho();
       clientFactory.open();
+      topicPrefix = "BasicTest-" + UUID.randomUUID().toString() + "-";
+
     }
     catch (Exception exception) {
       log.log(Level.SEVERE, "caught exception:", exception);
@@ -193,7 +198,7 @@ public class BasicTest {
 
     IMqttClient client = null;
     try {
-      String topicStr = "topic" + "_02";
+      String topicStr = topicPrefix + "topic" + "_02";
       String clientId = methodName;
       client = clientFactory.createMqttClient(serverURI, clientId);
 

--- a/org.eclipse.paho.client.mqttv3.test/src/test/java/org/eclipse/paho/client/mqttv3/test/Bug443142Test.java
+++ b/org.eclipse.paho.client.mqttv3.test/src/test/java/org/eclipse/paho/client/mqttv3/test/Bug443142Test.java
@@ -1,6 +1,7 @@
 package org.eclipse.paho.client.mqttv3.test;
 
 import java.net.URI;
+import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -28,6 +29,7 @@ import org.junit.Test;
 public class Bug443142Test {
     private static final Logger log = Logger.getLogger(Bug443142Test.class.getName());
     private static URI serverURI;
+    private static String topicPrefix;
 
     @BeforeClass
     public static void setUpBeforeClass() throws Exception {
@@ -35,6 +37,8 @@ public class Bug443142Test {
             String methodName = Utility.getMethodName();
             LoggingUtilities.banner(log, Bug443142Test.class, methodName);
             serverURI = TestProperties.getServerURI();
+            topicPrefix = "Bug443142Test-" + UUID.randomUUID().toString() + "-";
+
         }
         catch (Exception exception) {
             log.log(Level.SEVERE, "caught exception:", exception);
@@ -45,17 +49,18 @@ public class Bug443142Test {
     @Test
     public void testBug443142() throws Exception {
         CountDownLatch stopLatch = new CountDownLatch(1);
-        MqttClient client1 = new MqttClient(serverURI.toString(), "foo");
+        MqttClient client1 = new MqttClient(serverURI.toString(), "Bug443142Test-" + UUID.randomUUID().toString());
         client1.connect();
-        MqttClient client2 = new MqttClient(serverURI.toString(), "bar");
+        MqttClient client2 = new MqttClient(serverURI.toString(),"Bug443142Test-" + UUID.randomUUID().toString());
         client2.setCallback(new MyMqttCallback(stopLatch));
         client2.connect();
-        client2.subscribe("bar");
+        String barTopic = topicPrefix + "bar";
+        client2.subscribe( barTopic);
 
         // publish messages until the queue is full > 10
         for (int i = 0; i < 16; i++) {
             MqttMessage message = new MqttMessage(("foo-" + i).getBytes());
-            client1.publish("bar", message);
+            client1.publish(barTopic, message);
             log.info("client1 publish: " + message);
         }
 

--- a/org.eclipse.paho.client.mqttv3.test/src/test/java/org/eclipse/paho/client/mqttv3/test/LiveTakeOverTest.java
+++ b/org.eclipse.paho.client.mqttv3.test/src/test/java/org/eclipse/paho/client/mqttv3/test/LiveTakeOverTest.java
@@ -15,6 +15,7 @@
 package org.eclipse.paho.client.mqttv3.test;
 
 import java.net.URI;
+import java.util.UUID;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -41,6 +42,8 @@ public class LiveTakeOverTest {
 
   private static URI serverURI;
   private static MqttClientFactoryPaho clientFactory;
+  private static String topicPrefix;
+
 
   static enum FirstClientState {
     INITIAL,
@@ -51,7 +54,7 @@ public class LiveTakeOverTest {
   }
 
   private static String ClientId = "TakeOverClient";
-  private static String FirstSubTopicString = "FirstClient/Topic";
+  private static String FirstSubTopicString;
 
   /**
    * @throws Exception 
@@ -66,6 +69,9 @@ public class LiveTakeOverTest {
       serverURI = TestProperties.getServerURI();
       clientFactory = new MqttClientFactoryPaho();
       clientFactory.open();
+      topicPrefix = "FirstClientState-" + UUID.randomUUID().toString() + "-";
+      FirstSubTopicString = topicPrefix + "FirstClient/Topic";
+
     }
     catch (Exception exception) {
       log.log(Level.SEVERE, "caught exception:", exception);
@@ -132,7 +138,7 @@ public class LiveTakeOverTest {
       mqttClient.setCallback(mqttV3Receiver);
       MqttConnectOptions mqttConnectOptions = new MqttConnectOptions();
       mqttConnectOptions.setCleanSession(false);
-      mqttConnectOptions.setWill("WillTopic", "payload".getBytes(), 2, true);
+      mqttConnectOptions.setWill(topicPrefix+"WillTopic", "payload".getBytes(), 2, true);
       log.info("Connecting...(serverURI:" + serverURI + ", ClientId:" + ClientId);
       mqttClient.connect(mqttConnectOptions);
 
@@ -227,7 +233,7 @@ public class LiveTakeOverTest {
         mqttClient.setCallback(mqttV3Receiver);
         MqttConnectOptions mqttConnectOptions = new MqttConnectOptions();
         mqttConnectOptions.setCleanSession(false);
-        mqttConnectOptions.setWill("WillTopic", "payload".getBytes(), 2, true);
+        mqttConnectOptions.setWill(topicPrefix + "WillTopic", "payload".getBytes(), 2, true);
         log.info("Connecting...(serverURI:" + serverURI + ", ClientId:" + ClientId);
         mqttClient.connect(mqttConnectOptions);
         log.info("Subscribing to..." + FirstSubTopicString);

--- a/org.eclipse.paho.client.mqttv3.test/src/test/java/org/eclipse/paho/client/mqttv3/test/PerSubscriptionMessageHandlerTest.java
+++ b/org.eclipse.paho.client.mqttv3.test/src/test/java/org/eclipse/paho/client/mqttv3/test/PerSubscriptionMessageHandlerTest.java
@@ -18,6 +18,7 @@ package org.eclipse.paho.client.mqttv3.test;
 
 import java.net.URI;
 import java.util.ArrayList;
+import java.util.UUID;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -46,6 +47,8 @@ public class PerSubscriptionMessageHandlerTest {
 
 	  private static URI serverURI;
 	  private static MqttClientFactoryPaho clientFactory;
+	  private static String topicPrefix;
+
 	  
 	  /**
 	   * @throws Exception
@@ -60,6 +63,8 @@ public class PerSubscriptionMessageHandlerTest {
 	      serverURI = TestProperties.getServerURI();
 	      clientFactory = new MqttClientFactoryPaho();
 	      clientFactory.open();
+	      topicPrefix = "PerSubscriptionMessageHandlerTest-" + UUID.randomUUID().toString() + "-";
+
 	    }
 	    catch (Exception exception) {
 	      log.log(Level.SEVERE, "caught exception:", exception);
@@ -139,7 +144,7 @@ public class PerSubscriptionMessageHandlerTest {
     
 	    listener mylistener = new listener();
 	    IMqttClient mqttClient = clientFactory.createMqttClient(serverURI, methodName);
-	    String mytopic = "PerSubscriptionTest/topic";
+	    String mytopic = topicPrefix + "PerSubscriptionTest/topic";
 	    
 	    mqttClient.connect();
 	    log.info("Connecting...(serverURI:" + serverURI + ", ClientId:" + methodName);
@@ -169,7 +174,7 @@ public class PerSubscriptionMessageHandlerTest {
 	   
 	    listener mylistener = new listener();
 	    IMqttAsyncClient mqttClient = clientFactory.createMqttAsyncClient(serverURI, methodName);
-	    String mytopic = "PerSubscriptionTest/topic";
+	    String mytopic = topicPrefix + "PerSubscriptionTest/topic";
 	    
 	    IMqttToken token = mqttClient.connect(null, null);
 	    log.info("Connecting...(serverURI:" + serverURI + ", ClientId:" + methodName);
@@ -207,7 +212,7 @@ public class PerSubscriptionMessageHandlerTest {
 	    
 		    listener mylistener = new listener();
 		    IMqttClient mqttClient = clientFactory.createMqttClient(serverURI, methodName);
-		    String mytopic = "PerSubscriptionTest/topic";
+		    String mytopic = topicPrefix + "PerSubscriptionTest/topic";
 		    
 		    MqttConnectOptions opts = new MqttConnectOptions();
 		    opts.setCleanSession(false);
@@ -259,7 +264,7 @@ public class PerSubscriptionMessageHandlerTest {
 		   
 		    listener mylistener = new listener();
 		    IMqttAsyncClient mqttClient = clientFactory.createMqttAsyncClient(serverURI, methodName);
-		    String mytopic = "PerSubscriptionTest/topic";
+		    String mytopic = topicPrefix + "PerSubscriptionTest/topic";
 		    
 		    MqttConnectOptions opts = new MqttConnectOptions();
 		    opts.setCleanSession(false);
@@ -322,7 +327,7 @@ public class PerSubscriptionMessageHandlerTest {
 	    
 		    listener mylistener = new listener();
 		    IMqttClient mqttClient = clientFactory.createMqttClient(serverURI, methodName);
-		    String mytopic = "PerSubscriptionTest/topic";
+		    String mytopic = topicPrefix + "PerSubscriptionTest/topic";
 		    
 		    MqttConnectOptions opts = new MqttConnectOptions();
 		    opts.setCleanSession(false);

--- a/org.eclipse.paho.client.mqttv3.test/src/test/java/org/eclipse/paho/client/mqttv3/test/SendReceiveAsyncCallbackTest.java
+++ b/org.eclipse.paho.client.mqttv3.test/src/test/java/org/eclipse/paho/client/mqttv3/test/SendReceiveAsyncCallbackTest.java
@@ -16,6 +16,7 @@ package org.eclipse.paho.client.mqttv3.test;
 
 import java.net.URI;
 import java.util.ArrayList;
+import java.util.UUID;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -48,9 +49,10 @@ public class SendReceiveAsyncCallbackTest {
 	private static URI serverURI;
 	private static MqttClientFactoryPaho clientFactory;
 	private boolean testFinished = false;
-	private String topicFilter = "SendReceiveAsyncCallback/topic";
+	private static String topicFilter;
 	private listener myListener = new listener();
 	private onPublish myOnPublish = new onPublish(1);
+	private static String topicPrefix;
 
 	/**
 	 * @throws Exception
@@ -65,6 +67,9 @@ public class SendReceiveAsyncCallbackTest {
 			serverURI = TestProperties.getServerURI();
 			clientFactory = new MqttClientFactoryPaho();
 			clientFactory.open();
+		    topicPrefix = "SendReceiveAsyncCallbackTest-" + UUID.randomUUID().toString() + "-";
+		    topicFilter = topicPrefix + "SendReceiveAsyncCallback/topic";
+
 		} catch (Exception exception) {
 			log.log(Level.SEVERE, "caught exception:", exception);
 			throw exception;

--- a/org.eclipse.paho.client.mqttv3.test/src/test/java/org/eclipse/paho/client/mqttv3/test/SendReceiveAsyncTest.java
+++ b/org.eclipse.paho.client.mqttv3.test/src/test/java/org/eclipse/paho/client/mqttv3/test/SendReceiveAsyncTest.java
@@ -15,6 +15,7 @@
 package org.eclipse.paho.client.mqttv3.test;
 
 import java.net.URI;
+import java.util.UUID;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -44,6 +45,8 @@ public class SendReceiveAsyncTest {
 
   private static URI serverURI;
   private static MqttClientFactoryPaho clientFactory;
+  private static String topicPrefix;
+
 
   /**
    * @throws Exception
@@ -58,6 +61,8 @@ public class SendReceiveAsyncTest {
       serverURI = TestProperties.getServerURI();
       clientFactory = new MqttClientFactoryPaho();
       clientFactory.open();
+      topicPrefix = "SendReceiveAsyncTest-" + UUID.randomUUID().toString() + "-";
+
     }
     catch (Exception exception) {
       log.log(Level.SEVERE, "caught exception:", exception);
@@ -170,7 +175,7 @@ public class SendReceiveAsyncTest {
       log.info("Connecting...(serverURI:" + serverURI + ", ClientId:" + methodName + ", cleanSession: false");
       connectToken.waitForCompletion();
 
-      String[] topicNames = new String[]{methodName + "/Topic"};
+      String[] topicNames = new String[]{topicPrefix + methodName + "/Topic"};
       int[] topicQos = {0};
       subToken = mqttClient.subscribe(topicNames, topicQos, null, null);
       log.info("Subscribing to..." + topicNames[0]);
@@ -232,7 +237,7 @@ public class SendReceiveAsyncTest {
       connectToken.waitForCompletion();
 
       int largeSize = 1000;
-      String[] topicNames = new String[]{methodName + "/Topic"};
+      String[] topicNames = new String[]{topicPrefix + methodName + "/Topic"};
       int[] topicQos = {0};
       byte[] message = new byte[largeSize];
 
@@ -304,7 +309,7 @@ public class SendReceiveAsyncTest {
     IMqttToken disconnectToken;
 
     try {
-      String[] topicNames = new String[]{methodName + "/Topic"};
+      String[] topicNames = new String[]{topicPrefix + methodName + "/Topic"};
       int[] topicQos = {0};
 
       for (int i = 0; i < mqttPublisher.length; i++) {
@@ -410,7 +415,7 @@ public class SendReceiveAsyncTest {
       log.info("Connecting...(serverURI:" + serverURI + ", ClientId:" + methodName + ", cleanSession: false");
       connectToken.waitForCompletion();
 
-      String[] topicNames = new String[]{methodName + "/Topic"};
+      String[] topicNames = new String[]{topicPrefix + methodName + "/Topic"};
       int[] topicQos = {0};
       subToken = mqttClient.subscribe(topicNames, topicQos, null, null);
       log.info("Subscribing to..." + topicNames[0]);
@@ -548,7 +553,7 @@ public class SendReceiveAsyncTest {
   		log.info("Connecting...(serverURI:" + serverURI + ", ClientId:" + methodName);
   		connectToken.waitForCompletion();
   
-  		String topic = "testLargeMsg/Topic";
+  		String topic = topicPrefix + "testLargeMsg/Topic";
   		//10MB
   		int largeSize = 20 * (1 << 20);
   		byte[] message = new byte[largeSize];

--- a/org.eclipse.paho.client.mqttv3.test/src/test/java/org/eclipse/paho/client/mqttv3/test/SendReceiveTest.java
+++ b/org.eclipse.paho.client.mqttv3.test/src/test/java/org/eclipse/paho/client/mqttv3/test/SendReceiveTest.java
@@ -15,6 +15,7 @@
 package org.eclipse.paho.client.mqttv3.test;
 
 import java.net.URI;
+import java.util.UUID;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -43,6 +44,8 @@ public class SendReceiveTest {
 
   private static URI serverURI;
   private static MqttClientFactoryPaho clientFactory;
+  private static String topicPrefix;
+
 
   /**
    * @throws Exception 
@@ -57,6 +60,8 @@ public class SendReceiveTest {
       serverURI = TestProperties.getServerURI();
       clientFactory = new MqttClientFactoryPaho();
       clientFactory.open();
+      topicPrefix = "SendReceiveTest-" + UUID.randomUUID().toString() + "-";
+
     }
     catch (Exception exception) {
       log.log(Level.SEVERE, "caught exception:", exception);
@@ -146,7 +151,7 @@ public class SendReceiveTest {
       log.info("Connecting...(serverURI:" + serverURI + ", ClientId:" + methodName + ", cleanSession: false");
       mqttClient.connect(mqttConnectOptions);
 
-      String[] topicNames = new String[]{methodName + "/Topic"};
+      String[] topicNames = new String[]{topicPrefix + methodName + "/Topic"};
       int[] topicQos = {0};
       log.info("Subscribing to..." + topicNames[0]);
       mqttClient.subscribe(topicNames, topicQos);
@@ -195,7 +200,7 @@ public class SendReceiveTest {
       mqttClient.connect();
 
       int largeSize = 10000;
-      String[] topicNames = new String[]{methodName + "/Topic"};
+      String[] topicNames = new String[]{topicPrefix + methodName + "/Topic"};
       int[] topicQos = {0};
       byte[] message = new byte[largeSize];
 
@@ -255,7 +260,7 @@ public class SendReceiveTest {
       log.info("Connecting...(serverURI:" + serverURI + ", ClientId:" + methodName);
       mqttClient.connect();
 
-      String[] topicNames = new String[]{methodName + "/Topic0", methodName + "/Topic1", methodName + "/Topic2"};
+      String[] topicNames = new String[]{topicPrefix + methodName + "/Topic0", topicPrefix + methodName + "/Topic1", topicPrefix + methodName + "/Topic2"};
       int[] topicQos = {0, 1, 2};
       for (int i = 0; i < topicNames.length; i++) {
     	  log.info("Subscribing to..." + topicNames[i] + " at Qos " + topicQos[i]);
@@ -309,7 +314,7 @@ public class SendReceiveTest {
     IMqttClient[] mqttPublisher = new IMqttClient[2];
     IMqttClient[] mqttSubscriber = new IMqttClient[10];
     try {
-      String[] topicNames = new String[]{methodName + "/Topic"};
+      String[] topicNames = new String[]{topicPrefix + methodName + "/Topic"};
       int[] topicQos = {0};
 
       MqttTopic[] mqttTopic = new MqttTopic[mqttPublisher.length];
@@ -404,7 +409,7 @@ public class SendReceiveTest {
       log.info("Connecting...(serverURI:" + serverURI + ", ClientId:" + methodName + ", cleanSession: false");
       mqttClient.connect(mqttConnectOptions);
 
-      String[] topicNames = new String[]{methodName + "/Topic"};
+      String[] topicNames = new String[]{topicPrefix + methodName + "/Topic"};
       int[] topicQos = {0};
       log.info("Subscribing to..." + topicNames[0]);
       mqttClient.subscribe(topicNames, topicQos);

--- a/org.eclipse.paho.client.mqttv3.test/src/test/java/org/eclipse/paho/client/mqttv3/test/WebSocketTest.java
+++ b/org.eclipse.paho.client.mqttv3.test/src/test/java/org/eclipse/paho/client/mqttv3/test/WebSocketTest.java
@@ -13,18 +13,17 @@
 
 package org.eclipse.paho.client.mqttv3.test;
 
-import java.io.IOException;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Random;
+import java.util.UUID;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import org.eclipse.paho.client.mqttv3.IMqttClient;
 import org.eclipse.paho.client.mqttv3.IMqttDeliveryToken;
 import org.eclipse.paho.client.mqttv3.MqttCallback;
-import org.eclipse.paho.client.mqttv3.MqttConnectOptions;
 import org.eclipse.paho.client.mqttv3.MqttException;
 import org.eclipse.paho.client.mqttv3.MqttMessage;
 import org.eclipse.paho.client.mqttv3.MqttTopic;
@@ -50,6 +49,7 @@ public class WebSocketTest {
 
   private static URI serverURI;
   private static MqttClientFactoryPaho clientFactory;
+  private static String topicPrefix;
 
   /**
    * @throws Exception 
@@ -64,6 +64,7 @@ public class WebSocketTest {
       serverURI = TestProperties.getWebSocketServerURI();
       clientFactory = new MqttClientFactoryPaho();
       clientFactory.open();
+      topicPrefix = "WebSocketTest-" + UUID.randomUUID().toString() + "-";
     }
     catch (Exception exception) {
       log.log(Level.SEVERE, "caught exception:", exception);
@@ -147,7 +148,7 @@ public class WebSocketTest {
 
     IMqttClient client = null;
     try {
-      String topicStr = "topic" + "_02";
+      String topicStr = topicPrefix + "topic" + "_02";
       String clientId = methodName;
       client = clientFactory.createMqttClient(serverURI, clientId);
 
@@ -181,6 +182,9 @@ public class WebSocketTest {
     }
     finally {
       if (client != null) {
+    	  if(client.isConnected()){
+    		  client.disconnectForcibly();
+    	  }
         log.info("Close...");
         client.close();
       }
@@ -206,7 +210,7 @@ public class WebSocketTest {
 
 	    IMqttClient client = null;
 	    try {
-	      String topicStr = "topic_largeFile_01";
+	      String topicStr = topicPrefix + "topic_largeFile_01";
 	      String clientId = methodName;
 	      client = clientFactory.createMqttClient(serverURI, clientId);
 


### PR DESCRIPTION
Currently there is a risk that tests could fail because of other users using iot.eclipse.org, or other tests running causing topic clashes. This fix adds a UUID into all topics so that tests will no longer clash.

Signed-off-by: James Sutton james.sutton@uk.ibm.com
