### PR TITLE
SNI support - Java 1.7 is required

### DIFF
--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/TCPNetworkModule.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/TCPNetworkModule.java
@@ -24,6 +24,7 @@ import java.net.Socket;
 import java.net.SocketAddress;
 
 import javax.net.SocketFactory;
+import javax.net.ssl.SSLSocketFactory;
 
 import org.eclipse.paho.client.mqttv3.MqttException;
 import org.eclipse.paho.client.mqttv3.logging.Logger;
@@ -66,8 +67,16 @@ public class TCPNetworkModule implements NetworkModule {
 			// @TRACE 252=connect to host {0} port {1} timeout {2}
 			log.fine(CLASS_NAME,methodName, "252", new Object[] {host, new Integer(port), new Long(conTimeout*1000)});
 			SocketAddress sockaddr = new InetSocketAddress(host, port);
-			socket = factory.createSocket();
-			socket.connect(sockaddr, conTimeout*1000);
+			if (factory instanceof SSLSocketFactory) {
+				// SNI support
+				Socket tempsocket = new Socket();
+				tempsocket.connect(sockaddr, conTimeout*1000);
+				socket = ((SSLSocketFactory)factory).createSocket(tempsocket, host, port, true);
+			} else {
+				socket = factory.createSocket();
+				socket.connect(sockaddr, conTimeout*1000);
+			}
+			
 		
 			// SetTcpNoDelay was originally set ot true disabling Nagle's algorithm. 
 			// This should not be required.

--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/websocket/WebSocketHandshake.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/websocket/WebSocketHandshake.java
@@ -28,6 +28,7 @@ import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 /**
  * Helper class to execute a WebSocket Handshake.
  */
@@ -68,8 +69,9 @@ public class WebSocketHandshake {
 	 * @throws IOException
 	 */
 	public void execute() throws IOException {
-		String key = "mqtt-" + (System.currentTimeMillis()/1000);
-		String b64Key = Base64.encode(key);
+		byte[] key = new byte[16];
+		System.arraycopy(UUID.randomUUID().toString().getBytes(), 0, key, 0, 16);
+		String b64Key = Base64.encodeBytes(key);
 		sendHandshakeRequest(b64Key);
 		receiveHandshakeResponse(b64Key);
 	}
@@ -136,7 +138,7 @@ public class WebSocketHandshake {
 		}
 
 		String upgradeHeader = (String) headerMap.get(HTTP_HEADER_UPGRADE);
-		if(!upgradeHeader.toLowerCase().contains(HTTP_HEADER_UPGRADE_WEBSOCKET)){
+		if(upgradeHeader == null || !upgradeHeader.toLowerCase().contains(HTTP_HEADER_UPGRADE_WEBSOCKET)){
 			throw new IOException("WebSocket Response header: Incorrect upgrade.");
 		}
 


### PR DESCRIPTION
Please make sure that the following boxes are checked before submitting your Pull Request, thank you!
- [ x ] You have signed the [Eclipse CLA](http://www.eclipse.org/legal/CLA.php)
- [ x ] All of your commits have been signed-off with the correct email address (The same one that you used to sign the CLA)
- [ x ] If This PR fixes an issue, that you reference the issue below. OR if this is a new issue that you are fixing straight away that you add some Description about the bug and how this will fix it.
- [ ] If this is new functionality, You have added the appropriate Unit tests.

This change requires Java 1.7 to work.

Note that in issue https://github.com/eclipse/paho.mqtt.java/issues/251 I suggested to use SNIHostName class, but that will require Java 1.8 to compile.

Running unit tests manually with -Djavax.net.debug=ssl I can see the host name is set in ClientHello package during handshake:

```
*** ClientHello, TLSv1.2
RandomCookie:  GMT: 1457134523 bytes = { 89, 67, 220, 29, 149, 6, 241, 87, 159, 93, 48, 14, 63, 11, 140, 68, 34, 73, 158, 21
4, 76, 172, 25, 207, 152, 238, 158, 129 }
Session ID:  {}
Cipher Suites: [TLS_EMPTY_RENEGOTIATION_INFO_SCSV, SSL_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256, SSL_ECDHE_RSA_WITH_AES_128_CBC_S
HA256, SSL_RSA_WITH_AES_128_CBC_SHA256, SSL_ECDH_ECDSA_WITH_AES_128_CBC_SHA256, SSL_ECDH_RSA_WITH_AES_128_CBC_SHA256, SSL_DH
E_RSA_WITH_AES_128_CBC_SHA256, SSL_DHE_DSS_WITH_AES_128_CBC_SHA256, SSL_ECDHE_ECDSA_WITH_AES_128_CBC_SHA, SSL_ECDHE_RSA_WITH
_AES_128_CBC_SHA, SSL_RSA_WITH_AES_128_CBC_SHA, SSL_ECDH_ECDSA_WITH_AES_128_CBC_SHA, SSL_ECDH_RSA_WITH_AES_128_CBC_SHA, SSL_
DHE_RSA_WITH_AES_128_CBC_SHA, SSL_DHE_DSS_WITH_AES_128_CBC_SHA, SSL_ECDHE_ECDSA_WITH_3DES_EDE_CBC_SHA, SSL_ECDHE_RSA_WITH_3D
ES_EDE_CBC_SHA, SSL_RSA_WITH_3DES_EDE_CBC_SHA, SSL_ECDH_ECDSA_WITH_3DES_EDE_CBC_SHA, SSL_ECDH_RSA_WITH_3DES_EDE_CBC_SHA, SSL
_DHE_RSA_WITH_3DES_EDE_CBC_SHA, SSL_DHE_DSS_WITH_3DES_EDE_CBC_SHA]
Compression Methods:  { 0 }
Extension elliptic_curves, curve names: {secp256r1, secp192r1, secp224r1, secp384r1, secp521r1, secp160k1, secp160r1, secp16
0r2, secp192k1, secp224k1, secp256k1}
Extension ec_point_formats, formats: [uncompressed]
Extension signature_algorithms, signature_algorithms: SHA512withECDSA, SHA512withRSA, SHA384withECDSA, SHA384withRSA, SHA256
withECDSA, SHA256withRSA, SHA224withECDSA, SHA224withRSA, SHA1withECDSA, SHA1withRSA, SHA256withDSA, SHA1withDSA
Extension server_name, server_name: [host_name: lwyzbx.messaging.wdc01-2.test.internetofthings.ibmcloud.com]
***
MQTT Con: d:lwyzbx:TLS_D:tlsd1, WRITE: TLSv1.2 Handshake, length = 221
MQTT Con: d:lwyzbx:TLS_D:tlsd1, READ: TLSv1.2 Handshake, length = 93
*** ServerHello, TLSv1.2
```
