### PR TITLE
Updating Javadoc to be compatible with the new Java 8 JRE

### DIFF
--- a/org.eclipse.paho.client.mqttv3.test/src/test/java/org/eclipse/paho/client/mqttv3/test/automaticReconnect/OfflineBufferingTest.java
+++ b/org.eclipse.paho.client.mqttv3.test/src/test/java/org/eclipse/paho/client/mqttv3/test/automaticReconnect/OfflineBufferingTest.java
@@ -209,7 +209,6 @@ public class OfflineBufferingTest {
 		// Check that all messages have been delivered
 		for (int x = 0; x < 100; x++) {
 			boolean recieved = mqttV3Receiver.validateReceipt(topicPrefix + methodName, 0, Integer.toString(x).getBytes());
-			log.info("Validate Message: " + x + ": " + recieved);
 			Assert.assertTrue(recieved);
 		}
 		log.info("All messages sent and Recieved correctly.");

--- a/org.eclipse.paho.client.mqttv3.test/src/test/java/org/eclipse/paho/client/mqttv3/test/automaticReconnect/OfflineBufferingTest.java
+++ b/org.eclipse.paho.client.mqttv3.test/src/test/java/org/eclipse/paho/client/mqttv3/test/automaticReconnect/OfflineBufferingTest.java
@@ -209,6 +209,7 @@ public class OfflineBufferingTest {
 		// Check that all messages have been delivered
 		for (int x = 0; x < 100; x++) {
 			boolean recieved = mqttV3Receiver.validateReceipt(topicPrefix + methodName, 0, Integer.toString(x).getBytes());
+			log.info("Validate Message: " + x + ": " + recieved);
 			Assert.assertTrue(recieved);
 		}
 		log.info("All messages sent and Recieved correctly.");

--- a/org.eclipse.paho.client.mqttv3/pom.xml
+++ b/org.eclipse.paho.client.mqttv3/pom.xml
@@ -11,6 +11,7 @@
 	<packaging>eclipse-plugin</packaging>
 	
 	<profiles>
+	<!-- 
 		<profile>
 			<id>doclint-java8-disable</id>
 	    		<activation>
@@ -20,6 +21,7 @@
 				<javadoc.opts>-Xdoclint:none</javadoc.opts>
 			</properties>
 		</profile>
+		 -->
 	</profiles>
 
 	<build>
@@ -77,7 +79,7 @@
 					<target>${mqttclient.java.version}</target>
 				</configuration>
 			</plugin>
-			<!-- <plugin>
+			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
 				<version>2.10.3</version>
@@ -93,7 +95,7 @@
 					</execution>
 				</executions>
 			</plugin>
-			<plugin>
+			<!-- <plugin>
 				<groupId>org.eclipse.tycho.extras</groupId>
 				<artifactId>tycho-document-bundle-plugin</artifactId>
 		        <executions>

--- a/org.eclipse.paho.client.mqttv3/src/main/java-templates/org/eclipse/paho/client/mqttv3/internal/ClientComms.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java-templates/org/eclipse/paho/client/mqttv3/internal/ClientComms.java
@@ -84,6 +84,10 @@ public class ClientComms {
 	/**
 	 * Creates a new ClientComms object, using the specified module to handle
 	 * the network calls.
+	 * @param client The {@link IMqttAsyncClient}
+	 * @param persistence the {@link MqttClientPersistence} layer.
+	 * @param pingSender the {@link MqttPingSender}
+	 * @throws MqttException if an exception occurs whilst communicating with the server
 	 */
 	public ClientComms(IMqttAsyncClient client, MqttClientPersistence persistence, MqttPingSender pingSender) throws MqttException {
 		this.conState = DISCONNECTED;
@@ -141,6 +145,9 @@ public class ClientComms {
 	/**
 	 * Sends a message to the broker if in connected state, but only waits for the message to be
 	 * stored, before returning.
+	 * @param message The {@link MqttWireMessage} to send
+	 * @param token The {@link MqttToken} to send.
+	 * @throws MqttException if an error occurs sending the message
 	 */
 	public void sendNoWait(MqttWireMessage message, MqttToken token) throws MqttException {
 		final String methodName = "sendNoWait";
@@ -218,6 +225,9 @@ public class ClientComms {
 	 * Sends a connect message and waits for an ACK or NACK.
 	 * Connecting is a special case which will also start up the
 	 * network connection, receive thread, and keep alive thread.
+	 * @param options The {@link MqttConnectOptions} for the connection
+	 * @param token The {@link MqttToken} to track the connection
+	 * @throws MqttException if an error occurs when connecting
 	 */
 	public void connect(MqttConnectOptions options, MqttToken token) throws MqttException {
 		final String methodName = "connect";
@@ -288,6 +298,8 @@ public class ClientComms {
 	 * an abnormal disconnection.  The method may be invoked multiple times
 	 * in parallel as each thread when it receives an error uses this method
 	 * to ensure that shutdown completes successfully.
+	 * @param token the {@link MqttToken} To track closing the connection
+	 * @param reason the {@link MqttException} thrown requiring the connection to be shut down.
 	 */
 	public void shutdownConnection(MqttToken token, MqttException reason) {
 		final String methodName = "shutdownConnection";
@@ -478,6 +490,10 @@ public class ClientComms {
 
 	/**
 	 * Disconnect the connection and reset all the states.
+	 * @param quiesceTimeout How long to wait whilst quiesing before messages are deleted.
+	 * @param disconnectTimeout How long to wait whilst disconnecting
+	 * @param sendDisconnectPacket If true, will send a disconnect packet
+	 * @throws MqttException if an error occurs whilst disconnecting
 	 */
 	public void disconnectForcibly(long quiesceTimeout, long disconnectTimeout, boolean sendDisconnectPacket) throws MqttException {
 		// Allow current inbound and outbound work to complete
@@ -765,7 +781,7 @@ public class ClientComms {
 	/**
 	 * When Automatic reconnect is enabled, we want ClientComs to enter the
 	 * 'resting' state if disconnected. This will allow us to publish messages
-	 * @param resting
+	 * @param resting if true, resting is enabled
 	 */
 	public void setRestingState(boolean resting) {
 		this.resting = resting;
@@ -792,7 +808,6 @@ public class ClientComms {
 	/**
 	 * When the client automatically reconnects, we want to send all messages from the
 	 * buffer first before allowing the user to send any messages
-	 * @throws MqttException 
 	 */
 	public void notifyReconnect() {
 		final String methodName = "notifyReconnect";

--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/IMqttActionListener.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/IMqttActionListener.java
@@ -24,6 +24,7 @@ public interface IMqttActionListener {
 	 * are in the process of being delivered will be delivered to the requested
 	 * quality of service next time the client connects.  
 	 * @param asyncActionToken associated with the action that has failed
+	 * @param exception thrown by the action that has failed
 	 */
 	public void onFailure(IMqttToken asyncActionToken, Throwable exception);
 }

--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/IMqttAsyncClient.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/IMqttAsyncClient.java
@@ -24,6 +24,7 @@ package org.eclipse.paho.client.mqttv3;
  * <p>
  * It provides applications a simple programming interface to all features of the MQTT version 3.1
  * specification including:
+ * </p>
  * <ul>
  * <li>connect
  * <li>publish
@@ -31,9 +32,8 @@ package org.eclipse.paho.client.mqttv3;
  * <li>unsubscribe
  * <li>disconnect
  * </ul>
- * </p>
  * <p>
- * There are two styles of MQTT client, this one and {@link IMqttClient}.
+ * There are two styles of MQTT client, this one and {@link IMqttClient}.</p>
  * <ul>
  * <li>IMqttAsyncClient provides a set of non-blocking methods that return control to the
  * invoking application after initial validation of parameters and state. The main processing is
@@ -51,7 +51,6 @@ package org.eclipse.paho.client.mqttv3;
  * versions of the MQTT client. In most circumstances it is recommended to use IMqttAsyncClient
  * based clients which allow an application to mix both non-blocking and blocking calls. </li>
  * </ul>
- * </p>
  * <p>
  * An application is not restricted to using one style if an IMqttAsyncClient based client is used
  * as both blocking and non-blocking methods can be used in the same application. If an IMqttClient
@@ -61,40 +60,38 @@ package org.eclipse.paho.client.mqttv3;
  * <p>There are two forms of non-blocking method:
  * <ol>
  *   <li>
- *     <code><pre>
+ *     <pre>
  *     IMqttToken token = asyncClient.method(parms)
- *     </pre></code>
+ *     </pre>
  *     <p>In this form the method returns a token that can be used to track the
  *     progress of the action (method). The method provides a waitForCompletion()
  *     method that once invoked will block until the action completes. Once
  *     completed there are method on the token that can be used to check if the
  *     action completed successfully or not. For example
- * 	   to wait until a connect completes:
- *     <code><pre>
+ * 	   to wait until a connect completes:</p>
+ *     <pre>
  *      IMqttToken conToken;
  *   	conToken = asyncClient.client.connect(conToken);
  *     ... do some work...
  *   	conToken.waitForCompletion();
- *     </pre></code>
- *	   </p>
- *     <p>To turn a method into a blocking invocation the following form can be used:
- *     <code><pre>
+ *     </pre>
+ *     <p>To turn a method into a blocking invocation the following form can be used:</p>
+ *     <pre>
  *     IMqttToken token;
  *     token = asyncClient.method(parms).waitForCompletion();
- *     </pre></code>
-
+ *     </pre>
  *   </li>
  *
  *   <li>
- *     <code><pre>
+ *     <pre>
  *     IMqttToken token method(parms, Object userContext, IMqttActionListener callback)
- *     </pre></code>
+ *     </pre>
  *     <p>In this form a callback is registered with the method. The callback will be
  *     notified when the action succeeds or fails. The callback is invoked on the thread
  *     managed by the MQTT client so it is important that processing is minimised in the
  *     callback. If not the operation of the MQTT client will be inhibited. For example
- *     to be notified (called back) when a connect completes:
- *     <code><pre>
+ *     to be notified (called back) when a connect completes:</p>
+ *     <pre>
  *     	IMqttToken conToken;
  *	    conToken = asyncClient.connect("some context",new new MqttAsyncActionListener() {
  *			public void onSuccess(IMqttToken asyncActionToken) {
@@ -105,8 +102,8 @@ package org.eclipse.paho.client.mqttv3;
  *				log ("connect failed" +exception);
  *			}
  *		  });
- *      </pre></code>
- *	    An optional context object can be passed into the method which will then be made
+ *      </pre>
+ *	    <p>An optional context object can be passed into the method which will then be made
  *      available in the callback. The context is stored by the MQTT client) in the token
  *      which is then returned to the invoker. The token is provided to the callback methods
  *      where the context can then be accessed.
@@ -174,11 +171,11 @@ public interface IMqttAsyncClient {
 	 * </p>
 	 * <p>The method returns control before the connect completes. Completion can
 	 * be tracked by:
+	 * </p>
 	 * <ul>
 	 * <li>Waiting on the returned token {@link IMqttToken#waitForCompletion()} or</li>
 	 * <li>Passing in a callback {@link IMqttActionListener}</li>
 	 * </ul>
-	 * </p>
 	 *
 	 * @param options a set of connection parameters that override the defaults.
 	 * @param userContext optional object for used to pass context to the callback. Use
@@ -259,11 +256,11 @@ public interface IMqttAsyncClient {
 	 * <p>This method must not be called from inside {@link MqttCallback} methods.</p>
 	 * <p>The method returns control before the disconnect completes. Completion can
 	 * be tracked by:
+	 * </p>
 	 * <ul>
 	 * <li>Waiting on the returned token {@link IMqttToken#waitForCompletion()} or</li>
 	 * <li>Passing in a callback {@link IMqttActionListener}</li>
 	 * </ul>
-	 * </p>
 	 *
 	 * @param quiesceTimeout the amount of time in milliseconds to allow for
 	 * existing work to finish before disconnecting.  A value of zero or less
@@ -419,6 +416,7 @@ public interface IMqttAsyncClient {
 	 * client and will be delivered on a background thread.
 	 * In the event the connection fails or the client stops. Messages will be delivered to the
 	 * requested quality of service once the connection is re-established to the server on condition that:
+	 * </p>
 	 * <ul>
 	 * <li>The connection is re-established with the same clientID
 	 * <li>The original connection was made with (@link MqttConnectOptions#setCleanSession(boolean)}
@@ -427,7 +425,6 @@ public interface IMqttAsyncClient {
 	 * set to false
 	 * <li>Depending when the failure occurs QoS 0 messages may not be delivered.
 	 * </ul>
-	 * </p>
 	 *
 	 * <p>When building an application,
 	 * the design of the topic tree should take into account the following principles
@@ -442,22 +439,22 @@ public interface IMqttAsyncClient {
 	 * 	<li>A leading "/" creates a distinct topic.  For example, <em>/finance</em> is
 	 * 	different from <em>finance</em>. <em>/finance</em> matches "+/+" and "/+", but
 	 * 	not "+".</li>
-	 * 	<li>Do not include the null character (Unicode <samp class="codeph">\x0000</samp>) in
+	 * 	<li>Do not include the null character (Unicode <pre>\x0000</pre>) in
 	 * 	any topic.</li>
 	 * </ul>
 	 *
 	 * <p>The following principles apply to the construction and content of a topic
 	 * tree:</p>
-	 *
 	 * <ul>
 	 * 	<li>The length is limited to 64k but within that there are no limits to the
 	 * 	number of levels in a topic tree.</li>
 	 * 	<li>There can be any number of root nodes; that is, there can be any number
 	 * 	of topic trees.</li>
 	 * 	</ul>
-	 * </p>
+	 * 
 	 * <p>The method returns control before the publish completes. Completion can
 	 * be tracked by:
+	 * </p>
 	 * <ul>
 	 * <li>Setting an {@link IMqttAsyncClient#setCallback(MqttCallback)} where the
 	 * {@link MqttCallback#deliveryComplete(IMqttDeliveryToken)}
@@ -465,7 +462,6 @@ public interface IMqttAsyncClient {
 	 * <li>Waiting on the returned token {@link MqttToken#waitForCompletion()} or</li>
 	 * <li>Passing in a callback {@link IMqttActionListener} to this method</li>
 	 * </ul>
-	 * </p>
 	 *
 	 * @param topic  to deliver the message to, for example "finance/stock/ibm".
 	 * @param message to deliver to the server
@@ -551,23 +547,25 @@ public interface IMqttAsyncClient {
 	 * <p>
 	 * If (@link MqttConnectOptions#setCleanSession(boolean)} was set to true
 	 * when when connecting to the server then the subscription remains in place
-	 * until either:
+	 * until either:</p>
+	 * 
 	 * <ul>
 	 * <li>The client disconnects</li>
 	 * <li>An unsubscribe method is called to un-subscribe the topic</li>
-	 * </li>
-	 * </p>
+	 * </ul>
+	 * 
 	 * <p>
 	 * If (@link MqttConnectOptions#setCleanSession(boolean)} was set to false
 	 * when connecting to the server then the subscription remains in place
-	 * until either:
+	 * until either:</p>
 	 * <ul>
 	 * <li>An unsubscribe method is called to unsubscribe the topic</li>
-	 * <li>The next time the client connects with cleanSession set to true</ul>
-	 * </li>
+	 * <li>The next time the client connects with cleanSession set to true</li>
+	 * </ul>
+	 * <p>
 	 * With cleanSession set to false the MQTT server will store messages on
 	 * behalf of the client when the client is not connected. The next time the
-	 * client connects with the <bold>same client ID</bold> the server will
+	 * client connects with the <b>same client ID</b> the server will
 	 * deliver the stored messages to the client.
 	 * </p>
 	 *
@@ -589,9 +587,12 @@ public interface IMqttAsyncClient {
 	 * 	<dd><p>The number sign (#) is a wildcard character that matches
 	 * 	any number of levels within a topic. For example, if you subscribe to
 	 *  <span><span class="filepath">finance/stock/ibm/#</span></span>, you receive
-	 * 	messages on these topics:
-	 *  <pre>   finance/stock/ibm<br />   finance/stock/ibm/closingprice<br />   finance/stock/ibm/currentprice</pre>
-	 *  </p>
+	 * 	messages on these topics:</p>
+	 *  <ul>
+	 *  <li>finance/stock/ibm</li>
+	 *  <li>finance/stock/ibm/closingprice</li>
+	 *  <li>finance/stock/ibm/currentprice</li>
+	 *  </ul>
 	 *  <p>The multi-level wildcard
 	 *  can represent zero or more levels. Therefore, <em>finance/#</em> can also match
 	 * 	the singular <em>finance</em>, where <em>#</em> represents zero levels. The topic
@@ -622,14 +623,12 @@ public interface IMqttAsyncClient {
 	 * 	For example, <em>finance/+</em> and <em>finance/+/ibm</em> are both valid.</span></p>
 	 * 	</dd>
 	 * </dl>
-	 * </p>
 	 * <p>The method returns control before the subscribe completes. Completion can
-	 * be tracked by:
+	 * be tracked by:</p>
 	 * <ul>
 	 * <li>Waiting on the supplied token {@link MqttToken#waitForCompletion()} or</li>
 	 * <li>Passing in a callback {@link IMqttActionListener} to this method</li>
 	 * </ul>
-	 * </p>
 	 *
 	 * @param topicFilters one or more topics to subscribe to, which can include wildcards
 	 * @param qos the maximum quality of service to subscribe each topic at.Messages
@@ -790,11 +789,12 @@ public interface IMqttAsyncClient {
 	 * </p>
 	 * <p>The method returns control before the unsubscribe completes. Completion can
 	 * be tracked by:
+	 * </p>
+	 * 
 	 * <ul>
 	 * <li>Waiting on the returned token {@link MqttToken#waitForCompletion()} or</li>
 	 * <li>Passing in a callback {@link IMqttActionListener} to this method</li>
 	 * </ul>
-	 * </p>
 	 *
 	 * @param topicFilters one or more topics to unsubscribe from. Each topicFilter
 	 * must match one specified on an earlier subscribe.
@@ -814,12 +814,12 @@ public interface IMqttAsyncClient {
 	 * Sets a callback listener to use for events that happen asynchronously.
 	 * <p>There are a number of events that the listener will be notified about.
 	 * These include:
+	 * </p>
 	 * <ul>
 	 * <li>A new message has arrived and is ready to be processed</li>
 	 * <li>The connection to the server has been lost</li>
 	 * <li>Delivery of a message to the server has completed</li>
 	 * </ul>
-	 * </p>
 	 * <p>Other events that track the progress of an individual operation such
 	 * as connect and subscribe can be tracked using the {@link MqttToken} returned from
 	 * each non-blocking method or using setting a {@link IMqttActionListener} on the
@@ -852,7 +852,7 @@ public interface IMqttAsyncClient {
 	 * sent.  The default behaviour, when manualAcks is false, is to send the MQTT
 	 * acknowledgements automatically at the successful completion of the messageArrived
 	 * callback method.
-	 * @param manualAcks
+	 * @param manualAcks if set to true MQTT acknowledgements are not sent
 	 */
 	public void setManualAcks(boolean manualAcks);
 	
@@ -861,7 +861,7 @@ public interface IMqttAsyncClient {
 	 * This will cause the MQTT acknowledgement to be sent to the server.
 	 * @param messageId the MQTT message id to be acknowledged
 	 * @param qos the MQTT QoS of the message to be acknowledged
-	 * @throws MqttException
+	 * @throws MqttException if there was a problem sending the acknowledgement
 	 */
 	public void messageArrivedComplete(int messageId, int qos) throws MqttException;
 

--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/IMqttClient.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/IMqttClient.java
@@ -23,7 +23,7 @@ package org.eclipse.paho.client.mqttv3;
  * Enables an application to communicate with an MQTT server using blocking methods.
  * <p>
  * This interface allows applications to utilize all features of the MQTT version 3.1
- * specification including:
+ * specification including:</p>
  * <ul>
  * <li>connect
  * <li>publish
@@ -31,9 +31,8 @@ package org.eclipse.paho.client.mqttv3;
  * <li>unsubscribe
  * <li>disconnect
  * </ul>
- * </p>
  * <p>
- * There are two styles of MQTT client, this one and {@link IMqttAsyncClient}.
+ * There are two styles of MQTT client, this one and {@link IMqttAsyncClient}.</p>
  * <ul>
  * <li>IMqttClient provides a set of methods that block and return control to the application
  * program once the MQTT action has completed.</li>
@@ -47,14 +46,14 @@ package org.eclipse.paho.client.mqttv3;
  * programs and graphical programs where issuing methods that take time to complete on the the
  * main or GUI thread can cause problems.</li>
  * </ul>
- * </p>
  * <p>
  * The non-blocking client can also be used in a blocking form by turning a non-blocking
- * method into a blocking invocation using the following pattern:
- *     <code><pre>
+ * method into a blocking invocation using the following pattern:</p>
+ *     <pre>
  *     IMqttToken token;
  *     token = asyncClient.method(parms).waitForCompletion();
- *     </pre></code>
+ *     </pre>
+ * <p>
  * Using the non-blocking client allows an application to use a mixture of blocking and
  * non-blocking styles. Using the blocking client only allows an application to use one
  * style. The blocking client provides compatibility with earlier versions
@@ -114,7 +113,9 @@ public IMqttToken connectWithResult(MqttConnectOptions options) throws MqttSecur
 	 * This method must not be called from inside {@link MqttCallback} methods.
 	 * </p>
 	 *
-	 * @see #disconnect(long)
+	 * <p>This is a blocking method that returns once disconnect completes</p>
+	 *
+	 * @throws MqttException if a problem is encountered while disconnecting
 	 */
   public void disconnect() throws MqttException;
 
@@ -184,6 +185,7 @@ public IMqttToken connectWithResult(MqttConnectOptions options) throws MqttSecur
 	 *
 	 * @param topicFilter the topic to subscribe to, which can include wildcards.
 	 * @throws MqttException if there was an error registering the subscription.
+	 * @throws MqttSecurityException if the client is not authorized to register the subscription
 	 */
   public void subscribe(String topicFilter) throws MqttException, MqttSecurityException;
 
@@ -221,22 +223,23 @@ public IMqttToken connectWithResult(MqttConnectOptions options) throws MqttSecur
 	 * If (@link MqttConnectOptions#setCleanSession(boolean)} was set to true
 	 * when when connecting to the server then the subscription remains in place
 	 * until either:
+	 * </p>
 	 * <ul>
 	 * <li>The client disconnects</li>
 	 * <li>An unsubscribe method is called to un-subscribe the topic</li>
-	 * </li>
-	 * </p>
+	 * </ul>
 	 * <p>
 	 * If (@link MqttConnectOptions#setCleanSession(boolean)} was set to false
 	 * when when connecting to the server then the subscription remains in place
-	 * until either:
+	 * until either:</p>
 	 * <ul>
 	 * <li>An unsubscribe method is called to unsubscribe the topic</li>
-	 * <li>The client connects with cleanSession set to true</ul>
-	 * </li>
+	 * <li>The client connects with cleanSession set to true</li>
+	 * </ul>
+	 * <p>
 	 * With cleanSession set to false the MQTT server will store messages on
 	 * behalf of the client when the client is not connected. The next time the
-	 * client connects with the <bold>same client ID</bold> the server will
+	 * client connects with the <b>same client ID</b> the server will
 	 * deliver the stored messages to the client.
 	 * </p>
 	 *
@@ -258,9 +261,13 @@ public IMqttToken connectWithResult(MqttConnectOptions options) throws MqttSecur
 	 * 	<dd><p>The number sign (#) is a wildcard character that matches
 	 * 	any number of levels within a topic. For example, if you subscribe to
 	 *  <span><span class="filepath">finance/stock/ibm/#</span></span>, you receive
-	 * 	messages on these topics:
-	 *  <pre>   finance/stock/ibm<br />   finance/stock/ibm/closingprice<br />   finance/stock/ibm/currentprice</pre>
-	 *  </p>
+	 * 	messages on these topics:</p>
+	 * <ul>
+	 * <li><pre>finance/stock/ibm</pre></li>
+	 * <li><pre>finance/stock/ibm/closingprice</pre></li>
+	 * <li><pre>finance/stock/ibm/currentprice</pre></li>
+	 * </ul>
+	 *  
 	 *  <p>The multi-level wildcard
 	 *  can represent zero or more levels. Therefore, <em>finance/#</em> can also match
 	 * 	the singular <em>finance</em>, where <em>#</em> represents zero levels. The topic
@@ -291,7 +298,6 @@ public IMqttToken connectWithResult(MqttConnectOptions options) throws MqttSecur
 	 * 	For example, <em>finance/+</em> and <em>finance/+/ibm</em> are both valid.</span></p>
 	 * 	</dd>
 	 * </dl>
-	 * </p>
 	 *
 	 * <p>This is a blocking method that returns once subscribe completes</p>
 	 *
@@ -313,6 +319,7 @@ public IMqttToken connectWithResult(MqttConnectOptions options) throws MqttSecur
 	 * @param topicFilter the topic to subscribe to, which can include wildcards.
 	 * @param messageListener a callback to handle incoming messages
 	 * @throws MqttException if there was an error registering the subscription.
+	 * @throws MqttSecurityException if the client is not authorized to register the subscription
 	 */
 public void subscribe(String topicFilter, IMqttMessageListener messageListener) throws MqttException, MqttSecurityException;
 
@@ -351,23 +358,23 @@ public void subscribe(String topicFilter, int qos, IMqttMessageListener messageL
 	 * <p>
 	 * If (@link MqttConnectOptions#setCleanSession(boolean)} was set to true
 	 * when when connecting to the server then the subscription remains in place
-	 * until either:
+	 * until either:</p>
 	 * <ul>
 	 * <li>The client disconnects</li>
 	 * <li>An unsubscribe method is called to un-subscribe the topic</li>
-	 * </li>
-	 * </p>
+	 * </ul>
 	 * <p>
 	 * If (@link MqttConnectOptions#setCleanSession(boolean)} was set to false
 	 * when when connecting to the server then the subscription remains in place
-	 * until either:
+	 * until either:</p>
 	 * <ul>
 	 * <li>An unsubscribe method is called to unsubscribe the topic</li>
-	 * <li>The client connects with cleanSession set to true</ul>
-	 * </li>
+	 * <li>The client connects with cleanSession set to true</li>
+	 * </ul>
+	 * <p>
 	 * With cleanSession set to false the MQTT server will store messages on
 	 * behalf of the client when the client is not connected. The next time the
-	 * client connects with the <bold>same client ID</bold> the server will
+	 * client connects with the <b>same client ID</b> the server will
 	 * deliver the stored messages to the client.
 	 * </p>
 	 *
@@ -389,9 +396,12 @@ public void subscribe(String topicFilter, int qos, IMqttMessageListener messageL
 	 * 	<dd><p>The number sign (#) is a wildcard character that matches
 	 * 	any number of levels within a topic. For example, if you subscribe to
 	 *  <span><span class="filepath">finance/stock/ibm/#</span></span>, you receive
-	 * 	messages on these topics:
-	 *  <pre>   finance/stock/ibm<br />   finance/stock/ibm/closingprice<br />   finance/stock/ibm/currentprice</pre>
-	 *  </p>
+	 * 	messages on these topics:</p>
+	 * <ul>
+	 * <li><pre>finance/stock/ibm</pre></li>
+	 * <li><pre>finance/stock/ibm/closingprice</pre></li>
+	 * <li><pre>finance/stock/ibm/currentprice</pre></li>
+	 * </ul>
 	 *  <p>The multi-level wildcard
 	 *  can represent zero or more levels. Therefore, <em>finance/#</em> can also match
 	 * 	the singular <em>finance</em>, where <em>#</em> represents zero levels. The topic
@@ -422,7 +432,6 @@ public void subscribe(String topicFilter, int qos, IMqttMessageListener messageL
 	 * 	For example, <em>finance/+</em> and <em>finance/+/ibm</em> are both valid.</span></p>
 	 * 	</dd>
 	 * </dl>
-	 * </p>
 	 *
 	 * <p>This is a blocking method that returns once subscribe completes</p>
 	 *
@@ -524,23 +533,23 @@ public void subscribe(String topicFilter, int qos, IMqttMessageListener messageL
 	 * <p>
 	 * If (@link MqttConnectOptions#setCleanSession(boolean)} was set to true
 	 * when when connecting to the server then the subscription remains in place
-	 * until either:
+	 * until either:</p>
 	 * <ul>
 	 * <li>The client disconnects</li>
 	 * <li>An unsubscribe method is called to un-subscribe the topic</li>
-	 * </li>
-	 * </p>
+	 * </ul>
 	 * <p>
 	 * If (@link MqttConnectOptions#setCleanSession(boolean)} was set to false
 	 * when when connecting to the server then the subscription remains in place
-	 * until either:
+	 * until either:</p>
 	 * <ul>
 	 * <li>An unsubscribe method is called to unsubscribe the topic</li>
-	 * <li>The client connects with cleanSession set to true</ul>
-	 * </li>
+	 * <li>The client connects with cleanSession set to true</li>
+	 * </ul>
+	 * <p>
 	 * With cleanSession set to false the MQTT server will store messages on
 	 * behalf of the client when the client is not connected. The next time the
-	 * client connects with the <bold>same client ID</bold> the server will
+	 * client connects with the <b>same client ID</b> the server will
 	 * deliver the stored messages to the client.
 	 * </p>
 	 *
@@ -562,9 +571,12 @@ public void subscribe(String topicFilter, int qos, IMqttMessageListener messageL
 	 * 	<dd><p>The number sign (#) is a wildcard character that matches
 	 * 	any number of levels within a topic. For example, if you subscribe to
 	 *  <span><span class="filepath">finance/stock/ibm/#</span></span>, you receive
-	 * 	messages on these topics:
-	 *  <pre>   finance/stock/ibm<br />   finance/stock/ibm/closingprice<br />   finance/stock/ibm/currentprice</pre>
-	 *  </p>
+	 * 	messages on these topics:</p>
+	 * <ul>
+	 * <li><pre>finance/stock/ibm</pre></li>
+	 * <li><pre>finance/stock/ibm/closingprice</pre></li>
+	 * <li><pre>finance/stock/ibm/currentprice</pre></li>
+	 * </ul>
 	 *  <p>The multi-level wildcard
 	 *  can represent zero or more levels. Therefore, <em>finance/#</em> can also match
 	 * 	the singular <em>finance</em>, where <em>#</em> represents zero levels. The topic
@@ -595,7 +607,6 @@ public void subscribe(String topicFilter, int qos, IMqttMessageListener messageL
 	 * 	For example, <em>finance/+</em> and <em>finance/+/ibm</em> are both valid.</span></p>
 	 * 	</dd>
 	 * </dl>
-	 * </p>
 	 *
 	 * <p>This is a blocking method that returns once subscribe completes</p>
 	 *
@@ -619,23 +630,24 @@ public void subscribe(String topicFilter, int qos, IMqttMessageListener messageL
 	 * <p>
 	 * If (@link MqttConnectOptions#setCleanSession(boolean)} was set to true
 	 * when when connecting to the server then the subscription remains in place
-	 * until either:
+	 * until either:</p>
 	 * <ul>
 	 * <li>The client disconnects</li>
 	 * <li>An unsubscribe method is called to un-subscribe the topic</li>
-	 * </li>
-	 * </p>
+	 * </ul>
+	 * 
 	 * <p>
 	 * If (@link MqttConnectOptions#setCleanSession(boolean)} was set to false
 	 * when when connecting to the server then the subscription remains in place
-	 * until either:
+	 * until either:</p>
 	 * <ul>
 	 * <li>An unsubscribe method is called to unsubscribe the topic</li>
-	 * <li>The client connects with cleanSession set to true</ul>
-	 * </li>
+	 * <li>The client connects with cleanSession set to true</li>
+	 * </ul>
+	 * <p>
 	 * With cleanSession set to false the MQTT server will store messages on
 	 * behalf of the client when the client is not connected. The next time the
-	 * client connects with the <bold>same client ID</bold> the server will
+	 * client connects with the <b>same client ID</b> the server will
 	 * deliver the stored messages to the client.
 	 * </p>
 	 *
@@ -657,9 +669,12 @@ public void subscribe(String topicFilter, int qos, IMqttMessageListener messageL
 	 * 	<dd><p>The number sign (#) is a wildcard character that matches
 	 * 	any number of levels within a topic. For example, if you subscribe to
 	 *  <span><span class="filepath">finance/stock/ibm/#</span></span>, you receive
-	 * 	messages on these topics:
-	 *  <pre>   finance/stock/ibm<br />   finance/stock/ibm/closingprice<br />   finance/stock/ibm/currentprice</pre>
-	 *  </p>
+	 * 	messages on these topics:</p>
+	 * <ul>
+	 * <li><pre>finance/stock/ibm</pre></li>
+	 * <li><pre>finance/stock/ibm/closingprice</pre></li>
+	 * <li><pre>finance/stock/ibm/currentprice</pre></li>
+	 * </ul>
 	 *  <p>The multi-level wildcard
 	 *  can represent zero or more levels. Therefore, <em>finance/#</em> can also match
 	 * 	the singular <em>finance</em>, where <em>#</em> represents zero levels. The topic
@@ -690,7 +705,7 @@ public void subscribe(String topicFilter, int qos, IMqttMessageListener messageL
 	 * 	For example, <em>finance/+</em> and <em>finance/+/ibm</em> are both valid.</span></p>
 	 * 	</dd>
 	 * </dl>
-	 * </p>
+
 	 *
 	 * <p>This is a blocking method that returns once subscribe completes</p>
 	 *
@@ -765,24 +780,22 @@ public void subscribe(String topicFilter, int qos, IMqttMessageListener messageL
 	 * Delivers a message to the server at the requested quality of service and returns control
 	 * once the message has been delivered. In the event the connection fails or the client
 	 * stops, any messages that are in the process of being delivered will be delivered once
-	 * a connection is re-established to the server on condition that:
+	 * a connection is re-established to the server on condition that:</p>
 	 * <ul>
-	 * <li>The connection is re-established with the same clientID
+	 * <li>The connection is re-established with the same clientID</li>
 	 * <li>The original connection was made with (@link MqttConnectOptions#setCleanSession(boolean)}
-	 * set to false
+	 * set to false</li>
 	 * <li>The connection is re-established with (@link MqttConnectOptions#setCleanSession(boolean)}
-	 * set to false
+	 * set to false</li>
 	 * </ul>
-	 * </p>
 	 * <p>In the event that the connection breaks or the client stops it is still possible to determine
-	 * when the delivery of the message completes. Prior to re-establishing the connection to the server:
+	 * when the delivery of the message completes. Prior to re-establishing the connection to the server:</p>
 	 * <ul>
 	 * <li>Register a {@link #setCallback(MqttCallback)} callback on the client and the delivery complete
 	 * callback will be notified once a delivery of a message completes
 	 * <li>or call {@link #getPendingDeliveryTokens()} which will return a token for each message that
 	 * is in-flight.  The token can be used to wait for delivery to complete.
 	 * </ul>
-	 * </p>
 	 *
 	 * <p>When building an application,
 	 * the design of the topic tree should take into account the following principles
@@ -797,7 +810,7 @@ public void subscribe(String topicFilter, int qos, IMqttMessageListener messageL
 	 * 	<li>A leading "/" creates a distinct topic.  For example, <em>/finance</em> is
 	 * 	different from <em>finance</em>. <em>/finance</em> matches "+/+" and "/+", but
 	 * 	not "+".</li>
-	 * 	<li>Do not include the null character (Unicode<samp class="codeph"> \x0000</samp>) in
+	 * 	<li>Do not include the null character (Unicode<pre> \x0000</pre>) in
 	 * 	any topic.</li>
 	 * </ul>
 	 *
@@ -810,7 +823,7 @@ public void subscribe(String topicFilter, int qos, IMqttMessageListener messageL
 	 * 	<li>There can be any number of root nodes; that is, there can be any number
 	 * 	of topic trees.</li>
 	 * 	</ul>
-	 * </p>
+	 * 
 	 *
 	 * <p>This is a blocking method that returns once publish completes</p>	 *
 	 *
@@ -824,13 +837,12 @@ public void subscribe(String topicFilter, int qos, IMqttMessageListener messageL
 
 	/**
 	 * Sets the callback listener to use for events that happen asynchronously.
-	 * <p>There are a number of events that listener will be notified about. These include
+	 * <p>There are a number of events that listener will be notified about. These include:</p>
 	 * <ul>
 	 * <li>A new message has arrived and is ready to be processed</li>
 	 * <li>The connection to the server has been lost</li>
 	 * <li>Delivery of a message to the server has completed.</li>
 	 * </ul>
-	 * </p>
 	 * <p>Other events that track the progress of an individual operation such
 	 * as connect and subscribe can be tracked using the {@link MqttToken} passed to the
 	 * operation<p>
@@ -841,12 +853,11 @@ public void subscribe(String topicFilter, int qos, IMqttMessageListener messageL
 
 	/**
 	 * Get a topic object which can be used to publish messages.
-	 * <p>An alternative method that should be used in preference to this one when publishing a message is:
+	 * <p>An alternative method that should be used in preference to this one when publishing a message is:</p>
 	 * <ul>
 	 * <li>{@link MqttClient#publish(String, MqttMessage)} to publish a message in a blocking manner
 	 * <li>or use publish methods on the non-blocking client like {@link IMqttAsyncClient#publish(String, MqttMessage, Object, IMqttActionListener)}
 	 * </ul>
-	 * </p>
 	 * <p>When building an application,
 	 * the design of the topic tree should take into account the following principles
 	 * of topic name syntax and semantics:</p>
@@ -860,7 +871,7 @@ public void subscribe(String topicFilter, int qos, IMqttMessageListener messageL
 	 * 	<li>A leading "/" creates a distinct topic.  For example, <em>/finance</em> is
 	 * 	different from <em>finance</em>. <em>/finance</em> matches "+/+" and "/+", but
 	 * 	not "+".</li>
-	 * 	<li>Do not include the null character (Unicode<samp class="codeph"> \x0000</samp>) in
+	 * 	<li>Do not include the null character (Unicode<pre> \x0000</pre>) in
 	 * 	any topic.</li>
 	 * </ul>
 	 *
@@ -872,8 +883,7 @@ public void subscribe(String topicFilter, int qos, IMqttMessageListener messageL
 	 * 	number of levels in a topic tree.</li>
 	 * 	<li>There can be any number of root nodes; that is, there can be any number
 	 * 	of topic trees.</li>
-	 * 	</ul>
-	 * </p>
+	 * </ul>
 	 *
 	 * @param topic the topic to use, for example "finance/stock/ibm".
 	 * @return an MqttTopic object, which can be used to publish messages to
@@ -933,7 +943,7 @@ public void subscribe(String topicFilter, int qos, IMqttMessageListener messageL
 	 * sent.  The default behaviour, when manualAcks is false, is to send the MQTT
 	 * acknowledgements automatically at the successful completion of the messageArrived
 	 * callback method.
-	 * @param manualAcks
+	 * @param manualAcks if set to true, MQTT acknowledgements are not sent.
 	 */
 	public void setManualAcks(boolean manualAcks);
 	
@@ -942,7 +952,7 @@ public void subscribe(String topicFilter, int qos, IMqttMessageListener messageL
 	 * This will cause the MQTT acknowledgement to be sent to the server.
 	 * @param messageId the MQTT message id to be acknowledged
 	 * @param qos the MQTT QoS of the message to be acknowledged
-	 * @throws MqttException
+	 * @throws MqttException if there was a problem sending the acknowledgement
 	 */
 	public void messageArrivedComplete(int messageId, int qos) throws MqttException;
 

--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/IMqttDeliveryToken.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/IMqttDeliveryToken.java
@@ -15,16 +15,15 @@ package org.eclipse.paho.client.mqttv3;
  * be called withe delivery token being passed as a parameter. 
  * </ul>
  * <p> 
- * An action is in progress until either:
+ * An action is in progress until either:</p>
  * <ul>
- * <li>isComplete() returns true or 
- * <li>getException() is not null. If a client shuts down before delivery is complete. 
+ * <li>isComplete() returns true or </li>
+ * <li>getException() is not null. If a client shuts down before delivery is complete
  * an exception is returned.  As long as the Java Runtime is not stopped a delivery token
  * is valid across a connection disconnect and reconnect. In the event the client 
  * is shut down the getPendingDeliveryTokens method can be used once the client is 
- * restarted to obtain a list of delivery tokens for inflight messages.
+ * restarted to obtain a list of delivery tokens for inflight messages.</li>
  * </ul>
- * </p>
  * 
  */
 

--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/IMqttToken.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/IMqttToken.java
@@ -24,14 +24,13 @@ import org.eclipse.paho.client.mqttv3.internal.wire.MqttWireMessage;
  * An IMqttToken is used to track the state of the operation. An application can use the
  * token to wait for an operation to complete. A token is passed to callbacks
  * once the operation completes and provides context linking it to the original
- * request. A token is associated with a single operation.<p>
+ * request. A token is associated with a single operation.</p>
  * <p>
- * An action is in progress until either:
+ * An action is in progress until either:</p>
  * <ul>
- * <li>isComplete() returns true or
- * <li>getException() is not null.
+ * <li>isComplete() returns true or</li>
+ * <li>getException() is not null.</li>
  * </ul>
- * </p>
  *
  */
 public interface IMqttToken {
@@ -66,6 +65,7 @@ public interface IMqttToken {
 	 * and in the case where it failed. If the action failed {@link #getException()} will
 	 * be non null.
 	 * </p>
+	 * @return whether or not the action has finished.
 	 */
 	public boolean isComplete();
 
@@ -98,6 +98,7 @@ public interface IMqttToken {
 	/**
 	 * Returns the MQTT client that is responsible for processing the asynchronous
 	 * action
+	 * @return the client
 	 */
 	public IMqttAsyncClient getClient();
 
@@ -136,21 +137,22 @@ public interface IMqttToken {
 	 * connect, disconnect and ping operations as there can only ever
 	 * be one of these outstanding at a time. For other operations
 	 * the MQTT message id flowed over the network.
+	 * @return the message ID of the message that is associated with the token
 	 */
 	public int getMessageId();
 	
 	/**
-	 * Returns the granted QoS list from a suback 
+	 * @return the granted QoS list from a suback 
 	 */
 	public int[] getGrantedQos();
 	
 	/**
-	 * Returns the session present flag from a connack 
+	 * @return the session present flag from a connack 
 	 */
 	public boolean getSessionPresent();
 	
 	/**
-	 * Returns the response wire message
+	 * @return the response wire message
 	 */
 	public MqttWireMessage getResponse();
 

--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/MqttAsyncClient.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/MqttAsyncClient.java
@@ -59,12 +59,12 @@ import org.eclipse.paho.client.mqttv3.util.Debug;
  * MQTT action completes on a background thread.
  * This implementation is compatible with all Java SE runtimes from 1.4.2 and up.
  * </p>
- * <p>An application can connect to an MQTT server using:
+ * <p>An application can connect to an MQTT server using:</p>
  * <ul>
  * <li>A plain TCP socket
  * <li>A secure SSL/TLS socket
  * </ul>
- * </p>
+ * 
  * <p>To enable messages to be delivered even across network and client restarts
  * messages need to be safely stored until the message has been delivered at the requested
  * quality of service. A pluggable persistence mechanism is provided to store the messages.
@@ -129,11 +129,12 @@ public class MqttAsyncClient implements IMqttAsyncClient { // DestinationProvide
 	 * <p>The address of the server to connect to is specified as a URI. Two types of
 	 * connection are supported <code>tcp://</code> for a TCP connection and
 	 * <code>ssl://</code> for a TCP connection secured by SSL/TLS.
-	 * For example:
+	 * For example:</p>
 	 * <ul>
 	 * 	<li><code>tcp://localhost:1883</code></li>
 	 * 	<li><code>ssl://localhost:8883</code></li>
 	 * </ul>
+	 * <p>
 	 * If the port is not specified, it will
 	 * default to 1883 for <code>tcp://</code>" URIs, and 8883 for <code>ssl://</code> URIs.
 	 * </p>
@@ -183,10 +184,6 @@ public class MqttAsyncClient implements IMqttAsyncClient { // DestinationProvide
 		this(serverURI,clientId, new MqttDefaultFilePersistence());
 	}
 	
-	public MqttAsyncClient(String serverURI, String clientId, MqttClientPersistence persistence) throws MqttException {
-		this(serverURI,clientId, persistence, new TimerPingSender());
-	}
-
 	/**
 	 * Create an MqttAsyncClient that is used to communicate with an MQTT server.
 	 * <p>
@@ -207,11 +204,12 @@ public class MqttAsyncClient implements IMqttAsyncClient { // DestinationProvide
 	 * <p>The address of the server to connect to is specified as a URI. Two types of
 	 * connection are supported <code>tcp://</code> for a TCP connection and
 	 * <code>ssl://</code> for a TCP connection secured by SSL/TLS.
-	 * For example:
+	 * For example:</p>
 	 * <ul>
 	 * 	<li><code>tcp://localhost:1883</code></li>
 	 * 	<li><code>ssl://localhost:8883</code></li>
 	 * </ul>
+	 * <p>
 	 * If the port is not specified, it will
 	 * default to 1883 for <code>tcp://</code>" URIs, and 8883 for <code>ssl://</code> URIs.
 	 * </p>
@@ -266,6 +264,93 @@ public class MqttAsyncClient implements IMqttAsyncClient { // DestinationProvide
 	 * @param clientId a client identifier that is unique on the server being connected to
  	 * @param persistence the persistence class to use to store in-flight message. If null then the
  	 * default persistence mechanism is used
+	 * @throws MqttException if any other problem was encountered
+	 */
+	public MqttAsyncClient(String serverURI, String clientId, MqttClientPersistence persistence) throws MqttException {
+		this(serverURI,clientId, persistence, new TimerPingSender());
+	}
+
+	/**
+	 * Create an MqttAsyncClient that is used to communicate with an MQTT server.
+	 * <p>
+	 * The address of a server can be specified on the constructor. Alternatively
+	 * a list containing one or more servers can be specified using the
+	 * {@link MqttConnectOptions#setServerURIs(String[]) setServerURIs} method
+	 * on MqttConnectOptions.
+	 *
+	 * <p>The <code>serverURI</code> parameter is typically used with the
+	 * the <code>clientId</code> parameter to form a key. The key
+	 * is used to store and reference messages while they are being delivered.
+	 * Hence the serverURI specified on the constructor must still be specified even if a list
+	 * of servers is specified on an MqttConnectOptions object.
+	 * The serverURI on the constructor must remain the same across
+	 * restarts of the client for delivery of messages to be maintained from a given
+	 * client to a given server or set of servers.
+	 *
+	 * <p>The address of the server to connect to is specified as a URI. Two types of
+	 * connection are supported <code>tcp://</code> for a TCP connection and
+	 * <code>ssl://</code> for a TCP connection secured by SSL/TLS.
+	 * For example:</p>
+	 * <ul>
+	 * 	<li><code>tcp://localhost:1883</code></li>
+	 * 	<li><code>ssl://localhost:8883</code></li>
+	 * </ul>
+	 * <p>
+	 * If the port is not specified, it will
+	 * default to 1883 for <code>tcp://</code>" URIs, and 8883 for <code>ssl://</code> URIs.
+	 * </p>
+	 *
+	 * <p>
+	 * A client identifier <code>clientId</code> must be specified and be less that 65535 characters.
+	 * It must be unique across all clients connecting to the same
+	 * server. The clientId is used by the server to store data related to the client,
+	 * hence it is important that the clientId remain the same when connecting to a server
+	 * if durable subscriptions or reliable messaging are required.
+	 * <p>A convenience method is provided to generate a random client id that
+	 * should satisfy this criteria - {@link #generateClientId()}. As the client identifier
+	 * is used by the server to identify a client when it reconnects, the client must use the
+	 * same identifier between connections if durable subscriptions or reliable
+	 * delivery of messages is required.
+	 * </p>
+	 * <p>
+	 * In Java SE, SSL can be configured in one of several ways, which the
+	 * client will use in the following order:
+	 * </p>
+	 * <ul>
+	 * 	<li><strong>Supplying an <code>SSLSocketFactory</code></strong> - applications can
+	 * use {@link MqttConnectOptions#setSocketFactory(SocketFactory)} to supply
+	 * a factory with the appropriate SSL settings.</li>
+	 * 	<li><strong>SSL Properties</strong> - applications can supply SSL settings as a
+	 * simple Java Properties using {@link MqttConnectOptions#setSSLProperties(Properties)}.</li>
+	 * 	<li><strong>Use JVM settings</strong> - There are a number of standard
+	 * Java system properties that can be used to configure key and trust stores.</li>
+	 * </ul>
+	 *
+	 * <p>In Java ME, the platform settings are used for SSL connections.</p>
+	 * <p>
+	 * A persistence mechanism is used to enable reliable messaging.
+	 * For messages sent at qualities of service (QoS) 1 or 2 to be reliably delivered,
+	 * messages must be stored (on both the client and server) until the delivery of the message
+	 * is complete. If messages are not safely stored when being delivered then
+	 * a failure in the client or server can result in lost messages. A pluggable
+	 * persistence mechanism is supported via the {@link MqttClientPersistence}
+	 * interface. An implementer of this interface that safely stores messages
+	 * must be specified in order for delivery of messages to be reliable. In
+	 * addition {@link MqttConnectOptions#setCleanSession(boolean)} must be set
+	 * to false. In the event that only QoS 0 messages are sent or received or
+	 * cleanSession is set to true then a safe store is not needed.
+	 * </p>
+	 * <p>An implementation of file-based persistence is provided in
+	 * class {@link MqttDefaultFilePersistence} which will work in all Java SE based
+	 * systems. If no persistence is needed, the persistence parameter
+	 * can be explicitly set to <code>null</code>.</p>
+	 *
+	 * @param serverURI the address of the server to connect to, specified as a URI. Can be overridden using
+	 * {@link MqttConnectOptions#setServerURIs(String[])}
+	 * @param clientId a client identifier that is unique on the server being connected to
+ 	 * @param persistence the persistence class to use to store in-flight message. If null then the
+ 	 * default persistence mechanism is used
+	 * @param pingSender Custom {@link MqttPingSender} implementation.
 	 * @throws IllegalArgumentException if the URI does not start with
 	 * "tcp://", "ssl://" or "local://"
 	 * @throws IllegalArgumentException if the clientId is null or is greater than 65535 characters in length
@@ -313,7 +398,7 @@ public class MqttAsyncClient implements IMqttAsyncClient { // DestinationProvide
 	
 
 	/**
-	 * @param ch
+	 * @param ch the character to check.
 	 * @return returns 'true' if the character is a high-surrogate code unit
 	 */
 	protected static boolean Character_isHighSurrogate(char ch) {
@@ -325,11 +410,11 @@ public class MqttAsyncClient implements IMqttAsyncClient { // DestinationProvide
 	 * each of the supplied URIs
 	 *
 	 * @param address the URI for the server.
+	 * @param options the {@link MqttConnectOptions} for the connection.
 	 * @return a network module appropriate to the specified address.
+	 * @throws MqttException if an exception occurs creating the network Modules
+	 * @throws MqttSecurityException if an issue occurs creating an SSL / TLS Socket 
 	 */
-
-	// may need an array of these network modules
-
 	protected NetworkModule[] createNetworkModules(String address, MqttConnectOptions options) throws MqttException, MqttSecurityException {
 		final String methodName = "createNetworkModules";
 		// @TRACE 116=URI={0}
@@ -651,9 +736,21 @@ public class MqttAsyncClient implements IMqttAsyncClient { // DestinationProvide
 		comms.disconnectForcibly(quiesceTimeout, disconnectTimeout);
 	}
 
-        public void disconnectForcibly(long quiesceTimeout, long disconnectTimeout, boolean sendDisconnectPacket) throws MqttException {
-                comms.disconnectForcibly(quiesceTimeout, disconnectTimeout, sendDisconnectPacket);
-        }
+	/**
+	 * Disconnects from the server forcibly to reset all the states. Could be useful when disconnect attempt failed.
+	 * <p>
+	 * Because the client is able to establish the TCP/IP connection to a none MQTT server and it will certainly fail to
+	 * send the disconnect packet.
+	 * 
+	 * @param quiesceTimeout the amount of time in milliseconds to allow for existing work to finish before
+	 * disconnecting. A value of zero or less means the client will not quiesce.
+	 * @param disconnectTimeout the amount of time in milliseconds to allow send disconnect packet to server.
+	 * @param sendDisconnectPacket if true, will send the disconnect packet to the server
+	 * @throws MqttException if any unexpected error
+	 */
+    public void disconnectForcibly(long quiesceTimeout, long disconnectTimeout, boolean sendDisconnectPacket) throws MqttException {
+        comms.disconnectForcibly(quiesceTimeout, disconnectTimeout, sendDisconnectPacket);
+    }
 
 	/* (non-Javadoc)
 	 * @see IMqttAsyncClient#isConnected()
@@ -693,12 +790,11 @@ public class MqttAsyncClient implements IMqttAsyncClient { // DestinationProvide
 
 	/**
 	 * Get a topic object which can be used to publish messages.
-	 * <p>There are two alternative methods that should be used in preference to this one when publishing a message:
+	 * <p>There are two alternative methods that should be used in preference to this one when publishing a message:</p>
 	 * <ul>
-	 * <li>{@link MqttAsyncClient#publish(String, MqttMessage, MqttDeliveryToken)} to publish a message in a non-blocking manner or
-	 * <li>{@link MqttClient#publishBlock(String, MqttMessage, MqttDeliveryToken)} to publish a message in a blocking manner
+	 * <li>{@link MqttAsyncClient#publish(String, MqttMessage)} to publish a message in a non-blocking manner or</li>
+	 * <li>{@link MqttClient#publish(String, MqttMessage)} to publish a message in a blocking manner</li>
 	 * </ul>
-	 * </p>
 	 * <p>When you build an application,
 	 * the design of the topic tree should take into account the following principles
 	 * of topic name syntax and semantics:</p>
@@ -712,7 +808,7 @@ public class MqttAsyncClient implements IMqttAsyncClient { // DestinationProvide
 	 * 	<li>A leading "/" creates a distinct topic.  For example, <em>/finance</em> is
 	 * 	different from <em>finance</em>. <em>/finance</em> matches "+/+" and "/+", but
 	 * 	not "+".</li>
-	 * 	<li>Do not include the null character (Unicode<samp class="codeph"> \x0000</samp>) in
+	 * 	<li>Do not include the null character (Unicode \x0000) in
 	 * 	any topic.</li>
 	 * </ul>
 	 *
@@ -725,7 +821,6 @@ public class MqttAsyncClient implements IMqttAsyncClient { // DestinationProvide
 	 * 	<li>There can be any number of root nodes; that is, there can be any number
 	 * 	of topic trees.</li>
 	 * 	</ul>
-	 * </p>
 	 *
 	 * @param topic the topic to use, for example "finance/stock/ibm".
 	 * @return an MqttTopic object, which can be used to publish messages to
@@ -997,6 +1092,7 @@ public class MqttAsyncClient implements IMqttAsyncClient { // DestinationProvide
 		return this.publish(topic, message, null, null);
 	}
 
+
 	/* (non-Javadoc)
 	 * @see org.eclipse.paho.client.mqttv3.IMqttAsyncClient#publish(java.lang.String, org.eclipse.paho.client.mqttv3.MqttMessage, java.lang.Object, org.eclipse.paho.client.mqttv3.IMqttActionListener)
 	 */
@@ -1026,7 +1122,7 @@ public class MqttAsyncClient implements IMqttAsyncClient { // DestinationProvide
 
 	/**
 	 * User triggered attempt to reconnect
-	 * @throws MqttException
+	 * @throws MqttException if there is an issue with reconnecting
 	 */
 	public void reconnect() throws MqttException {
 		final String methodName = "reconnect";
@@ -1138,20 +1234,35 @@ public class MqttAsyncClient implements IMqttAsyncClient { // DestinationProvide
 	
 	/**
 	 * Sets the DisconnectedBufferOptions for this client
-	 * @param bufferOpts
+	 * @param bufferOpts the {@link DisconnectedBufferOptions}
 	 */
 	public void setBufferOpts(DisconnectedBufferOptions bufferOpts) {
 		this.comms.setDisconnectedMessageBuffer(new DisconnectedMessageBuffer(bufferOpts));
 	}
 	
+	
+	/**
+	 * Returns the number of messages in the Disconnected Message Buffer
+	 * @return Count of messages in the buffer
+	 */
 	public int getBufferedMessageCount(){
 		return this.comms.getBufferedMessageCount();
 	}
 	
+	
+	/**
+	 * Returns a message from the Disconnected Message Buffer
+	 * @param bufferIndex the index of the message to be retrieved.
+	 * @return the message located at the bufferIndex
+	 */
 	public MqttMessage getBufferedMessage(int bufferIndex){
 		return this.comms.getBufferedMessage(bufferIndex);
 	}
 	
+	/**
+	 * Deletes a message from the Disconnected Message Buffer
+	 * @param bufferIndex the index of the message to be deleted.
+	 */
 	public void deleteBufferedMessage(int bufferIndex){
 		this.comms.deleteBufferedMessage(bufferIndex);
 	}
@@ -1174,6 +1285,7 @@ public class MqttAsyncClient implements IMqttAsyncClient { // DestinationProvide
 
 	/**
 	 * Return a debug object that can be used to help solve problems.
+	 * @return the {@link Debug} object
 	 */
 	public Debug getDebug() {
 		return new Debug(clientId,comms);

--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/MqttClient.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/MqttClient.java
@@ -33,12 +33,12 @@ import org.eclipse.paho.client.mqttv3.util.Debug;
  * actions block until they have completed (or timed out).
  * This implementation is compatible with all Java SE runtimes from 1.4.2 and up.
  * </p>
- * <p>An application can connect to an MQTT server using:
+ * <p>An application can connect to an MQTT server using:</p>
  * <ul>
  * <li>A plain TCP socket
  * <li>An secure SSL/TLS socket
  * </ul>
- * </p>
+ * 
  * <p>To enable messages to be delivered even across network and client restarts
  * messages need to be safely stored until the message has been delivered at the requested
  * quality of service. A pluggable persistence mechanism is provided to store the messages.
@@ -84,11 +84,12 @@ public class MqttClient implements IMqttClient { //), DestinationProvider {
 	 * <p>The address of the server to connect to is specified as a URI. Two types of
 	 * connection are supported <code>tcp://</code> for a TCP connection and
 	 * <code>ssl://</code> for a TCP connection secured by SSL/TLS.
-	 * For example:
+	 * For example:</p>
 	 * <ul>
 	 * 	<li><code>tcp://localhost:1883</code></li>
 	 * 	<li><code>ssl://localhost:8883</code></li>
 	 * </ul>
+	 * <p>
 	 * If the port is not specified, it will
 	 * default to 1883 for <code>tcp://</code>" URIs, and 8883 for <code>ssl://</code> URIs.
 	 * </p>
@@ -158,11 +159,12 @@ public class MqttClient implements IMqttClient { //), DestinationProvider {
 	 * <p>The address of the server to connect to is specified as a URI. Two types of
 	 * connection are supported <code>tcp://</code> for a TCP connection and
 	 * <code>ssl://</code> for a TCP connection secured by SSL/TLS.
-	 * For example:
+	 * For example:</p>
 	 * <ul>
 	 * 	<li><code>tcp://localhost:1883</code></li>
 	 * 	<li><code>ssl://localhost:8883</code></li>
 	 * </ul>
+	 * <p>
 	 * If the port is not specified, it will
 	 * default to 1883 for <code>tcp://</code>" URIs, and 8883 for <code>ssl://</code> URIs.
 	 * </p>
@@ -290,9 +292,21 @@ public class MqttClient implements IMqttClient { //), DestinationProvider {
 		aClient.disconnectForcibly(quiesceTimeout, disconnectTimeout);
 	}
 
-        public void disconnectForcibly(long quiesceTimeout, long disconnectTimeout, boolean sendDisconnectPacket) throws MqttException {
-                aClient.disconnectForcibly(quiesceTimeout, disconnectTimeout, sendDisconnectPacket);
-        }
+	/**
+	 * Disconnects from the server forcibly to reset all the states. Could be useful when disconnect attempt failed.
+	 * <p>
+	 * Because the client is able to establish the TCP/IP connection to a none MQTT server and it will certainly fail to
+	 * send the disconnect packet.
+	 * 
+	 * @param quiesceTimeout the amount of time in milliseconds to allow for existing work to finish before
+	 * disconnecting. A value of zero or less means the client will not quiesce.
+	 * @param disconnectTimeout the amount of time in milliseconds to allow send disconnect packet to server.
+	 * @param sendDisconnectPacket if true, will send the disconnect packet to the server
+	 * @throws MqttException if any unexpected error
+	 */
+    public void disconnectForcibly(long quiesceTimeout, long disconnectTimeout, boolean sendDisconnectPacket) throws MqttException {
+    	aClient.disconnectForcibly(quiesceTimeout, disconnectTimeout, sendDisconnectPacket);
+    }
 
 	/*
 	 * @see IMqttClient#subscribe(String)
@@ -482,12 +496,13 @@ public class MqttClient implements IMqttClient { //), DestinationProvider {
 	 * Set the maximum time to wait for an action to complete.
 	 * <p>Set the maximum time to wait for an action to complete before
 	 * returning control to the invoking application. Control is returned
-	 * when:
+	 * when:</p>
 	 * <ul>
-	 * <li>the action completes
-	 * <li>or when the timeout if exceeded
-	 * <li>or when the client is disconnect/shutdown
-	 * <ul>
+	 * <li>the action completes</li>
+	 * <li>or when the timeout if exceeded</li>
+	 * <li>or when the client is disconnect/shutdown</li>
+	 * </ul>
+	 * <p>
 	 * The default value is -1 which means the action will not timeout.
 	 * In the event of a timeout the action carries on running in the
 	 * background until it completes. The timeout is used on methods that
@@ -495,6 +510,7 @@ public class MqttClient implements IMqttClient { //), DestinationProvider {
 	 * </p>
 	 * @param timeToWaitInMillis before the action times out. A value or 0 or -1 will wait until
 	 * the action finishes and not timeout.
+	 * @throws IllegalArgumentException if timeToWaitInMillis is invalid
 	 */
 	public void setTimeToWait(long timeToWaitInMillis) throws IllegalArgumentException{
 		if (timeToWaitInMillis < -1) {
@@ -505,6 +521,7 @@ public class MqttClient implements IMqttClient { //), DestinationProvider {
 
 	/**
 	 * Return the maximum time to wait for an action to complete.
+	 * @return the time to wait
 	 * @see MqttClient#setTimeToWait(long)
 	 */
 	public long getTimeToWait() {
@@ -599,12 +616,17 @@ public class MqttClient implements IMqttClient { //), DestinationProvider {
 		return MqttAsyncClient.generateClientId();
 	}
 	
+	/**
+	 * Will attempt to reconnect to the server after the client has lost connection.
+	 * @throws MqttException if an error occurs attempting to reconnect
+	 */
 	public void reconnect() throws MqttException {
 		aClient.reconnect();
 	}
 
 	/**
 	 * Return a debug object that can be used to help solve problems.
+	 * @return the {@link Debug} Object.
 	 */
 	public Debug getDebug() {
 		return (aClient.getDebug());

--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/MqttClientPersistence.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/MqttClientPersistence.java
@@ -50,7 +50,7 @@ public interface MqttClientPersistence {
 	/**
 	 * Close the persistent store that was previously opened.
 	 * This will be called when a client application disconnects from the broker.
-	 * @throws MqttPersistenceException 
+	 * @throws MqttPersistenceException if an error occurs closing the persistence store.
 	 */	
 	public void close() throws MqttPersistenceException;
 
@@ -74,23 +74,29 @@ public interface MqttClientPersistence {
 	
 	/**
 	 * Remove the data for the specified key.
+	 * @param key The key for the data to remove
+	 * @throws MqttPersistenceException if there was a problem removing the data.
 	 */
 	public void remove(String key) throws MqttPersistenceException;
 
 	/**
 	 * Returns an Enumeration over the keys in this persistent data store.
 	 * @return an enumeration of {@link String} objects.
+	 * @throws MqttPersistenceException if there was a problem getting they keys
 	 */
 	public Enumeration keys() throws MqttPersistenceException;
 	
 	/**
 	 * Clears persistence, so that it no longer contains any persisted data.
+	 * @throws MqttPersistenceException if there was a problem clearing all data from the persistence store
 	 */
 	public void clear() throws MqttPersistenceException;
 	
 	/**
 	 * Returns whether or not data is persisted using the specified key.
 	 * @param key the key for data, which was used when originally saving it.
+	 * @return True if the persistence store contains the key
+	 * @throws MqttPersistenceException if there was a problem checking whether they key existed.
 	 */
 	public boolean containsKey(String key) throws MqttPersistenceException;
 }

--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/MqttConnectOptions.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/MqttConnectOptions.java
@@ -50,7 +50,13 @@ public class MqttConnectOptions {
 	 * The default MqttVersion is 3.1.1 first, dropping back to 3.1 if that fails
 	 */
 	public static final int MQTT_VERSION_DEFAULT = 0;
+	/**
+	 * Mqtt Version 3.1
+	 */
 	public static final int MQTT_VERSION_3_1 = 3;
+	/**
+	 * Mqtt Version 3.1.1
+	 */
 	public static final int MQTT_VERSION_3_1_1 = 4;
 
 	protected static final int URI_TYPE_TCP = 0;
@@ -101,6 +107,7 @@ public class MqttConnectOptions {
 
 	/**
 	 * Sets the password to use for the connection.
+	 * @param password A Char Array of the password
 	 */
 	public void setPassword(char[] password) {
 		this.password = password;
@@ -116,6 +123,7 @@ public class MqttConnectOptions {
 
 	/**
 	 * Sets the user name to use for the connection.
+	 * @param userName The Username as a String
 	 * @throws IllegalArgumentException if the user name is blank or only
 	 * contains whitespace characters.
 	 */
@@ -173,6 +181,11 @@ public class MqttConnectOptions {
 
 	/**
 	 * Sets up the will information, based on the supplied parameters.
+	 * 
+	 * @param topic the topic to send the LWT message to
+	 * @param msg the {@link MqttMessage} to send
+	 * @param qos the QoS Level to send the message at
+	 * @param retained whether the message should be retained or not
 	 */
 	protected void setWill(String topic, MqttMessage msg, int qos, boolean retained) {
 		willDestination = topic;
@@ -214,7 +227,8 @@ public class MqttConnectOptions {
 	 * A value of 0 disables keepalive processing in the client.
 	 * <p>The default value is 60 seconds</p>
 	 *
-	 * @param keepAliveInterval the interval, measured in seconds, must be >= 0.
+	 * @param keepAliveInterval the interval, measured in seconds, must be &gt;= 0.
+	 * @throws IllegalArgumentException if the keepAliveInterval was invalid
 	 */
 	public void setKeepAliveInterval(int keepAliveInterval)throws IllegalArgumentException {
 		if (keepAliveInterval <0 ) {
@@ -237,7 +251,7 @@ public class MqttConnectOptions {
      * Sets the "max inflight". 
      * please increase this value in a high traffic environment.
      * <p>The default value is 10</p>
-     * @param maxInflight
+     * @param maxInflight the number of maxInfligt messages
      */
     public void setMaxInflight(int maxInflight) {
         if (maxInflight < 0) {
@@ -262,7 +276,7 @@ public class MqttConnectOptions {
 	 * The default timeout is 30 seconds.
 	 * A value of 0 disables timeout processing meaning the client will wait until the
 	 * network connection is made successfully or fails.
-	 * @param connectionTimeout the timeout value, measured in seconds. It must be >0;
+	 * @param connectionTimeout the timeout value, measured in seconds. It must be &gt;0;
 	 */
 	public void setConnectionTimeout(int connectionTimeout) {
 		if (connectionTimeout <0 ) {
@@ -274,6 +288,7 @@ public class MqttConnectOptions {
 	/**
 	 * Returns the socket factory that will be used when connecting, or
 	 * <code>null</code> if one has not been set.
+	 * @return The Socket Factory
 	 */
 	public SocketFactory getSocketFactory() {
 		return socketFactory;
@@ -319,7 +334,8 @@ public class MqttConnectOptions {
 	}
 
 	/**
-	 * Sets the SSL properties for the connection.  Note that these
+	 * Sets the SSL properties for the connection.
+	 * <p>Note that these
 	 * properties are only valid if an implementation of the Java
 	 * Secure Socket Extensions (JSSE) is available.  These properties are
 	 * <em>not</em> used if a SocketFactory has been set using
@@ -386,6 +402,7 @@ public class MqttConnectOptions {
 	 * "PKIX" or "IBMJ9X509".
 	 * </dd>
 	 * </dl>
+	 * @param props The SSL {@link Properties}
 	 */
 	public void setSSLProperties(Properties props) {
 		this.sslClientProps = props;
@@ -409,13 +426,15 @@ public class MqttConnectOptions {
 	 * the specified QOS even if the client, server or connection are restarted.
 	 * <li> The server will treat a subscription as durable.
 	 * </ul>
-	 * <lI>If set to true the client and server will not maintain state across
+	 * <li>If set to true the client and server will not maintain state across
 	 * restarts of the client, the server or the connection. This means
 	 * <ul>
 	 * <li>Message delivery to the specified QOS cannot be maintained if the
 	 * client, server or connection are restarted
-	 * <lI>The server will treat a subscription as non-durable
+	 * <li>The server will treat a subscription as non-durable
 	 * </ul>
+	 * </ul>
+	 * @param cleanSession Set to True to enable cleanSession
  	 */
 	public void setCleanSession(boolean cleanSession) {
 		this.cleanSession = cleanSession;
@@ -458,16 +477,15 @@ public class MqttConnectOptions {
 	 * <p>Some MQTT servers support a high availability feature where two or more
 	 * "equal" MQTT servers share state. An MQTT client can connect to any of the "equal"
 	 * servers and be assured that messages are reliably delivered and durable subscriptions
-	 * are maintained no matter which server the client connects to.
+	 * are maintained no matter which server the client connects to.</p>
 	 * <p>The cleansession flag must be set to false if durable subscriptions and/or reliable
-	 * message delivery is required.
+	 * message delivery is required.</p></li>
 	 * <li>Hunt List
 	 * <p>A set of servers may be specified that are not "equal" (as in the high availability
 	 * option). As no state is shared across the servers reliable message delivery and
 	 * durable subscriptions are not valid. The cleansession flag must be set to true if the
-	 * hunt list mode is used
+	 * hunt list mode is used</p></li>
 	 * </ol>
-	 * </p>
 	 * @param array of serverURIs
 	 */
 	public void setServerURIs(String[] array) {
@@ -479,10 +497,9 @@ public class MqttConnectOptions {
 
 	/**
 	 * Validate a URI
-	 * @param srvURI
+	 * @param srvURI The Server URI
 	 * @return the URI type
 	 */
-
 	protected static int validateURI(String srvURI) {
 		try {
 			URI vURI = new URI(srvURI);
@@ -521,6 +538,7 @@ public class MqttConnectOptions {
 	 * by using the MQTT_VERSION_3_1_1 or MQTT_VERSION_3_1 options respectively.
 	 *
 	 * @param MqttVersion the version of the MQTT protocol.
+	 * @throws IllegalArgumentException If the MqttVersion supplied is invalid
 	 */
 	public void setMqttVersion(int MqttVersion)throws IllegalArgumentException {
 		if (MqttVersion != MQTT_VERSION_DEFAULT && 
@@ -551,13 +569,16 @@ public class MqttConnectOptions {
 	 *  it attempts to reconnect, for every failed reconnect attempt, the delay will double
 	 *  until it is at 2 minutes at which point the delay will stay at 2 minutes.</li>
 	 * </ul>
-	 * @param automaticReconnect
+	 * @param automaticReconnect If set to True, Automatic Reconnect will be enabled
 	 */
 	public void setAutomaticReconnect(boolean automaticReconnect) {
 		this.automaticReconnect = automaticReconnect;
 	}
 	
 
+	/**
+	 * @return The Debug Properties
+	 */
 	public Properties getDebug() {
 		final String strNull="null";
 		Properties p = new Properties();

--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/MqttMessage.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/MqttMessage.java
@@ -33,6 +33,7 @@ public class MqttMessage {
 
 	/**
 	 * Utility method to validate the supplied QoS value.
+	 * @param qos The QoS Level
 	 * @throws IllegalArgumentException if value of QoS is not 0, 1 or 2.
 	 */
 	public static void validateQos(int qos) {
@@ -58,6 +59,7 @@ public class MqttMessage {
 	/**
 	 * Constructs a message with the specified byte array as a payload,
 	 * and all other values set to defaults.
+	 * @param payload The Bytearray of the payload
 	 */
 	public MqttMessage(byte[] payload) {
 		setPayload(payload);
@@ -163,6 +165,7 @@ public class MqttMessage {
 	 * If a persistence mechanism is not specified, the message will not be
 	 * delivered in the event of a client failure.</li>
 	 *
+	 *</ul>
 	 * If persistence is not configured, QoS 1 and 2 messages will still be delivered
 	 * in the event of a network or server problem as the client will hold state in memory.
 	 * If the MQTT client is shutdown or fails and persistence is not configured then
@@ -223,7 +226,7 @@ public class MqttMessage {
 	/**
 	 * This is only to be used internally to provide the MQTT id of a message
 	 * received from the server.  Has no effect when publishing messages.
-	 * @param messageId
+	 * @param messageId The Message ID
 	 */
 	public void setId(int messageId) {
 		this.messageId = messageId;

--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/MqttPersistable.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/MqttPersistable.java
@@ -33,7 +33,7 @@ package org.eclipse.paho.client.mqttv3;
  * array starting at offset 1 and length 4, plus a payload byte array
  * starting at offset 30 and length 40000. There are three ways in which
  * the persistence implementation may return data to the client on
- * recovery:
+ * recovery:</p> 
  * <ul>
  * <li>It could return the data as it was passed in
  * originally, with the same byte arrays and offsets.</li>
@@ -48,8 +48,7 @@ package org.eclipse.paho.client.mqttv3;
  * and length 40004.
  * This is useful when recovering from a file where the header and payload
  * could be written as a contiguous stream of bytes.</li>
- * </ul>
- * </p>  
+ * </ul> 
  */
 public interface MqttPersistable {
 
@@ -58,18 +57,21 @@ public interface MqttPersistable {
 	 * The bytes start at {@link #getHeaderOffset()}
 	 * and continue for {@link #getHeaderLength()}.
 	 * @return the header bytes. 
+	 * @throws MqttPersistenceException if an error occurs getting the Header Bytes
 	 */
 	public byte[] getHeaderBytes() throws MqttPersistenceException;
 
 	/**
 	 * Returns the length of the header.
 	 * @return the header length
+	 * @throws MqttPersistenceException if an error occurs getting the Header length
 	 */
 	public int getHeaderLength() throws MqttPersistenceException;
 
 	/**
 	 * Returns the offset of the header within the byte array returned by {@link #getHeaderBytes()}.
 	 * @return the header offset.
+	 * @throws MqttPersistenceException if an error occurs getting the Header offset
 	 * 
 	 */
 	public int getHeaderOffset() throws MqttPersistenceException;
@@ -79,18 +81,21 @@ public interface MqttPersistable {
 	 * The bytes start at {@link #getPayloadOffset()}
 	 * and continue for {@link #getPayloadLength()}.
 	 * @return the payload bytes.  
+	 * @throws MqttPersistenceException if an error occurs getting the Payload Bytes
 	 */
 	public byte[] getPayloadBytes() throws MqttPersistenceException;
 
 	/**
 	 * Returns the length of the payload.
 	 * @return the payload length.
+	 * @throws MqttPersistenceException if an error occurs getting the Payload length
 	 */
 	public int getPayloadLength() throws MqttPersistenceException;
 
 	/**
 	 * Returns the offset of the payload within the byte array returned by {@link #getPayloadBytes()}.
 	 * @return the payload offset.
+	 * @throws MqttPersistenceException if an error occurs getting the Payload Offset
 	 * 
 	 */
 	public int getPayloadOffset() throws MqttPersistenceException;

--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/MqttPingSender.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/MqttPingSender.java
@@ -23,7 +23,7 @@ public interface MqttPingSender {
 
 	/**
 	 * Initial method. Pass interal state of current client in.
-	 * @param  The core of the client, which holds the state information for pending and in-flight messages.
+	 * @param  comms The core of the client, which holds the state information for pending and in-flight messages.
 	 */
 	public void init(ClientComms comms);
 
@@ -39,7 +39,7 @@ public interface MqttPingSender {
 	
 	/**
 	 * Schedule next ping in certain delay.
-	 * @param  delay in milliseconds.
+	 * @param  delayInMilliseconds delay in milliseconds.
 	 */
 	public void schedule(long delayInMilliseconds);
 	

--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/MqttTopic.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/MqttTopic.java
@@ -64,6 +64,10 @@ public class MqttTopic {
 	private ClientComms comms;
 	private String name;
 	
+	/**
+	 * @param name The Name of the topic
+	 * @param comms The {@link ClientComms}
+	 */
 	public MqttTopic(String name, ClientComms comms) {
 		this.comms = comms;
 		this.name = name;
@@ -78,6 +82,9 @@ public class MqttTopic {
 	 * @param payload the byte array to use as the payload
 	 * @param qos the Quality of Service.  Valid values are 0, 1 or 2.
 	 * @param retained whether or not this message should be retained by the server.
+	 * @return {@link MqttDeliveryToken}
+	 * @throws MqttException If an error occurs publishing the message
+	 * @throws MqttPersistenceException If an error occurs persisting the message
 	 * @throws IllegalArgumentException if value of QoS is not 0, 1 or 2.
 	 * @see #publish(MqttMessage)
 	 * @see MqttMessage#setQos(int)
@@ -100,6 +107,8 @@ public class MqttTopic {
 	 * 
 	 * @param message the message to publish
 	 * @return an MqttDeliveryToken for tracking the delivery of the message
+	 * @throws MqttException if an error occurs publishing the message
+	 * @throws MqttPersistenceException  if an error occurs persisting the message
 	 */
 	public MqttDeliveryToken publish(MqttMessage message) throws MqttException, MqttPersistenceException {
 		MqttDeliveryToken token = new MqttDeliveryToken(comms.getClient().getClientId());
@@ -141,7 +150,7 @@ public class MqttTopic {
 	 * @throws IllegalArgumentException if the topic is invalid
 	 */
 	public static void validate(String topicString, boolean wildcardAllowed) 
-			throws IllegalStateException, IllegalArgumentException{
+			throws  IllegalArgumentException{
 		int topicLen = 0;
 		try {
 			topicLen = topicString.getBytes("UTF-8").length;
@@ -238,10 +247,11 @@ public class MqttTopic {
 	 * 
 	 * @param topicFilter topic filter: wildcards allowed
 	 * @param topicName topic name: wildcards not allowed
+	 * @return true if the topic matches the filter
 	 * @throws IllegalArgumentException if the topic name or filter is invalid
 	 */
 	public static boolean isMatched(String topicFilter, String topicName) 
-	                    throws IllegalStateException, IllegalArgumentException {
+	                    throws IllegalArgumentException {
 	    int curn = 0,
 	        curf = 0;
 	    int curn_end = topicName.length();

--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/TimerPingSender.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/TimerPingSender.java
@@ -23,7 +23,7 @@ import org.eclipse.paho.client.mqttv3.logging.LoggerFactory;
 /**
  * Default ping sender implementation
  *
- * <p>This class implements the {@link IMqttPingSender} pinger interface
+ * <p>This class implements the {@link MqttPingSender} pinger interface
  * allowing applications to send ping packet to server every keep alive interval.
  * </p>
  *

--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/CommsCallback.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/CommsCallback.java
@@ -76,6 +76,7 @@ public class CommsCallback implements Runnable {
 
 	/**
 	 * Starts up the Callback thread.
+	 * @param threadName The name of the thread
 	 */
 	public void start(String threadName) {
 		synchronized (lifecycle) {
@@ -283,7 +284,7 @@ public class CommsCallback implements Runnable {
 	 * An action has completed - if a completion listener has been set on the
 	 * token then invoke it with the outcome of the action.
 	 * 
-	 * @param token
+	 * @param token The {@link MqttToken} that has completed
 	 */
 	public void fireActionEvent(MqttToken token) {
 		final String methodName = "fireActionEvent";
@@ -435,6 +436,7 @@ public class CommsCallback implements Runnable {
 
 	/**
 	 * Returns the thread used by this callback.
+	 * @return The {@link Thread}
 	 */
 	protected Thread getThread() {
 		return callbackThread;

--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/CommsReceiver.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/CommsReceiver.java
@@ -52,6 +52,7 @@ public class CommsReceiver implements Runnable {
 	
 	/**
 	 * Starts up the Receiver's thread.
+	 * @param threadName The name of the thread
 	 */
 	public void start(String threadName) {
 		final String methodName = "start";

--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/CommsSender.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/CommsSender.java
@@ -51,6 +51,7 @@ public class CommsSender implements Runnable {
 	
 	/**
 	 * Starts up the Sender thread.
+	 * @param threadName The name of the thread
 	 */
 	public void start(String threadName) {
 		synchronized (lifecycle) {

--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/CommsTokenStore.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/CommsTokenStore.java
@@ -32,7 +32,7 @@ import org.eclipse.paho.client.mqttv3.logging.LoggerFactory;
  * Provides a "token" based system for storing and tracking actions across 
  * multiple threads. 
  * When a message is sent, a token is associated with the message
- * and saved using the {@link #saveToken(MqttToken, MqttWireMessage)} method. Anyone interested
+ * and saved using the {@link CommsTokenStore#saveToken(MqttToken, MqttWireMessage)} method. Anyone interested
  * in tacking the state can call one of the wait methods on the token or using 
  * the asynchronous listener callback method on the operation. 
  * The {@link CommsReceiver} class, on another thread, reads responses back from 
@@ -102,6 +102,8 @@ public class CommsTokenStore {
 	 * Restores a token after a client restart.  This method could be called
 	 * for a SEND of CONFIRM, but either way, the original SEND is what's 
 	 * needed to re-build the token.
+	 * @param message The {@link MqttPublish} message to restore
+	 * @return {@link MqttDeliveryToken}
 	 */
 	protected MqttDeliveryToken restoreToken(MqttPublish message) {
 		final String methodName = "restoreToken";

--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/ConnectActionListener.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/ConnectActionListener.java
@@ -50,13 +50,14 @@ public class ConnectActionListener implements IMqttActionListener {
   private boolean reconnect;
 
 /**
-   * @param persistence
-   * @param client 
-   * @param comms
-   * @param options 
-   * @param userToken  
-   * @param userContext
-   * @param userCallback
+   * @param persistence The {@link MqttClientPersistence} layer
+   * @param client the {@link MqttAsyncClient}
+   * @param comms {@link ClientComms}
+   * @param options the {@link MqttConnectOptions}
+   * @param userToken  the {@link MqttToken}
+   * @param userContext the User Context Object
+   * @param userCallback the {@link IMqttActionListener} as the callback for the user
+   * @param reconnect If true, this is a reconnect attempt
    */
   public ConnectActionListener(
       MqttAsyncClient client,
@@ -81,7 +82,7 @@ public class ConnectActionListener implements IMqttActionListener {
   /**
    * If the connect succeeded then call the users onSuccess callback
    * 
-   * @param token 
+   * @param token the {@link IMqttToken} from the successful connection
    */
   public void onSuccess(IMqttToken token) {
 	if (originalMqttVersion == MqttConnectOptions.MQTT_VERSION_DEFAULT) {
@@ -112,8 +113,8 @@ public class ConnectActionListener implements IMqttActionListener {
    * The connect failed, so try the next URI on the list.
    * If there are no more URIs, then fail the overall connect. 
    * 
-   * @param token 
-   * @param exception 
+   * @param token the {@link IMqttToken} from the failed connection attempt
+   * @param exception the {@link Throwable} exception from the failed connection attempt
    */
   public void onFailure(IMqttToken token, Throwable exception) {
 
@@ -165,7 +166,7 @@ public class ConnectActionListener implements IMqttActionListener {
 
   /**
    * Start the connect processing
-   * @throws MqttPersistenceException 
+   * @throws MqttPersistenceException if an error is thrown whilst setting up persistence 
    */
   public void connect() throws MqttPersistenceException {
     MqttToken token = new MqttToken(client.getClientId());
@@ -192,7 +193,7 @@ public class ConnectActionListener implements IMqttActionListener {
   
   /**
    * Set the MqttCallbackExtened callback to receive connectComplete callbacks
-   * @param mqttCallbackExtended
+   * @param mqttCallbackExtended the {@link MqttCallbackExtended} to be called when the connection completes
    */
   public void setMqttCallbackExtended(MqttCallbackExtended mqttCallbackExtended) {
 		this.mqttCallbackExtended = mqttCallbackExtended;

--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/DisconnectedMessageBuffer.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/DisconnectedMessageBuffer.java
@@ -45,8 +45,9 @@ public class DisconnectedMessageBuffer implements Runnable {
 	 * then the 0th item in the buffer will be deleted and the
 	 * new message will be added. If it is not enabled then an
 	 * MqttException will be thrown.
-	 * @param message
-	 * @throws MqttException
+	 * @param message the {@link MqttWireMessage} that will be buffered
+	 * @param token the associated {@link MqttToken}
+	 * @throws MqttException if the Buffer is full
 	 */
 	public void putMessage(MqttWireMessage message, MqttToken token) throws MqttException{
 		BufferedMessage bufferedMessage = new BufferedMessage(message, token);
@@ -64,9 +65,8 @@ public class DisconnectedMessageBuffer implements Runnable {
 	
 	/**
 	 * Retrieves a message from the buffer at the given index.
-	 * @param messageIndex
-	 * @return
-	 * @throws MqttException
+	 * @param messageIndex the index of the message to be retrieved in the buffer
+	 * @return the {@link BufferedMessage}
 	 */
 	public BufferedMessage getMessage(int messageIndex){
 		synchronized (bufLock) {
@@ -77,8 +77,7 @@ public class DisconnectedMessageBuffer implements Runnable {
 	
 	/**
 	 * Removes a message from the buffer
-	 * @param messageIndex
-	 * @throws MqttException
+	 * @param messageIndex the index of the message to be deleted in the buffer
 	 */
 	public void deleteMessage(int messageIndex){
 		synchronized (bufLock) {
@@ -88,8 +87,7 @@ public class DisconnectedMessageBuffer implements Runnable {
 	
 	/**
 	 * Returns the number of messages currently in the buffer
-	 * @return
-	 * @throws MqttException
+	 * @return The count of messages in the buffer
 	 */
 	public int getMessageCount() {
 		synchronized (bufLock) {

--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/ExceptionHelper.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/ExceptionHelper.java
@@ -42,6 +42,8 @@ public class ExceptionHelper {
 	 * Returns whether or not the specified class is available to the current
 	 * class loader.  This is used to protect the code against using Java SE
 	 * APIs on Java ME.
+	 * @param className The name of the class
+	 * @return If true, the class is available
 	 */
 	public static boolean isClassAvailable(String className) {
 		boolean result = false;

--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/SSLNetworkModule.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/SSLNetworkModule.java
@@ -40,6 +40,10 @@ public class SSLNetworkModule extends TCPNetworkModule {
 	 * Constructs a new SSLNetworkModule using the specified host and
 	 * port.  The supplied SSLSocketFactory is used to supply the network
 	 * socket.
+	 * @param factory the {@link SSLSocketFactory} to be used in this SSLNetworkModule
+	 * @param host the Hostname of the Server
+	 * @param port the Port of the Server
+	 * @param resourceContext Resource Context
 	 */
 	public SSLNetworkModule(SSLSocketFactory factory, String host, int port, String resourceContext) {
 		super(factory, host, port, resourceContext);
@@ -50,6 +54,7 @@ public class SSLNetworkModule extends TCPNetworkModule {
 
 	/**
 	 * Returns the enabled cipher suites.
+	 * @return a string array of enabled Cipher suites
 	 */
 	public String[] getEnabledCiphers() {
 		return enabledCiphers;
@@ -57,6 +62,7 @@ public class SSLNetworkModule extends TCPNetworkModule {
 
 	/**
 	 * Sets the enabled cipher suites on the underlying network socket.
+	 * @param enabledCiphers a String array of cipher suites to enable
 	 */
 	public void setEnabledCiphers(String[] enabledCiphers) {
 		final String methodName = "setEnabledCiphers";

--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/TCPNetworkModule.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/TCPNetworkModule.java
@@ -46,6 +46,10 @@ public class TCPNetworkModule implements NetworkModule {
 	 * Constructs a new TCPNetworkModule using the specified host and
 	 * port.  The supplied SocketFactory is used to supply the network
 	 * socket.
+	 * @param factory the {@link SocketFactory} to be used to set up this connection
+	 * @param host The server hostname
+	 * @param port The server port
+	 * @param resourceContext The Resource Context
 	 */
 	public TCPNetworkModule(SocketFactory factory, String host, int port, String resourceContext) {
 		log.setResourceName(resourceContext);
@@ -57,6 +61,8 @@ public class TCPNetworkModule implements NetworkModule {
 
 	/**
 	 * Starts the module, by creating a TCP socket to the server.
+	 * @throws IOException if there is an error creating the socket
+	 * @throws MqttException if there is an error connecting to the server
 	 */
 	public void start() throws IOException, MqttException {
 		final String methodName = "start";
@@ -94,6 +100,7 @@ public class TCPNetworkModule implements NetworkModule {
 
 	/**
 	 * Stops the module, by closing the TCP socket.
+	 * @throws IOException if there is an error closing the socket
 	 */
 	public void stop() throws IOException {
 		if (socket != null) {
@@ -122,7 +129,7 @@ public class TCPNetworkModule implements NetworkModule {
 	
 	/**
 	 * Set the maximum time to wait for a socket to be established
-	 * @param timeout
+	 * @param timeout  The connection timeout
 	 */
 	public void setConnectTimeout(int timeout) {
 		this.conTimeout = timeout;

--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/Token.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/Token.java
@@ -120,6 +120,8 @@ public class Token {
 	 * in the case of a NACK.  It does still throw an exception if something else
 	 * goes wrong (e.g. an IOException).  This is used for packets like CONNECT, 
 	 * which have useful information in the ACK that needs to be accessed.
+	 * @return the {@link MqttWireMessage}
+	 * @throws MqttException if there is an error whilst waiting for the response
 	 */
 	protected MqttWireMessage waitForResponse() throws MqttException {
 		return waitForResponse(-1);

--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/security/SSLSocketFactoryFactory.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/security/SSLSocketFactoryFactory.java
@@ -80,7 +80,8 @@ import org.eclipse.paho.client.mqttv3.logging.Logger;
  * cipher suites on the socket [see below].</li>
  * </ol>
  * <ul>
- * <li><i>For an MQTT server:</i></li>
+ * <li><i>For an MQTT server:</i>
+
  * <ol>
  * <li><b>getKeyStore(configID)</b>: Optionally, to check that if there is no
  * keystore, then that all the enabled cipher suits are anonymous.</li>
@@ -90,10 +91,12 @@ import org.eclipse.paho.client.mqttv3.logging.Logger;
  * SSLServerSocket (itself created from the SSLServerSocketFactory) whether
  * client authentication is needed.</li>
  * </ol>
- * <li><i>For an MQTT client:</i></li>
+ * </li>
+ * <li><i>For an MQTT client:</i>
  * <ol>
  * <li><b>createSocketFactory(configID)</b>: to create an SSLSocketFactory.</li>
  * </ol>
+ * </li>
  * </ul>
  */
 public class SSLSocketFactoryFactory {
@@ -182,6 +185,7 @@ public class SSLSocketFactoryFactory {
 	/**
 	 * Create new instance of class.
 	 * Constructor used by the broker.
+	 * @param logger the {@link Logger} to be used
 	 */
 	public SSLSocketFactoryFactory(Logger logger) {
 		this();
@@ -1336,7 +1340,7 @@ public class SSLSocketFactoryFactory {
 	 * @param configID
 	 *            The configuration identifier for selecting a configuration.
 	 * @return An SSLSocketFactory
-	 * @throws MqttDirectException
+	 * @throws MqttSecurityException if an error occurs whilst creating the {@link SSLSocketFactory}
 	 */
 	public SSLSocketFactory createSocketFactory(String configID) 
 			throws MqttSecurityException {

--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/websocket/WebSocketFrame.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/websocket/WebSocketFrame.java
@@ -48,9 +48,9 @@ public class WebSocketFrame {
 
 	/**
 	 * Initialise a new WebSocketFrame
-	 * @param opcode
-	 * @param fin
-	 * @param payload
+	 * @param opcode WebSocket Opcode
+	 * @param fin If it's final
+	 * @param payload The payload
 	 */
 	public WebSocketFrame(byte opcode, boolean fin, byte[] payload){
 		this.opcode = opcode;
@@ -61,7 +61,7 @@ public class WebSocketFrame {
 	
 	/**
 	 * Initialise WebSocketFrame from raw Data
-	 * @param rawFrame
+	 * @param rawFrame The raw byte buffer
 	 */
 	public  WebSocketFrame (byte[] rawFrame){
 			
@@ -126,8 +126,8 @@ public class WebSocketFrame {
 	
 	/**
 	 * Takes an input stream and parses it into a Websocket frame.
-	 * @param input
-	 * @throws IOException
+	 * @param input The incoming {@link InputStream}
+	 * @throws IOException if an exception occurs whilst reading the input stream
 	 */
 	public WebSocketFrame(InputStream input) throws IOException {
 		byte firstByte = (byte) input.read();
@@ -219,9 +219,9 @@ public class WebSocketFrame {
 	
 	/**
 	 * Appends the Length and Mask to the buffer
-	 * @param buffer
-	 * @param length
-	 * @param mask
+	 * @param buffer the outgoing {@link ByteBuffer}
+	 * @param length the length of the frame
+	 * @param mask The WebSocket Mask
 	 */
 	public static void appendLengthAndMask(ByteBuffer buffer, int length, byte mask[]){
 		if(mask != null){
@@ -267,9 +267,9 @@ public class WebSocketFrame {
 
 	/**
 	 * Appends the Fin flag and the OpCode
-	 * @param buffer
-	 * @param opcode
-	 * @param fin
+	 * @param buffer The outgoing buffer
+	 * @param opcode The Websocket OpCode
+	 * @param fin if this is a final frame
 	 */
 	public static void appendFinAndOpCode(ByteBuffer buffer, byte opcode, boolean fin){
 		byte b = 0x00;

--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/websocket/WebSocketHandshake.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/websocket/WebSocketHandshake.java
@@ -65,7 +65,7 @@ public class WebSocketHandshake {
 	/**
 	 * Executes a Websocket Handshake.
 	 * Will throw an IOException if the handshake fails
-	 * @throws IOException
+	 * @throws IOException thrown if an exception occurs during the handshake
 	 */
 	public void execute() throws IOException {
 		String key = "mqtt3-" + (System.currentTimeMillis()/1000);

--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/websocket/WebSocketReceiver.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/websocket/WebSocketReceiver.java
@@ -44,6 +44,7 @@ public class WebSocketReceiver implements Runnable{
 
 	/**
 	 * Starts up the WebSocketReceiver's thread
+	 * @param threadName The name of the thread
 	 */
 	public void start(String threadName){
 		final String methodName = "start";

--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/wire/CountingInputStream.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/wire/CountingInputStream.java
@@ -28,6 +28,7 @@ public class CountingInputStream extends InputStream {
 	/**
 	 * Constructs a new <code>CountingInputStream</code> wrapping the supplied
 	 * input stream.
+	 * @param in The {@link InputStream}
 	 */
 	public CountingInputStream(InputStream in) {
 		this.in = in;
@@ -43,7 +44,7 @@ public class CountingInputStream extends InputStream {
 	}
 
 	/**
-	 * Returns the number of bytes read since the last reset.
+	 * @return  the number of bytes read since the last reset.
 	 */
 	public int getCounter() {
 		return counter;

--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/wire/MqttConnect.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/wire/MqttConnect.java
@@ -44,10 +44,10 @@ public class MqttConnect extends MqttWireMessage {
 	/**
 	 * Constructor for an on the wire MQTT connect message
 	 * 
-	 * @param info
-	 * @param data
-	 * @throws IOException
-	 * @throws MqttException
+	 * @param info The info byte
+	 * @param data the data byte array
+	 * @throws IOException thrown if an exception occurs when reading the input streams
+	 * @throws MqttException thrown if an exception occurs when decoding UTF-8
 	 */
 	public MqttConnect(byte info, byte[] data) throws IOException, MqttException {
 		super(MqttWireMessage.MESSAGE_TYPE_CONNECT);

--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/wire/MqttInputStream.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/wire/MqttInputStream.java
@@ -68,6 +68,9 @@ public class MqttInputStream extends InputStream {
 	 * If the message cannot be fully read within the socket read timeout,
 	 * a null message is returned and the method can be called again until
 	 * the message is fully read.
+	 * @return The {@link MqttWireMessage}
+	 * @throws IOException if an exception is thrown when reading from the stream
+	 * @throws MqttException if the message is invalid 
 	 */
 	public MqttWireMessage readMqttWireMessage() throws IOException, MqttException {
 		final String methodName ="readMqttWireMessage";

--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/wire/MqttOutputStream.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/wire/MqttOutputStream.java
@@ -65,6 +65,9 @@ public class MqttOutputStream extends OutputStream {
 
 	/**
 	 * Writes an <code>MqttWireMessage</code> to the stream.
+	 * @param message The {@link MqttWireMessage} to send
+	 * @throws IOException if an exception is thrown when writing to the output stream.
+	 * @throws MqttException if an exception is thrown when getting the header or payload
 	 */
 	public void write(MqttWireMessage message) throws IOException, MqttException {
 		final String methodName = "write";

--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/wire/MqttPubRel.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/wire/MqttPubRel.java
@@ -28,7 +28,7 @@ public class MqttPubRel extends MqttPersistableWireMessage {
 
 	/**
 	 * Createa a pubrel message based on a pubrec
-	 * @param pubRec
+	 * @param pubRec the {@link MqttPubRec}
 	 */
 	public MqttPubRel(MqttPubRec pubRec) {
 		super(MqttWireMessage.MESSAGE_TYPE_PUBREL);
@@ -37,9 +37,9 @@ public class MqttPubRel extends MqttPersistableWireMessage {
 	
 	/**
 	 * Creates a pubrel based on a pubrel set of bytes read fro the network
-	 * @param info
-	 * @param data
-	 * @throws IOException
+	 * @param info the info byte
+	 * @param data the byte array
+	 * @throws IOException if an exception occurs whilst reading from the input stream
 	 */
 	public MqttPubRel(byte info, byte[] data) throws IOException {
 		super(MqttWireMessage.MESSAGE_TYPE_PUBREL);

--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/wire/MqttPublish.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/wire/MqttPublish.java
@@ -44,8 +44,10 @@ public class MqttPublish extends MqttPersistableWireMessage {
 	 * Constructs a new MqttPublish object.
 	 * @param info the message info byte
 	 * @param data the variable header and payload bytes
+	 * @throws MqttException if an exception occurs creating the publish
+	 * @throws IOException if an exception occurs creating the publish
 	 */
-	public MqttPublish(byte info, byte[] data) throws MqttException, IOException {
+	public MqttPublish(byte info, byte[] data) throws MqttException, IOException  {
 		super(MqttWireMessage.MESSAGE_TYPE_PUBLISH);
 		message = new MqttReceivedMessage();
 		message.setQos((info >> 1) & 0x03);

--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/wire/MqttSubscribe.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/wire/MqttSubscribe.java
@@ -36,8 +36,9 @@ public class MqttSubscribe extends MqttWireMessage {
 	/**
 	 * Constructor for an on the wire MQTT subscribe message
 	 * 
-	 * @param info
-	 * @param data
+	 * @param info the info byte
+	 * @param data the data byte array
+	 * @throws IOException if an exception occurs whilst reading the input stream
 	 */
 	public MqttSubscribe(byte info, byte[] data) throws IOException {
 		super(MqttWireMessage.MESSAGE_TYPE_SUBSCRIBE);

--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/wire/MqttUnsubscribe.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/wire/MqttUnsubscribe.java
@@ -33,6 +33,7 @@ public class MqttUnsubscribe extends MqttWireMessage {
 
 	/**
 	 * Constructs an MqttUnsubscribe
+	 * @param names The topics to unsubscribe from
 	 */
 	public MqttUnsubscribe(String[] names) {
 		super(MqttWireMessage.MESSAGE_TYPE_UNSUBSCRIBE);
@@ -42,9 +43,9 @@ public class MqttUnsubscribe extends MqttWireMessage {
 	/**
 	 * Constructor for an on the wire MQTT un-subscribe message
 	 * 
-	 * @param info
-	 * @param data
-	 * @throws IOException
+	 * @param info the info byte
+	 * @param data the data byte array
+	 * @throws IOException if an exception occurs whilst reading the input stream
 	 */
 	public MqttUnsubscribe(byte info, byte[] data) throws IOException {
 		super(MqttWireMessage.MESSAGE_TYPE_UNSUBSCRIBE);

--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/wire/MqttWireMessage.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/wire/MqttWireMessage.java
@@ -71,25 +71,28 @@ public abstract class MqttWireMessage {
 	/**
 	 * Sub-classes should override this to encode the message info.
 	 * Only the least-significant four bits will be used.
+	 * @return The Message information byte
 	 */
 	protected abstract byte getMessageInfo();
 	
 	/**
 	 * Sub-classes should override this method to supply the payload bytes.
+	 * @return The payload byte array
+	 * @throws MqttException if an exception occurs whilst getting the payload
 	 */
 	public byte[] getPayload() throws MqttException {
 		return new byte[0];
 	}
 	
 	/**
-	 * Returns the type of the message.
+	 * @return the type of the message.
 	 */
 	public byte getType() {
 		return type;
 	}
 	
 	/**
-	 * Returns the MQTT message ID.
+	 * @return the MQTT message ID.
 	 */
 	public int getMessageId() {
 		return msgId;
@@ -97,6 +100,7 @@ public abstract class MqttWireMessage {
 	
 	/**
 	 * Sets the MQTT message ID.
+	 * @param msgId the MQTT message ID
 	 */
 	public void setMessageId(int msgId) {
 		this.msgId = msgId;
@@ -134,7 +138,7 @@ public abstract class MqttWireMessage {
 
 
 	/**
-	 * Returns whether or not this message needs to include a message ID.
+	 * @return whether or not this message needs to include a message ID.
 	 */
 	public boolean isMessageIdRequired() {
 		return true;
@@ -253,6 +257,9 @@ public abstract class MqttWireMessage {
 	
 	/**
 	 * Decodes an MQTT Multi-Byte Integer from the given stream.
+	 * @param in the input stream 
+	 * @return {@link MultiByteInteger}
+	 * @throws IOException if an exception occurs when reading the input stream
 	 */
 	protected static MultiByteInteger readMBI(DataInputStream in) throws IOException {
 		byte digit;

--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/wire/MultiByteInteger.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/wire/MultiByteInteger.java
@@ -33,14 +33,14 @@ public class MultiByteInteger {
 	}
 	
 	/**
-	 * Returns the number of bytes read when decoding this MBI.
+	 * @return the number of bytes read when decoding this MBI.
 	 */
 	public int getEncodedLength() {
 		return length;
 	}
 
 	/**
-	 * Returns the value of this MBI.
+	 * @return the value of this MBI.
 	 */
 	public long getValue() {
 		return value;

--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/logging/Logger.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/logging/Logger.java
@@ -38,7 +38,7 @@ import java.util.ResourceBundle;
  * one of the predefined level constants such as Logger.SEVERE and Logger.FINE
  * with the appropriate log(int level...) or trace(int level...) methods.
  * <p>
- * The levels in descending order are:
+ * The levels in descending order are:</p>
  * <ul>
  * <li>SEVERE (log - highest value)</li>
  * <li>WARNING (log)</li>
@@ -48,7 +48,7 @@ import java.util.ResourceBundle;
  * <li>FINER (trace)</li>
  * <li>FINEST (trace - lowest value)</li>
  * </ul>
- * <p>
+ * 
  */
 public interface Logger {
 	/**
@@ -119,6 +119,7 @@ public interface Logger {
 	/**
 	 * Set a name that can be used to provide context with each log record.
 	 * This overrides the value passed in on initialise
+	 * @param logContext The Log context name
 	 */
 	public void setResourceName(String logContext);
 	
@@ -552,6 +553,8 @@ public interface Logger {
 	 *            would format two inserts into the message.
 	 * @param inserts
 	 *            Array of parameters to the message, may be null.
+	 * @param ex 
+	 * 			Throwable associated with log message.
 	 */
 	public void trace(int level, String sourceClass, String sourceMethod, String msg, Object[] inserts, Throwable ex);
 

--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/logging/LoggerFactory.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/logging/LoggerFactory.java
@@ -60,7 +60,6 @@ public class LoggerFactory {
 	 * @param messageCatalogName the resource bundle containing the logging messages.
 	 * @param loggerID  unique name to identify this logger.
 	 * @return a suitable Logger.
-	 * @throws Exception
 	 */
 	public static Logger getLogger(String messageCatalogName, String loggerID) {
 		String loggerClassName = overrideloggerClassName;

--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/persist/MqttDefaultFilePersistence.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/persist/MqttDefaultFilePersistence.java
@@ -155,8 +155,8 @@ public class MqttDefaultFilePersistence implements MqttClientPersistence {
 	/**
 	 * Writes the specified persistent data to the previously specified persistence directory.
 	 * This method uses a safe overwrite policy to ensure IO errors do not lose messages.
-	 * @param message
-	 * @throws MqttPersistenceException
+	 * @param message The {@link MqttPersistable} message to be persisted
+	 * @throws MqttPersistenceException if an exception occurs whilst persisting the message
 	 */
 	public void put(String key, MqttPersistable message) throws MqttPersistenceException {
 		checkIsOpen();
@@ -235,7 +235,7 @@ public class MqttDefaultFilePersistence implements MqttClientPersistence {
 	/**
 	 * Returns all of the persistent data from the previously specified persistence directory.
 	 * @return all of the persistent data from the persistence directory.
-	 * @throws MqttPersistenceException
+	 * @throws MqttPersistenceException if an exception is thrown whilst getting the keys
 	 */
 	public Enumeration keys() throws MqttPersistenceException {
 		checkIsOpen();

--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/util/Debug.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/util/Debug.java
@@ -141,6 +141,9 @@ public class Debug {
 
 	/**
 	 * Return a set of properties as a formatted string
+	 * @param props The Dump Properties
+	 * @param name The associated name 
+	 * @return a set of properties as a formatted string
 	 */
 	public static String dumpProperties(Properties props, String name) {
 		

--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/util/Strings.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/util/Strings.java
@@ -26,8 +26,7 @@ public final class Strings {
 	 * Checks if the CharSequence equals any character in the given set of characters.
 	 * 
 	 * @param cs the CharSequence to check
-	 * @param first the first CharSequence
-	 * @param rest the rest CharSequence
+	 * @param strs the set of characters to check against
 	 * @return true if equals any
 	 */
 	public static boolean equalsAny(CharSequence cs, CharSequence[] strs) {

--- a/org.eclipse.paho.client.mqttv3/src/main/resources/org/eclipse/paho/client/mqttv3/internal/nls/logcat.properties
+++ b/org.eclipse.paho.client.mqttv3/src/main/resources/org/eclipse/paho/client/mqttv3/internal/nls/logcat.properties
@@ -78,6 +78,8 @@
 514=Failed to persist buffered message key={0}
 515=Could not Persist, attempting to Re-Open Persistence Store
 516=Restoring all buffered messages.
+517=Un-Persisting Buffered message key={0}
+518=Failed to Un-Persist Buffered message key={0}
 600=>
 601=key={0} message={1}
 602=key={0} exception


### PR DESCRIPTION
Please make sure that the following boxes are checked before submitting your Pull Request, thank you!
- [x] You have signed the [Eclipse CLA](http://www.eclipse.org/legal/CLA.php)
- [x] All of your commits have been signed-off with the correct email address (The same one that you used to sign the CLA)

We previously had to disable javadoc validation in the build as the new Java 8 compiler would hard fail due to invalid javadoc comments in the Java client. Disabling validation was only a temporary fix to get builds running, so I've now gone through and added / fixed / removed javadoc where necessary.
