### PR TITLE
Added a testcase

### DIFF
--- a/org.eclipse.paho.client.mqttv3.test/src/test/java/org/eclipse/paho/client/mqttv3/test/MqttConnectOptionsTest.java
+++ b/org.eclipse.paho.client.mqttv3.test/src/test/java/org/eclipse/paho/client/mqttv3/test/MqttConnectOptionsTest.java
@@ -1,0 +1,58 @@
+package org.eclipse.paho.client.mqttv3.test;
+
+import org.eclipse.paho.client.mqttv3.MqttConnectOptions;
+import static org.junit.Assert.*;
+import org.junit.Test;
+
+public class MqttConnectOptionsTest {
+
+	@Test
+	public void testValidateURI() {
+		try {
+			MqttConnectOptions.validateURI("");
+			fail("Must fail: Empty URI");
+		} catch (IllegalArgumentException e) {
+			assertEquals("Unknown scheme \"null\" of URI \"\"", e.getMessage());
+		}
+		
+		try {
+			MqttConnectOptions.validateURI("udp://localhost:1883");
+			fail("Must fail: Unknow scheme");
+		} catch (IllegalArgumentException e) {
+			assertEquals("Unknown scheme \"udp\" of URI \"udp://localhost:1883\"", e.getMessage());
+		}
+		
+		MqttConnectOptions.validateURI("tcp://localhost:1883");
+		
+		try {
+			MqttConnectOptions.validateURI("tcp://localhost:1883/mqtt");
+			fail("Must fail: URI path must be empty");
+		} catch (IllegalArgumentException e) {
+			assertEquals("URI path must be empty \"tcp://localhost:1883/mqtt\"", e.getMessage());
+		}
+		
+		MqttConnectOptions.validateURI("tcp://localhost");
+		
+		try {
+			MqttConnectOptions.validateURI("localhost:1883");
+			fail("Must fail: Unknow scheme");
+		} catch (IllegalArgumentException e) {
+			assertEquals("Unknown scheme \"localhost\" of URI \"localhost:1883\"", e.getMessage());
+		}
+		
+		try {
+			MqttConnectOptions.validateURI("localhost");
+			fail("Must fail: URI path must be empty");
+		} catch (IllegalArgumentException e) {
+			assertEquals("URI path must be empty \"localhost\"", e.getMessage());
+		}
+		
+		try {
+			MqttConnectOptions.validateURI("tcp://");
+			fail("Must fail: Can't parse string to URI");
+		} catch (IllegalArgumentException e) {
+			assertEquals("Can't parse string to URI \"tcp://\"", e.getMessage());
+		}
+	}
+
+}

--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/MqttConnectOptions.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/MqttConnectOptions.java
@@ -500,26 +500,29 @@ public class MqttConnectOptions {
 	 * @param srvURI The Server URI
 	 * @return the URI type
 	 */
-	protected static int validateURI(String srvURI) {
+	public static int validateURI(String srvURI) {
 		try {
 			URI vURI = new URI(srvURI);
-			if (vURI.getScheme().equals("ws")){
+			if ("ws".equals(vURI.getScheme())){
 				return URI_TYPE_WS;
 			}
-			else if (vURI.getScheme().equals("wss")) {
+			else if ("wss".equals(vURI.getScheme())) {
 				return URI_TYPE_WSS;
 			}
 
-			if (!vURI.getPath().equals("")) {
-				throw new IllegalArgumentException(srvURI);
+			if ((vURI.getPath() == null) || vURI.getPath().isEmpty()) {
+				// No op path must be empty
 			}
-			if (vURI.getScheme().equals("tcp")) {
+			else {
+				throw new IllegalArgumentException(srvURI);
+			} 
+			if ("tcp".equals(vURI.getScheme())) {
 				return URI_TYPE_TCP;
 			}
-			else if (vURI.getScheme().equals("ssl")) {
+			else if ("ssl".equals(vURI.getScheme())) {
 				return URI_TYPE_SSL;
 			}
-			else if (vURI.getScheme().equals("local")) {
+			else if ("local".equals(vURI.getScheme())) {
 				return URI_TYPE_LOCAL;
 			}
 			else {

--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/MqttConnectOptions.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/MqttConnectOptions.java
@@ -501,35 +501,36 @@ public class MqttConnectOptions {
 	 * @return the URI type
 	 */
 	public static int validateURI(String srvURI) {
+		URI vURI;
 		try {
-			URI vURI = new URI(srvURI);
-			if ("ws".equals(vURI.getScheme())){
-				return URI_TYPE_WS;
-			}
-			else if ("wss".equals(vURI.getScheme())) {
-				return URI_TYPE_WSS;
-			}
-
-			if ((vURI.getPath() == null) || vURI.getPath().isEmpty()) {
-				// No op path must be empty
-			}
-			else {
-				throw new IllegalArgumentException(srvURI);
-			} 
-			if ("tcp".equals(vURI.getScheme())) {
-				return URI_TYPE_TCP;
-			}
-			else if ("ssl".equals(vURI.getScheme())) {
-				return URI_TYPE_SSL;
-			}
-			else if ("local".equals(vURI.getScheme())) {
-				return URI_TYPE_LOCAL;
-			}
-			else {
-				throw new IllegalArgumentException(srvURI);
-			}
+			vURI = new URI(srvURI);
 		} catch (URISyntaxException ex) {
-			throw new IllegalArgumentException(srvURI);
+			throw new IllegalArgumentException("Can't parse string to URI \"" + srvURI + "\"", ex);
+		}
+
+		if ("ws".equals(vURI.getScheme())){
+			return URI_TYPE_WS;
+		}
+		else if ("wss".equals(vURI.getScheme())) {
+			return URI_TYPE_WSS;
+		}
+		if ((vURI.getPath() == null) || vURI.getPath().isEmpty()) {
+			// No op path must be empty
+		}
+		else {
+			throw new IllegalArgumentException("URI path must be empty \"" + srvURI + "\"");
+		} 
+		if ("tcp".equals(vURI.getScheme())) {
+			return URI_TYPE_TCP;
+		}
+		else if ("ssl".equals(vURI.getScheme())) {
+			return URI_TYPE_SSL;
+		}
+		else if ("local".equals(vURI.getScheme())) {
+			return URI_TYPE_LOCAL;
+		}
+		else {
+			throw new IllegalArgumentException("Unknown scheme \"" + vURI.getScheme() + "\" of URI \"" + srvURI + "\"");
 		}
 	}
 	


### PR DESCRIPTION
The test randomly failing on my machine? Maybe you will have a look at it?
validateURI is used @ org.eclipse.paho.client.mqttv3.MqttAsyncClient createNetworkModule to extract the scheme. It would be clearer to have a validate and something like getSchemeOfURI() ?



Please make sure that the following boxes are checked before submitting your Pull Request, thank you!

- [ x] You have signed the [Eclipse ECA](https://wiki.eclipse.org/ECA)
- [ x] All of your commits have been signed-off with the correct email address (The same one that you used to sign the CLA)
- [ ] If This PR fixes an issue, that you reference the issue below. OR if this is a new issue that you are fixing straight away that you add some Description about the bug and how this will fix it.
- [ x] If this is new functionality, You have added the appropriate Unit tests.
