### PR TITLE
Adding connection checks to WebSocket Tests

### DIFF
--- a/org.eclipse.paho.client.mqttv3.test/src/test/java/org/eclipse/paho/client/mqttv3/test/WebSocketTest.java
+++ b/org.eclipse.paho.client.mqttv3.test/src/test/java/org/eclipse/paho/client/mqttv3/test/WebSocketTest.java
@@ -131,6 +131,9 @@ public class WebSocketTest {
     }
     finally {
       if (client != null) {
+    	  if(client.isConnected()){
+    		  client.disconnectForcibly();
+    	  }
         log.info("Close...");
         client.close();
       }
@@ -240,6 +243,9 @@ public class WebSocketTest {
 	    	e.printStackTrace();
 	    } finally {
 	      if (client != null) {
+	    	  if(client.isConnected()){
+	    		  client.disconnectForcibly();
+	    	  }
 	        log.info("Close...");
 	        client.close();
 	      }
@@ -263,10 +269,22 @@ public class WebSocketTest {
             serverURI.getPath(),
             serverURI.getQuery(),
             serverURI.getFragment());
-
-    IMqttClient client = clientFactory.createMqttClient(serverURIWithUserInfo, clientId);
-    client.connect();
-    client.disconnect();
+    IMqttClient client = null;
+    try {
+     client = clientFactory.createMqttClient(serverURIWithUserInfo, clientId);
+    	client.connect();
+    	client.disconnect();
+    } catch (Exception e){
+    	e.printStackTrace();
+    } finally {
+      if (client != null) {
+    	  if(client.isConnected()){
+    		  client.disconnectForcibly();
+    	  }
+        log.info("Close...");
+        client.close();
+      }
+    }
   }
 
   // -------------------------------------------------------------

--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/websocket/WebSocketHandshake.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/websocket/WebSocketHandshake.java
@@ -68,7 +68,7 @@ public class WebSocketHandshake {
 	 * @throws IOException
 	 */
 	public void execute() throws IOException {
-		String key = "mqtt-" + (System.currentTimeMillis()/1000);
+		String key = "mqtt3-" + (System.currentTimeMillis()/1000);
 		String b64Key = Base64.encode(key);
 		sendHandshakeRequest(b64Key);
 		receiveHandshakeResponse(b64Key);


### PR DESCRIPTION
Please make sure that the following boxes are checked before submitting your Pull Request, thank you!
- [x] You have signed the [Eclipse CLA](http://www.eclipse.org/legal/CLA.php)
- [x] All of your commits have been signed-off with the correct email address (The same one that you used to sign the CLA)
- [x] If This PR fixes an issue, that you reference the issue below. OR if this is a new issue that you are fixing straight away that you add some Description about the bug and how this will fix it.
- [ ] If this is new functionality, You have added the appropriate Unit tests.

In some of the nightly builds we've been seeing an error in some of the WebSocket Tests:

```
Error Message

MqttException
Stacktrace

org.eclipse.paho.client.mqttv3.MqttException: MqttException
    at org.eclipse.paho.client.mqttv3.internal.ExceptionHelper.createMqttException(ExceptionHelper.java:38)
    at org.eclipse.paho.client.mqttv3.internal.ClientComms$ConnectBG.run(ClientComms.java:674)
    at java.lang.Thread.run(Thread.java:745)
Caused by: java.io.IOException: Already connected
    at java.io.PipedOutputStream.connect(PipedOutputStream.java:100)
    at java.io.PipedInputStream.connect(PipedInputStream.java:188)
    at org.eclipse.paho.client.mqttv3.internal.websocket.WebSocketReceiver.<init>(WebSocketReceiver.java:42)
    at org.eclipse.paho.client.mqttv3.internal.websocket.WebSocketNetworkModule.start(WebSocketNetworkModule.java:79)
    at org.eclipse.paho.client.mqttv3.internal.ClientComms$ConnectBG.run(ClientComms.java:660)
    at java.lang.Thread.run(Thread.java:745)
Standard Output

20160907 241305.000 
20160907 241305.000 *************************************************************
20160907 241305.000 * WebSocketTest.testWebSocketPubSub
20160907 241305.000 *************************************************************
20160907 241305.001 Assigning callback...
20160907 241305.001 Connecting...(serverURI:ws://iot.eclipse.org:80, ClientId:testWebSocketPubSub
20160907 241306.016 Close...
```

Although this has been difficult to recreate on my own machines, I suspect that this issue is caused by an MqttClient used in a previous test not being fully disconnected when this test begins. To resolve this, I've added the following check to all remaining tests in the Class:

```
if(client.isConnected()){
    client.disconnectForcibly();
 }
```

Signed-off-by: James Sutton james.sutton@uk.ibm.com
