### PR TITLE
Remove buffered message after delivery

### DIFF
--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/ClientState.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/ClientState.java
@@ -1089,6 +1089,7 @@ public class ClientState {
 				
 				// QoS 1 - user notified now remove from persistence...
 				persistence.remove(getSendPersistenceKey(message));
+				persistence.remove(getSendBufferedPersistenceKey(message));
 				outboundQoS1.remove(new Integer(ack.getMessageId()));
 				decrementInFlight();
 				releaseMessageId(message.getMessageId());
@@ -1100,6 +1101,7 @@ public class ClientState {
 				// QoS 2 - user notified now remove from persistence...
 				persistence.remove(getSendPersistenceKey(message));
 				persistence.remove(getSendConfirmPersistenceKey(message));
+				persistence.remove(getSendBufferedPersistenceKey(message));
 				outboundQoS2.remove(new Integer(ack.getMessageId()));
 
 				inFlightPubRels--;


### PR DESCRIPTION
Signed-off-by: Tomasz Bembnista <tomasz.bembnista@gmail.com>

Fixed Problem: buffered messages will not be deleted after the client has reconnected and sent the buffered messages.

Please make sure that the following boxes are checked before submitting your Pull Request, thank you!

- [x] You have signed the [Eclipse CLA](http://www.eclipse.org/legal/CLA.php)
- [x] All of your commits have been signed-off with the correct email address (The same one that you used to sign the CLA)
- [x] If This PR fixes an issue, that you reference the issue below. OR if this is a new issue that you are fixing straight away that you add some Description about the bug and how this will fix it.
- [x] If this is new functionality, You have added the appropriate Unit tests.
