### PR TITLE
Change Sec-WebSocket-Protocol to mqtt

### DIFF
--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/websocket/WebSocketHandshake.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/websocket/WebSocketHandshake.java
@@ -105,7 +105,7 @@ public class WebSocketHandshake {
 			pw.print("Upgrade: websocket" + LINE_SEPARATOR);
 			pw.print("Connection: Upgrade" + LINE_SEPARATOR);
 			pw.print("Sec-WebSocket-Key: " + key + LINE_SEPARATOR);
-			pw.print("Sec-WebSocket-Protocol: mqttv3.1" + LINE_SEPARATOR);
+			pw.print("Sec-WebSocket-Protocol: mqtt" + LINE_SEPARATOR);
 			pw.print("Sec-WebSocket-Version: 13" + LINE_SEPARATOR);
 
 			String userInfo = srvUri.getUserInfo();


### PR DESCRIPTION
As per Mqtt Spec
http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/csprd02/mqtt-v3.1.1-csprd02.html#_Toc385349863
The client MUST include mqtt in the list of WebSocket Sub Protocols it
offers [MQTT-6.0.0.3].

Signed-off-by: prmathur-microsoft <prmathur@microsoft.com>

Please make sure that the following boxes are checked before submitting your Pull Request, thank you!

- [X] You have signed the [Eclipse ECA](https://wiki.eclipse.org/ECA)
- [X] All of your commits have been signed-off with the correct email address (The same one that you used to sign the CLA)
- [X] If This PR fixes an issue, that you reference the issue below. OR if this is a new issue that you are fixing straight away that you add some Description about the bug and how this will fix it.
- [ ] If this is new functionality, You have added the appropriate Unit tests.

This PR fixes #361 