### PR TITLE
changed visibility of MqttConnectOptions.validateURI to public, to be…

### DIFF
--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/MqttConnectOptions.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/MqttConnectOptions.java
@@ -500,26 +500,29 @@ public class MqttConnectOptions {
 	 * @param srvURI The Server URI
 	 * @return the URI type
 	 */
-	protected static int validateURI(String srvURI) {
+	public static int validateURI(String srvURI) {
 		try {
 			URI vURI = new URI(srvURI);
-			if (vURI.getScheme().equals("ws")){
+			if ("ws".equals(vURI.getScheme())){
 				return URI_TYPE_WS;
 			}
-			else if (vURI.getScheme().equals("wss")) {
+			else if ("wss".equals(vURI.getScheme())) {
 				return URI_TYPE_WSS;
 			}
 
-			if (!vURI.getPath().equals("")) {
-				throw new IllegalArgumentException(srvURI);
+			if ((vURI.getPath() == null) || vURI.getPath().isEmpty()) {
+				// No op path must be empty
 			}
-			if (vURI.getScheme().equals("tcp")) {
+			else {
+				throw new IllegalArgumentException(srvURI);
+			} 
+			if ("tcp".equals(vURI.getScheme())) {
 				return URI_TYPE_TCP;
 			}
-			else if (vURI.getScheme().equals("ssl")) {
+			else if ("ssl".equals(vURI.getScheme())) {
 				return URI_TYPE_SSL;
 			}
-			else if (vURI.getScheme().equals("local")) {
+			else if ("local".equals(vURI.getScheme())) {
 				return URI_TYPE_LOCAL;
 			}
 			else {


### PR DESCRIPTION
… able to use this method for external validation too.

changed logging to avoid NullPointerExceptions with invalid URLs.

Signed-off-by: Arne Plöse <aploese@gmx.de>

Please make sure that the following boxes are checked before submitting your Pull Request, thank you!

- [x] You have signed the [Eclipse ECA](https://wiki.eclipse.org/ECA)
- [x] All of your commits have been signed-off with the correct email address (The same one that you used to sign the CLA)
- [x] If This PR fixes an issue, that you reference the issue below. OR if this is a new issue that you are fixing straight away that you add some Description about the bug and how this will fix it.
- [ ] If this is new functionality, You have added the appropriate Unit tests.
