### PR TITLE
Set also "count"

### DIFF
--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/wire/MqttSubscribe.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/wire/MqttSubscribe.java
@@ -73,6 +73,7 @@ public class MqttSubscribe extends MqttWireMessage {
 		if (names.length != qos.length) {
 		throw new IllegalArgumentException();
 		}
+		this.count = names.length;
 		
 		for (int i=0;i<qos.length;i++) {
 			MqttMessage.validateQos(qos[i]);


### PR DESCRIPTION
When initializing via Java API, "count" field should also be set, otherwise toString() will think that there are no topics.
