### PR TITLE
Clean up double header in contributing file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,8 +20,6 @@ Please read the [Eclipse Foundation policy on accepting contributions via Git](h
 
 ## Contributing a change
 
-## Contributing a change
-
 1. [Fork the repository on GitHub](https://github.com/eclipse/paho.mqtt.java/fork)
 2. Clone the forked repository onto your computer: ``` git clone https://github.com/<your username>/paho.mqtt.java.git ```
 3. Create a new branch from the latest ```develop``` branch with ```git checkout -b YOUR_BRANCH_NAME origin/develop```


### PR DESCRIPTION
This is only a minor typo. The same heading appears twice in the contributing file.

Please make sure that the following boxes are checked before submitting your Pull Request, thank you!

- [X] You have signed the [Eclipse ECA](https://wiki.eclipse.org/ECA)
- [X] All of your commits have been signed-off with the correct email address (The same one that you used to sign the CLA)
