### PR TITLE
fixed #167 by replacing string concatenation with a StringBuffer. Unf…

### DIFF
--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/MqttAsyncClient.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/MqttAsyncClient.java
@@ -794,18 +794,18 @@ public class MqttAsyncClient implements IMqttAsyncClient { // DestinationProvide
 			this.comms.removeMessageListener(topicFilters[i]);
 		}
 		
-		String subs = "";
+		StringBuffer subs = new StringBuffer();
 		for (int i=0;i<topicFilters.length;i++) {
 			if (i>0) {
-				subs+=", ";
+				subs.append(", ");
 			}
-			subs+= "topic="+ topicFilters[i]+" qos="+qos[i];
+			subs.append("topic=").append(topicFilters[i]).append(" qos=").append(qos[i]);
 			
 			//Check if the topic filter is valid before subscribing
 			MqttTopic.validate(topicFilters[i], true/*allow wildcards*/);
 		}
 		//@TRACE 106=Subscribe topicFilter={0} userContext={1} callback={2}
-		log.fine(CLASS_NAME,methodName,"106",new Object[]{subs, userContext, callback});
+		log.fine(CLASS_NAME,methodName,"106",new Object[]{subs.toString(), userContext, callback});
 
 		MqttToken token = new MqttToken(getClientId());
 		token.setActionCallback(callback);


### PR DESCRIPTION
Please make sure that the following boxes are checked before submitting your Pull Request, thank you!
- [x] You have signed the [Eclipse CLA](http://www.eclipse.org/legal/CLA.php)
- [x] All of your commits have been signed-off with the correct email address (The same one that you used to sign the CLA)
- [x] If This PR fixes an issue, that you reference the issue below. OR if this is a new issue that you are fixing straight away that you add some Description about the bug and how this will fix it.
- [x] If this is new functionality, You have added the appropriate Unit tests.

…ortunately StringBuilder can’t be used because of Java 1.4.2

Signed-off-by: Dominik Obermaier dominik.obermaier@gmail.com

Fixes #167 
