### PR TITLE
New Features: SSL hostname verification, protocols and cipher suites, SOCKS proxies, TCP SO_LINGER timeouts

### DIFF
--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/MqttConnectOptions.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/MqttConnectOptions.java
@@ -21,6 +21,7 @@ import java.util.Properties;
 
 import javax.net.SocketFactory;
 
+import org.eclipse.paho.client.mqttv3.socket.ConnectionSocketFactory;
 import org.eclipse.paho.client.mqttv3.util.Debug;
 
 import java.net.URI;
@@ -66,9 +67,11 @@ public class MqttConnectOptions {
 	private String userName;
 	private char[] password;
 	private SocketFactory socketFactory;
+	private ConnectionSocketFactory connectionSocketFactory;
 	private Properties sslClientProps = null;
 	private boolean cleanSession = CLEAN_SESSION_DEFAULT;
 	private int connectionTimeout = CONNECTION_TIMEOUT_DEFAULT;
+	private int soLinger = -1;
 	private String[] serverURIs = null;
 	private int MqttVersion = MQTT_VERSION_DEFAULT;
 	private boolean automaticReconnect = false;
@@ -271,6 +274,17 @@ public class MqttConnectOptions {
 		this.connectionTimeout = connectionTimeout;
 	}
 
+	public int getSoLinger() {
+		return soLinger;
+	}
+	
+	public void setSoLinger(int soLinger) {
+		if (soLinger < 0) {
+			throw new IllegalArgumentException();
+		}
+		this.soLinger = soLinger;
+	}
+
 	/**
 	 * Returns the socket factory that will be used when connecting, or
 	 * <code>null</code> if one has not been set.
@@ -288,6 +302,14 @@ public class MqttConnectOptions {
 	 */
 	public void setSocketFactory(SocketFactory socketFactory) {
 		this.socketFactory = socketFactory;
+	}
+
+	public ConnectionSocketFactory getConnectionSocketFactory() {
+		return connectionSocketFactory;
+	}
+	
+	public void setConnectionSocketFactory(ConnectionSocketFactory connectionSocketFactory) {
+		this.connectionSocketFactory = connectionSocketFactory;
 	}
 
 	/**

--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/websocket/WebSocketNetworkModule.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/websocket/WebSocketNetworkModule.java
@@ -28,6 +28,7 @@ import org.eclipse.paho.client.mqttv3.MqttException;
 import org.eclipse.paho.client.mqttv3.internal.TCPNetworkModule;
 import org.eclipse.paho.client.mqttv3.logging.Logger;
 import org.eclipse.paho.client.mqttv3.logging.LoggerFactory;
+import org.eclipse.paho.client.mqttv3.socket.ConnectionSocketFactory;
 
 public class WebSocketNetworkModule extends TCPNetworkModule {
 	
@@ -62,7 +63,7 @@ public class WebSocketNetworkModule extends TCPNetworkModule {
 		}
 	};
 	
-	public WebSocketNetworkModule(SocketFactory factory, String uri, String host, int port, String resourceContext){
+	public WebSocketNetworkModule(ConnectionSocketFactory factory, String uri, String host, int port, String resourceContext){
 		super(factory, host, port, resourceContext);
 		this.uri = uri;
 		this.host = host;

--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/websocket/WebSocketSecureNetworkModule.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/websocket/WebSocketSecureNetworkModule.java
@@ -28,6 +28,7 @@ import org.eclipse.paho.client.mqttv3.MqttException;
 import org.eclipse.paho.client.mqttv3.internal.SSLNetworkModule;
 import org.eclipse.paho.client.mqttv3.logging.Logger;
 import org.eclipse.paho.client.mqttv3.logging.LoggerFactory;
+import org.eclipse.paho.client.mqttv3.socket.ConnectionSocketFactory;
 
 public class WebSocketSecureNetworkModule extends SSLNetworkModule{
 	
@@ -62,7 +63,7 @@ public class WebSocketSecureNetworkModule extends SSLNetworkModule{
 		}
 	};
 
-	public WebSocketSecureNetworkModule(SSLSocketFactory factory, String uri, String host, int port, String clientId) {
+	public WebSocketSecureNetworkModule(ConnectionSocketFactory factory, String uri, String host, int port, String clientId) {
 		super(factory, host, port, clientId);
 		this.uri = uri;
 		this.host = host;

--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/socket/ConnectionSocketFactory.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/socket/ConnectionSocketFactory.java
@@ -1,0 +1,72 @@
+/*
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+
+package org.eclipse.paho.client.mqttv3.socket;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+
+/**
+ * A factory for creating and connecting connection sockets.
+ */
+public interface ConnectionSocketFactory {
+
+	/**
+	 * Creates new, unconnected socket. The socket should subsequently be passed to
+	 * {@link #connectSocket(int, Socket, String, InetSocketAddress, InetSocketAddress,
+	 *	HttpContext) connectSocket} method.
+	 *
+	 * @return  a new socket
+	 *
+	 * @throws IOException if an I/O error occurs while creating the socket
+	 */
+	Socket createSocket() throws IOException;
+
+	/**
+	 * Connects the socket to the target host with the given resolved remote address.
+	 *
+	 * @param connectTimeout connect timeout.
+	 * @param socket the socket to connect, as obtained from {@link #createSocket()}.
+	 * {@code null} indicates that a new socket should be created and connected.
+	 * @param host target host as specified by the caller (end user).
+	 * @param remoteAddress the resolved remote address to connect to.
+	 * @param localAddress the local address to bind the socket to, or {@code null} for any.
+	 *
+	 * @return  the connected socket. The returned object may be different
+	 *		  from the {@code sock} argument if this factory supports
+	 *		  a layered protocol.
+	 *
+	 * @throws IOException if an I/O error occurs
+	 */
+	Socket connectSocket(
+		int connectTimeout,
+		Socket socket,
+		String host,
+		InetSocketAddress remoteAddress,
+		InetSocketAddress localAddress) throws IOException;
+}

--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/socket/NoopHostnameVerifier.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/socket/NoopHostnameVerifier.java
@@ -1,0 +1,44 @@
+/*
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+
+package org.eclipse.paho.client.mqttv3.socket;
+
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLSession;
+
+/**
+ * The no-op HostnameVerifier essentially turns hostname verification off.
+ * This implementation is a no-op, and never throws the SSLException.
+ */
+public class NoopHostnameVerifier implements HostnameVerifier {
+
+	public static final NoopHostnameVerifier INSTANCE = new NoopHostnameVerifier();
+
+	public boolean verify(final String s, final SSLSession sslSession) {
+		return true;
+	}
+}

--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/socket/PlainConnectionSocketFactory.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/socket/PlainConnectionSocketFactory.java
@@ -1,0 +1,79 @@
+/*
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+
+package org.eclipse.paho.client.mqttv3.socket;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import javax.net.SocketFactory;
+
+/**
+ * The default class for creating plain (unencrypted) sockets.
+ */
+public class PlainConnectionSocketFactory implements ConnectionSocketFactory {
+	private SocketFactory factory;
+
+	public PlainConnectionSocketFactory() {
+		super();
+	}
+	
+	public PlainConnectionSocketFactory(SocketFactory factory) {
+		super();
+		this.factory = factory;
+	}
+
+	public Socket createSocket() throws IOException {
+		if (factory != null) {
+			return factory.createSocket();
+		} else {
+			return new Socket();
+		}
+	}
+
+	public Socket connectSocket(
+			final int connectTimeout,
+			final Socket socket,
+			final String host,
+			final InetSocketAddress remoteAddress,
+			final InetSocketAddress localAddress) throws IOException {
+		final Socket s = socket != null ? socket : createSocket();
+		if (localAddress != null) {
+			s.bind(localAddress);
+		}
+		try {
+			s.connect(remoteAddress, connectTimeout);
+		} catch (final IOException e) {
+			try {
+				s.close();
+			} catch (final IOException ignore) {
+			}
+			throw e;
+		}
+		return s;
+	}
+}

--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/socket/SSLConnectionSocketFactory.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/socket/SSLConnectionSocketFactory.java
@@ -1,0 +1,272 @@
+/*
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+
+package org.eclipse.paho.client.mqttv3.socket;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.security.cert.Certificate;
+import java.security.cert.X509Certificate;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+
+import javax.net.SocketFactory;
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLHandshakeException;
+import javax.net.ssl.SSLPeerUnverifiedException;
+import javax.net.ssl.SSLSession;
+import javax.net.ssl.SSLSocket;
+import javax.security.auth.x500.X500Principal;
+
+import org.eclipse.paho.client.mqttv3.logging.Logger;
+import org.eclipse.paho.client.mqttv3.logging.LoggerFactory;
+
+/**
+ * Socket factory for TLS/SSL connections.
+ */
+public class SSLConnectionSocketFactory implements ConnectionSocketFactory {
+	private static final String CLASS_NAME = SSLConnectionSocketFactory.class.getName();
+	private static final Logger log = LoggerFactory.getLogger(LoggerFactory.MQTT_CLIENT_MSG_CAT, CLASS_NAME);
+	
+	private final javax.net.ssl.SSLSocketFactory socketFactory;
+	private final HostnameVerifier hostnameVerifier;
+	private final String[] supportedProtocols;
+	private String[] supportedCipherSuites;
+	private int sslHandshakeTimeout = 30000; //ms
+
+	public SSLConnectionSocketFactory(
+			final javax.net.ssl.SSLSocketFactory socketFactory,
+			final HostnameVerifier hostnameVerifier) {
+		this(socketFactory, null, null, hostnameVerifier);
+	}
+
+	public SSLConnectionSocketFactory(
+			final javax.net.ssl.SSLSocketFactory socketFactory,
+			final String[] supportedProtocols,
+			final String[] supportedCipherSuites,
+			final HostnameVerifier hostnameVerifier) {
+		if (socketFactory == null) {
+			throw new IllegalArgumentException("SSL socket factory must not be null");
+		}
+		this.socketFactory = socketFactory;
+		this.supportedProtocols = supportedProtocols;
+		this.supportedCipherSuites = supportedCipherSuites;
+		this.hostnameVerifier = hostnameVerifier != null ? hostnameVerifier : NoopHostnameVerifier.INSTANCE;
+	}
+
+	/**
+	 * Performs any custom initialization for a newly created SSLSocket
+	 * (before the SSL handshake happens).
+	 *
+	 * The default implementation is a no-op, but could be overridden to, e.g.,
+	 * call {@link javax.net.ssl.SSLSocket#setEnabledCipherSuites(String[])}.
+	 * @throws IOException may be thrown if overridden
+	 */
+	protected void prepareSocket(final SSLSocket socket) throws IOException {
+	}
+
+	public Socket createSocket() throws IOException {
+		return SocketFactory.getDefault().createSocket();
+	}
+
+	public Socket connectSocket(
+			final int connectTimeout,
+			final Socket socket,
+			final String host,
+			final InetSocketAddress remoteAddress,
+			final InetSocketAddress localAddress) throws IOException {
+		final String methodName = "connectSocket";
+		
+		if (host == null) {
+			throw new IllegalArgumentException("Host must not be null");
+		}
+		if (remoteAddress == null) {
+			throw new IllegalArgumentException("Remote address must not be null");
+		}
+		final Socket s = socket != null ? socket : createSocket();
+		if (localAddress != null) {
+			s.bind(localAddress);
+		}
+		try {
+			if (log.isLoggable(Logger.FINE)) {
+				this.log.fine(CLASS_NAME, methodName, "Connecting socket to " + remoteAddress + " with timeout " + connectTimeout);
+			}
+			s.connect(remoteAddress, connectTimeout);
+		} catch (final IOException e) {
+			try {
+				s.close();
+			} catch (final IOException ignore) {
+			}
+			throw e;
+		}
+		// Setup the SSL socket.
+		if (s instanceof SSLSocket) {
+			final SSLSocket sslSocket = (SSLSocket) s;
+			this.log.fine(CLASS_NAME, methodName, "Starting handshake");
+			int soTimeout = sslSocket.getSoTimeout();
+			if (soTimeout == 0) {
+				// Avoid infinite SSL handshake timeout.
+				sslSocket.setSoTimeout(this.sslHandshakeTimeout);
+			}
+			sslSocket.startHandshake();
+			sslSocket.setSoTimeout(soTimeout);
+			verifyHostname(sslSocket, host);
+			return s;
+		} else {
+			return createSSLSocket(s, host, remoteAddress.getPort());
+		}
+	}
+	
+	public void setSupportedCipherSuites(String[] supportedCipherSuites) {
+		this.supportedCipherSuites = supportedCipherSuites;
+	}
+	
+	public void setSSLHandshakeTimeout(int timeout) {
+		if (timeout != 0) {
+			this.sslHandshakeTimeout = timeout;
+		}
+	}
+
+	private Socket createSSLSocket(
+			final Socket socket,
+			final String target,
+			final int port) throws IOException {
+		final String methodName = "createSSLSocket";
+		
+		final SSLSocket sslSocket = (SSLSocket) this.socketFactory.createSocket(
+				socket,
+				target,
+				port,
+				true);
+		if (supportedProtocols != null) {
+			sslSocket.setEnabledProtocols(supportedProtocols);
+		} else {
+			// If supported protocols are not explicitly set, remove all SSL protocol versions.
+			final String[] allProtocols = sslSocket.getEnabledProtocols();
+			final List enabledProtocols = new ArrayList(allProtocols.length);
+			for (int i = 0; i < allProtocols.length; i++) {
+				String protocol= allProtocols[i];
+				if (!protocol.startsWith("SSL")) {
+					enabledProtocols.add(protocol);
+				}
+			}
+			if (!enabledProtocols.isEmpty()) {
+				sslSocket.setEnabledProtocols((String[]) enabledProtocols.toArray(new String[enabledProtocols.size()]));
+			}
+		}
+		if (supportedCipherSuites != null) {
+			sslSocket.setEnabledCipherSuites(supportedCipherSuites);
+		}
+
+		if (log.isLoggable(Logger.FINE)) {
+			this.log.fine(CLASS_NAME, methodName, "Enabled protocols: " + Arrays.asList(sslSocket.getEnabledProtocols()));
+			this.log.fine(CLASS_NAME, methodName, "Enabled cipher suites:" + Arrays.asList(sslSocket.getEnabledCipherSuites()));
+		}
+
+		prepareSocket(sslSocket);
+		this.log.fine(CLASS_NAME, methodName, "Starting handshake");
+		int soTimeout = sslSocket.getSoTimeout();
+		if (soTimeout == 0) {
+			// Avoid infinite SSL handshake timeout.
+			sslSocket.setSoTimeout(this.sslHandshakeTimeout);
+		}
+		sslSocket.startHandshake();
+		sslSocket.setSoTimeout(soTimeout);
+		verifyHostname(sslSocket, target);
+		return sslSocket; 
+	}
+
+	private void verifyHostname(final SSLSocket sslSocket, final String hostname) throws IOException {
+		final String methodName = "verifyHostname";
+		
+		try {
+			SSLSession session = sslSocket.getSession();
+			if (session == null) {
+				throw new SSLHandshakeException("SSL session unavailable");
+			}
+
+			if (log.isLoggable(Logger.FINE)) {
+				this.log.fine(CLASS_NAME, methodName, "Secure session established");
+				this.log.fine(CLASS_NAME, methodName, " negotiated protocol: " + session.getProtocol());
+				this.log.fine(CLASS_NAME, methodName, " negotiated cipher suite: " + session.getCipherSuite());
+
+				try {
+					final Certificate[] certs = session.getPeerCertificates();
+					final X509Certificate x509Certificate = (X509Certificate) certs[0];
+					final X500Principal peer = x509Certificate.getSubjectX500Principal();
+
+					this.log.fine(CLASS_NAME, methodName, " peer principal: " + peer.toString());
+					final Collection altNames1 = x509Certificate.getSubjectAlternativeNames();
+					if (altNames1 != null) {
+						final List altNames = new ArrayList();
+						for (Iterator itr = altNames1.iterator(); itr.hasNext();) {
+							final List aC = (List) itr.next();
+							if (!aC.isEmpty()) {
+								altNames.add((String) aC.get(1));
+							}
+						}
+						this.log.fine(CLASS_NAME, methodName, " peer alternative names: " + altNames);
+					}
+
+					final X500Principal issuer = x509Certificate.getIssuerX500Principal();
+					this.log.fine(CLASS_NAME, methodName, " issuer principal: " + issuer.toString());
+					final Collection altNames2 = x509Certificate.getIssuerAlternativeNames();
+					if (altNames2 != null) {
+						final List altNames = new ArrayList();
+						for (Iterator itr = altNames2.iterator(); itr.hasNext();) {
+							final List aC = (List) itr.next();
+							if (!aC.isEmpty()) {
+								altNames.add((String) aC.get(1));
+							}
+						}
+						this.log.fine(CLASS_NAME, methodName, " issuer alternative names: " + altNames);
+					}
+				} catch (Exception ignore) {
+				}
+			}
+
+			if (!this.hostnameVerifier.verify(hostname, session)) {
+				final Certificate[] certs = session.getPeerCertificates();
+				final X509Certificate x509Certificate = (X509Certificate) certs[0];
+				final X500Principal x500Principal = x509Certificate.getSubjectX500Principal();
+				throw new SSLPeerUnverifiedException("Host name '" + hostname + "' does not match " +
+						"the certificate subject provided by the peer (" + x500Principal.toString() + ")");
+			}
+		} catch (final IOException e) {
+			// Close the socket before re-throwing the exception.
+			try {
+				sslSocket.close();
+			} catch (final Exception ignore) {
+			}
+			throw e;
+		}
+	}
+}


### PR DESCRIPTION
* Apache HTTP Client like support for selecting SSL protocols, cipher suites and (most importantly) hostname verification to prevent SSL man-in-the-middle attacks.
* ConnectionSocketFactory source code taken from the Apache HTTP Client open source project.
* Does not break existing Paho MQTT Client public APIs.
* Support for SOCKS proxies using ConnectionSocketFactory.
* Support for TCP SO_LINGER timeouts.
* For SSL hostname verification one can use org.apache.http.conn.ssl.DefaultHostnameVerifier from the Apache HTTP Client open source project.
* SOCKS proxy support example:
<pre><code>
private class SocksSSLSocketFactory extends SSLConnectionSocketFactory {
    public SocksSSLSocketFactory(final SSLSocketFactory socketFactory,
            final String[] supportedProtocols,
            final String[] supportedCipherSuites,
            final HostnameVerifier hostnameVerifier) {
        super(socketFactory, supportedProtocols, supportedCipherSuites, hostnameVerifier);
    }

    public Socket createSocket() throws IOException {
        final String methodName = "createSocket";
          
        InetSocketAddress socksProxy = new InetSocketAddress(mProxyHostname, mProxyPort);

        if (log.isLoggable(Logger.FINE)) {
            log.fine(CLASS_NAME, methodName, "Connecting to SOCKS proxy "+ socksProxy);
        }

        Proxy proxy = new Proxy(Proxy.Type.SOCKS, socksProxy);
        return new Socket(proxy);
    }

    public Socket connectSocket(int connectTimeout, Socket socket, String host, InetSocketAddress remoteAddress,
            InetSocketAddress localAddress) throws IOException {
        InetSocketAddress unresolvedRemoteHost = InetSocketAddress.createUnresolved(host, remoteAddress.getPort());
        return super.connectSocket(connectTimeout, socket, host, unresolvedRemoteHost, localAddress);
    }
}
</code></pre>

	modified:   org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/MqttAsyncClient.java
	modified:   org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/MqttConnectOptions.java
	modified:   org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/SSLNetworkModule.java
	modified:   org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/TCPNetworkModule.java
	modified:   org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/websocket/WebSocketNetworkModule.java
	modified:   org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/websocket/WebSocketSecureNetworkModule.java
	new file:   org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/socket/ConnectionSocketFactory.java
	new file:   org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/socket/NoopHostnameVerifier.java
	new file:   org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/socket/PlainConnectionSocketFactory.java
	new file:   org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/socket/SSLConnectionSocketFactory.java
