### PR TITLE
fixed deadlock that was caused by joining the receiver thread in the …

### DIFF
--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/websocket/WebSocketReceiver.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/websocket/WebSocketReceiver.java
@@ -65,21 +65,25 @@ public class WebSocketReceiver implements Runnable{
 	public void stop() {
 		final String methodName = "stop";
 		stopping = true;
+        boolean closed = false;
 		synchronized (lifecycle) {
 			//@TRACE 850=stopping
 			log.fine(CLASS_NAME,methodName, "850");
 			if(running) {
 				running = false;
 				receiving = false;
+                closed = true;
 				closeOutputStream();
-				if( !Thread.currentThread().equals(receiverThread)) {
-					try {
-						// Wait for the thread to finish
-						receiverThread.join();
-					} catch (InterruptedException ex) {
-						// Interrupted Exception
-					}
-				}
+
+			}
+		}
+		if(closed && !Thread.currentThread().equals(receiverThread)) {
+			try {
+				// Wait for the thread to finish
+		        //This must not happen in the synchronized block, otherwise we can deadlock ourselves!
+				receiverThread.join();
+			} catch (InterruptedException ex) {
+				// Interrupted Exception
 			}
 		}
 		receiverThread = null;


### PR DESCRIPTION
Please make sure that the following boxes are checked before submitting your Pull Request, thank you!
- [x] You have signed the [Eclipse CLA](http://www.eclipse.org/legal/CLA.php)
- [x] All of your commits have been signed-off with the correct email address (The same one that you used to sign the CLA)
- [x] If This PR fixes an issue, that you reference the issue below. OR if this is a new issue that you are fixing straight away that you add some Description about the bug and how this will fix it.
- [x] If this is new functionality, You have added the appropriate Unit tests.

…synchronized block of the lifecycle. The bug caused Paho to wait forever when there was a socket exception after the close was initiated (e.g. when the broker closed the connection prematurely or when something bad happenes on the network)

Fixes issue #244 
