### PR TITLE
Removing incorrect Documentation for IMqttClient.publish

### DIFF
--- a/org.eclipse.paho.client.mqttv3.test/src/test/java/org/eclipse/paho/client/mqttv3/test/automaticReconnect/OfflineBufferingTest.java
+++ b/org.eclipse.paho.client.mqttv3.test/src/test/java/org/eclipse/paho/client/mqttv3/test/automaticReconnect/OfflineBufferingTest.java
@@ -209,7 +209,6 @@ public class OfflineBufferingTest {
 		// Check that all messages have been delivered
 		for (int x = 0; x < 100; x++) {
 			boolean recieved = mqttV3Receiver.validateReceipt(topicPrefix + methodName, 0, Integer.toString(x).getBytes());
-			log.info("Validate Message: " + x + ": " + recieved);
 			Assert.assertTrue(recieved);
 		}
 		log.info("All messages sent and Recieved correctly.");

--- a/org.eclipse.paho.client.mqttv3.test/src/test/java/org/eclipse/paho/client/mqttv3/test/automaticReconnect/OfflineBufferingTest.java
+++ b/org.eclipse.paho.client.mqttv3.test/src/test/java/org/eclipse/paho/client/mqttv3/test/automaticReconnect/OfflineBufferingTest.java
@@ -209,6 +209,7 @@ public class OfflineBufferingTest {
 		// Check that all messages have been delivered
 		for (int x = 0; x < 100; x++) {
 			boolean recieved = mqttV3Receiver.validateReceipt(topicPrefix + methodName, 0, Integer.toString(x).getBytes());
+			log.info("Validate Message: " + x + ": " + recieved);
 			Assert.assertTrue(recieved);
 		}
 		log.info("All messages sent and Recieved correctly.");

--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/IMqttClient.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/IMqttClient.java
@@ -817,7 +817,6 @@ public void subscribe(String topicFilter, int qos, IMqttMessageListener messageL
 	 * @param topic  to deliver the message to, for example "finance/stock/ibm".
 	 * @param message to delivery to the server
  	 * @throws MqttPersistenceException when a problem with storing the message
-	 * @throws IllegalArgumentException if value of QoS is not 0, 1 or 2.
 	 * @throws MqttException for other errors encountered while publishing the message.
 	 * For instance client not connected.
 	 */


### PR DESCRIPTION
IMqttClient.publish(String topic, MqttMessage message) documented that it would also throw an IllegalArgumentException if QoS was incorrect, however there is no QoS argument for this publish call.

https://github.com/eclipse/paho.mqtt.java/issues/282
