### PR TITLE
A basic rework of the API using Promises and PushStreams

### DIFF
--- a/org.eclipse.paho.mqttv5.client/pom.xml
+++ b/org.eclipse.paho.mqttv5.client/pom.xml
@@ -13,12 +13,35 @@
 	<artifactId>org.eclipse.paho.mqttv5.client</artifactId>
 	<name>org.eclipse.paho.mqttv5.client</name>
 
+	<repositories>
+		<repository>
+			<id>OSGi Snapshots</id>
+			<url></url>
+			<releases>
+				<enabled>false</enabled>
+			</releases>
+			<snapshots>
+				<enabled>true</enabled>
+			</snapshots>
+		</repository>
+	</repositories>
+
 
 	<dependencies>
 		<dependency>
 			<groupId>org.osgi</groupId>
-			<artifactId>osgi.promise</artifactId>
-			<version>6.0.0</version>
+			<artifactId>org.osgi.util.promise</artifactId>
+			<version>1.1.0-SNAPSHOT</version>
+		</dependency>
+		<dependency>
+			<groupId>org.osgi</groupId>
+			<artifactId>org.osgi.util.function</artifactId>
+			<version>1.1.0-SNAPSHOT</version>
+		</dependency>
+		<dependency>
+			<groupId>org.osgi</groupId>
+			<artifactId>org.osgi.util.pushstream</artifactId>
+			<version>1.0.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.paho</groupId>

--- a/org.eclipse.paho.mqttv5.client/pom.xml
+++ b/org.eclipse.paho.mqttv5.client/pom.xml
@@ -16,7 +16,7 @@
 	<repositories>
 		<repository>
 			<id>OSGi Snapshots</id>
-			<url></url>
+			<url>https://oss.sonatype.org/content/groups/osgi</url>
 			<releases>
 				<enabled>false</enabled>
 			</releases>

--- a/org.eclipse.paho.mqttv5.client/src/main/java/org/eclipse/paho/mqttv5/client/alpha/IMqttAsyncClient.java
+++ b/org.eclipse.paho.mqttv5.client/src/main/java/org/eclipse/paho/mqttv5/client/alpha/IMqttAsyncClient.java
@@ -1,0 +1,638 @@
+/*******************************************************************************
+ * Copyright (c) 2013, 2015 IBM Corp.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution. 
+ *
+ * The Eclipse Public License is available at 
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at 
+ *   http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * Contributors:
+ *    Dave Locke - initial API and implementation and/or initial documentation
+ *    Ian Craggs - MQTT 3.1.1 support
+ *    Ian Craggs - per subscription message handlers (bug 466579)
+ *    Ian Craggs - ack control (bug 472172)
+ */
+
+package org.eclipse.paho.mqttv5.client.alpha;
+
+import java.util.ArrayList;
+
+import org.eclipse.paho.mqttv5.client.MqttActionListener;
+import org.eclipse.paho.mqttv5.client.MqttConnectionOptions;
+import org.eclipse.paho.mqttv5.client.alpha.result.IMqttConnectionResult;
+import org.eclipse.paho.mqttv5.client.alpha.result.IMqttResult;
+import org.eclipse.paho.mqttv5.common.MqttException;
+import org.eclipse.paho.mqttv5.common.MqttMessage;
+import org.eclipse.paho.mqttv5.common.MqttPersistenceException;
+import org.eclipse.paho.mqttv5.common.MqttSecurityException;
+import org.eclipse.paho.mqttv5.common.MqttSubscription;
+import org.eclipse.paho.mqttv5.common.packet.UserProperty;
+
+/**
+ * Enables an application to communicate with an MQTT server using non-blocking methods.
+ * <p>
+ * It provides applications a simple programming interface to all features of the MQTT version 5
+ * specification including:
+ * </p>
+ * <ul>
+ * <li>connect
+ * <li>publish
+ * <li>subscribe
+ * <li>unsubscribe
+ * <li>disconnect
+ * </ul>
+ * <p>
+ * There are two styles of MQTT client, this one and {@link IMqttClient}.</p>
+ * <ul>
+ * <li>IMqttAsyncClient provides a set of non-blocking methods that return control to the
+ * invoking application after initial validation of parameters and state. The main processing is
+ * performed in the background so as not to block the application program's thread. This non-
+ * blocking approach is handy when the application needs to carry on processing while the
+ * MQTT action takes place. For instance connecting to an MQTT server can take time, using
+ * the non-blocking connect method allows an application to display a busy indicator while the
+ * connect action takes place in the background. Non blocking methods are particularly useful
+ * in event oriented programs and graphical programs where invoking methods that take time
+ * to complete on the the main or GUI thread can cause problems. The non-blocking interface
+ * can also be used in blocking form.</li>
+ * <li>IMqttClient provides a set of methods that block and return control to the application
+ * program once the MQTT action has completed. It is a thin layer that sits on top of the
+ * IMqttAsyncClient implementation and is provided mainly for compatibility with earlier
+ * versions of the MQTT client. In most circumstances it is recommended to use IMqttAsyncClient
+ * based clients which allow an application to mix both non-blocking and blocking calls. </li>
+ * </ul>
+ * <p>
+ * An application is not restricted to using one style if an IMqttAsyncClient based client is used
+ * as both blocking and non-blocking methods can be used in the same application. If an IMqttClient
+ * based client is used then only blocking methods are available to the application.
+ * For more details on the blocking client see {@link IMqttClient}</p>
+ *
+ * <p>There are two forms of non-blocking method:
+ * <ol>
+ *   <li>
+ *     <p>In this form a callback is registered with the promise. The callback will be
+ *     notified when the action succeeds or fails. The callback is invoked on the thread
+ *     managed by the MQTT client so it is important that processing is minimised in the
+ *     callback. If not the operation of the MQTT client will be inhibited. For example
+ *     to be notified (called back) when a connect completes:</p>
+ *     <pre>
+ *     	IMqttToken conToken;
+ *	    conToken = asyncClient.connect()
+ *          .then(p -> {
+ *                  log("Connected");
+ *                  return p;
+ *              }, p -> {
+ *                  log ("connect failed" + exception);
+ *              });
+ *      </pre>
+ *	    <p>An optional context object can be passed into the method which will then be made
+ *      available in the callback. The context is stored by the MQTT client in the token
+ *      which is then returned to the invoker. The context is also provided to the callback methods
+ *      where the context can then be accessed.
+ *     </p>
+ *   </li>
+ *   <li>
+ *     <pre>
+ *     IMqttToken token = asyncClient.method(parms)
+ *     </pre>
+ *     <p>In this form the method returns a token that can be used to track the
+ *     progress of the action (method). The method provides a getPromise()
+ *     method that represents the state of the action. Once the action is
+ *     completed the getValue() method on the promise can be used to get the
+ *     result, but more normally one of the Promise's callback methods will
+ *     be used to find out if the action completed successfully or not. For example:
+ * 	   </p>
+ *     <pre>
+ *      IMqttToken conToken;
+ *   	conToken = asyncClient.client.connect(conToken);
+ *     ... do some work...
+ *   	conToken.getValue();
+ *     </pre>
+ *   </li>
+ *
+ *   <li>
+ *     <pre>
+ *     IMqttToken token method(parms, Object userContext, IMqttActionListener callback)
+ *     </pre>
+ *   </li>
+ * </ol>
+ *   <p>To understand when the delivery of a message is complete either of the two methods above
+ *   can be used to either wait on or be notified when the publish completes.</p>
+ *
+ */
+public interface IMqttAsyncClient extends IMqttCommonClient {
+	/**
+	 * Connects to an MQTT server using the default options.
+	 * <p>The default options are specified in {@link MqttConnectionOptions} class.
+	 * </p>
+	 *
+	 * @throws MqttSecurityException  for security related problems
+	 * @throws MqttException  for non security related problems
+	 * @return token used to track and wait for the connect to complete.
+	 * @see #connect(MqttConnectionOptions, Object)
+	 */
+	public IMqttToken<IMqttConnectionResult<Void>, Void> connect() throws MqttException, MqttSecurityException;
+
+	/**
+	 * Connects to an MQTT server using the provided connect options.
+	 * <p>The connection will be established using the options specified in the
+	 * {@link MqttConnectionOptions} parameter.
+	 * </p>
+	 *
+	 * @param options a set of connection parameters that override the defaults.
+	 * @throws MqttSecurityException  for security related problems
+	 * @throws MqttException  for non security related problems
+	 * @return token used to track and wait for the connect to complete.
+	 * @see #connect(MqttConnectionOptions, Object)
+	 */
+	public IMqttToken<IMqttConnectionResult<Void>, Void> connect(MqttConnectionOptions options) throws MqttException, MqttSecurityException ;
+	/**
+	 * Connects to an MQTT server using the default options.
+	 * <p>The default options are specified in {@link MqttConnectionOptions} class.
+	 * </p>
+	 *
+	 * @param userContext optional object used to pass context to the callback. Use
+	 * null if not required.
+	 * @throws MqttSecurityException  for security related problems
+	 * @throws MqttException  for non security related problems
+	 * @return token used to track and wait for the connect to complete.
+	 * @see #connect(MqttConnectionOptions, Object)
+	 */
+	public <C> IMqttToken<IMqttConnectionResult<C>, C> connect(C userContext) throws MqttException, MqttSecurityException;
+
+
+	/**
+	 * Connects to an MQTT server using the specified options.
+	 * <p>The server to connect to is specified on the constructor.
+	 * </p>
+	 * <p>The method returns control before the connect completes. Completion can
+	 * be tracked by:
+	 * </p>
+	 * <ul>
+	 * <li>Registering a callback with the Promise returned by the token {@link IMqttToken#getPromise()} or</li>
+	 * <li>Waiting on the Promise returned by the token {@link IMqttToken#getPromise()}</li>
+	 * </ul>
+	 *
+	 * @param options a set of connection parameters that override the defaults.
+	 * @param userContext optional object for used to pass context to the callback. Use
+	 * null if not required.
+	 * @return token used to track and wait for the connect to complete.
+	 * @throws MqttSecurityException  for security related problems
+	 * @throws MqttException  for non security related problems including communication errors
+	 */
+	public <C> IMqttToken<IMqttConnectionResult<C>, C> connect(MqttConnectionOptions options, C userContext) throws MqttException, MqttSecurityException;
+
+	/**
+	 * Disconnects from the server.
+	 * <p>An attempt is made to quiesce the client allowing outstanding
+	 * work to complete before disconnecting. It will wait
+	 * for a maximum of 30 seconds for work to quiesce before disconnecting.
+ 	 * This method must not be called from inside callback methods.
+ 	 * </p>
+ 	 *
+	 * @return token used to track and wait for disconnect to complete
+	 * @throws MqttException for problems encountered while disconnecting
+	 * @see #disconnect(long, Object, Integer, String, ArrayList)
+	 */
+	public IMqttToken<IMqttResult<Void>, Void> disconnect( ) throws MqttException;
+
+	/**
+	 * Disconnects from the server.
+	 * <p>An attempt is made to quiesce the client allowing outstanding
+	 * work to complete before disconnecting. It will wait
+	 * for a maximum of the specified quiesce time  for work to complete before disconnecting.
+ 	 * This method must not be called from inside callback methods.
+ 	 * </p>
+	 * @param quiesceTimeout the amount of time in milliseconds to allow for
+	 * existing work to finish before disconnecting.  A value of zero or less
+	 * means the client will not quiesce.
+	 * @return token used to track and wait for disconnect to complete.
+	 * @throws MqttException for problems encountered while disconnecting
+	 * @see #disconnect(long, Object, Integer, String, ArrayList)
+	 */
+	public IMqttToken<IMqttResult<Void>, Void> disconnect(long quiesceTimeout) throws MqttException;
+
+	/**
+	 * Disconnects from the server.
+	 * <p>An attempt is made to quiesce the client allowing outstanding
+	 * work to complete before disconnecting. It will wait
+	 * for a maximum of 30 seconds for work to quiesce before disconnecting.
+ 	 * This method must not be called from inside callback methods.
+ 	 * </p>
+ 	 *
+ 	 * @param userContext optional object used to pass context to the callback. Use
+	 * null if not required.
+	 * @return token used to track and wait for the disconnect to complete.
+	 * @throws MqttException for problems encountered while disconnecting
+	 * @see #disconnect(long, Object, MqttActionListener, Integer, String, ArrayList)
+
+	 */
+	public <C> IMqttToken<IMqttResult<C>, C> disconnect( C userContext) throws MqttException;
+
+	/**
+	 * Disconnects from the server.
+	 * <p>
+	 * The client will wait for callback methods to
+	 * complete. It will then wait for up to the quiesce timeout to allow for
+	 * work which has already been initiated to complete. For instance when a QoS 2
+	 * message has started flowing to the server but the QoS 2 flow has not completed.It
+	 * prevents new messages being accepted and does not send any messages that have
+	 * been accepted but not yet started delivery across the network to the server. When
+	 * work has completed or after the quiesce timeout, the client will disconnect from
+	 * the server. If the cleanSession flag was set to false and is set to false the
+	 * next time a connection is made QoS 1 and 2 messages that
+	 * were not previously delivered will be delivered.</p>
+	 * <p>This method must not be called from inside callback methods.</p>
+	 * <p>The method returns control before the disconnect completes. Completion can
+	 * be tracked by:
+	 * </p>
+	 * <ul>
+	 * <li>Registering a callback with the Promise returned by the token {@link IMqttToken#getPromise()} or</li>
+	 * <li>Waiting on the Promise returned by the token {@link IMqttToken#getPromise()}</li>
+	 * </ul>
+	 *
+	 * @param quiesceTimeout the amount of time in milliseconds to allow for
+	 * existing work to finish before disconnecting.  A value of zero or less
+	 * means the client will not quiesce.
+ 	 * @param userContext optional object used to pass context to the callback. Use
+	 * null if not required.
+	 * @param sessionExpiryInterval optional property to be sent in the disconnect packet to the server. Use null if not required.
+	 * @param reasonString optional property to be sent in the disconnect packet to the server. Use null if not required.
+	 * @param userDefinedProperties {@link ArrayList} of {@link UserProperty} to be sent to the server. Use null if not required.
+	 * @return token used to track and wait for the connect to complete. The token
+	 * will be passed to any callback that has been set.
+	 * @throws MqttException for problems encountered while disconnecting
+	 */
+	public <C> IMqttToken<IMqttResult<C>, C> disconnect(long quiesceTimeout, C userContext, Integer sessionExpiryInterval, String reasonString, ArrayList<UserProperty> userDefinedProperties) throws MqttException;
+	
+	/**
+	 * Disconnects from the server forcibly to reset all the states. Could be useful when disconnect attempt failed.
+	 * <p>
+	 * Because the client is able to establish the TCP/IP connection to a none MQTT server and it will certainly fail to
+	 * send the disconnect packet. It will wait for a maximum of 30 seconds for work to quiesce before disconnecting and
+	 * wait for a maximum of 10 seconds for sending the disconnect packet to server.
+	 * 
+	 * @throws MqttException if any unexpected error
+	 * @since 0.4.1
+	 */
+	public void disconnectForcibly() throws MqttException;
+	
+	/**
+	 * Disconnects from the server forcibly to reset all the states. Could be useful when disconnect attempt failed.
+	 * <p>
+	 * Because the client is able to establish the TCP/IP connection to a none MQTT server and it will certainly fail to
+	 * send the disconnect packet. It will wait for a maximum of 30 seconds for work to quiesce before disconnecting.
+	 * 
+	 * @param disconnectTimeout the amount of time in milliseconds to allow send disconnect packet to server.
+	 * @throws MqttException if any unexpected error
+	 * @since 0.4.1
+	 */
+	public void disconnectForcibly(long disconnectTimeout) throws MqttException;
+	
+	/**
+	 * Disconnects from the server forcibly to reset all the states. Could be useful when disconnect attempt failed.
+	 * <p>
+	 * Because the client is able to establish the TCP/IP connection to a none MQTT server and it will certainly fail to
+	 * send the disconnect packet.
+	 * 
+	 * @param quiesceTimeout the amount of time in milliseconds to allow for existing work to finish before
+	 * disconnecting. A value of zero or less means the client will not quiesce.
+	 * @param disconnectTimeout the amount of time in milliseconds to allow send disconnect packet to server.
+	 * @throws MqttException if any unexpected error
+	 * @since 0.4.1
+	 */
+	public void disconnectForcibly(long quiesceTimeout, long disconnectTimeout) throws MqttException;
+
+	/**
+	 * Publishes a message to a topic on the server.
+	 * <p>A convenience method, which will
+	 * create a new {@link MqttMessage} object with a byte array payload and the
+	 * specified QoS, and then publish it.
+	 * </p>
+	 *
+	 * @param topic to deliver the message to, for example "finance/stock/ibm".
+	 * @param payload the byte array to use as the payload
+	 * @param qos the Quality of Service to deliver the message at. Valid values are 0, 1 or 2.
+	 * @param retained whether or not this message should be retained by the server.
+	 * @return token used to track and wait for the publish to complete. 
+	 * @throws MqttPersistenceException when a problem occurs storing the message
+	 * @throws IllegalArgumentException if value of QoS is not 0, 1 or 2.
+	 * @throws MqttException for other errors encountered while publishing the message.
+	 * For instance if too many messages are being processed.
+	 * @see #publish(String, MqttMessage, Object)
+	 * @see MqttMessage#setQos(int)
+	 * @see MqttMessage#setRetained(boolean)
+	 */
+	public IMqttDeliveryToken<Void> publish(String topic, byte[] payload, int qos,
+			boolean retained ) throws MqttException, MqttPersistenceException;
+
+	/**
+	 * Publishes a message to a topic on the server.
+ 	 * <p>A convenience method, which will
+	 * create a new {@link MqttMessage} object with a byte array payload and the
+	 * specified QoS, and then publish it.
+	 * </p>
+	 *
+	 * @param topic  to deliver the message to, for example "finance/stock/ibm".
+	 * @param payload the byte array to use as the payload
+	 * @param qos the Quality of Service to deliver the message at.  Valid values are 0, 1 or 2.
+	 * @param retained whether or not this message should be retained by the server.
+	 * @param userContext optional object used to pass context to the callback. Use
+	 * null if not required.
+	 * @return token used to track and wait for the publish to complete. 
+	 * @throws MqttPersistenceException when a problem occurs storing the message
+	 * @throws IllegalArgumentException if value of QoS is not 0, 1 or 2.
+	 * @throws MqttException for other errors encountered while publishing the message.
+	 * For instance client not connected.
+	 * @see #publish(String, MqttMessage, Object)
+	 * @see MqttMessage#setQos(int)
+	 * @see MqttMessage#setRetained(boolean)
+	 */
+	public <C> IMqttDeliveryToken<C> publish(String topic, byte[] payload, int qos,
+			boolean retained, C userContext ) throws MqttException, MqttPersistenceException;
+
+	/**
+	 * Publishes a message to a topic on the server.
+	 * Takes an {@link MqttMessage} message and delivers it to the server at the
+	 * requested quality of service.
+	 *
+	 * @param topic  to deliver the message to, for example "finance/stock/ibm".
+	 * @param message to deliver to the server
+	 * @return token used to track and wait for the publish to complete. The token
+	 * will be passed to any callback that has been set.
+	 * @throws MqttPersistenceException when a problem occurs storing the message
+	 * @throws IllegalArgumentException if value of QoS is not 0, 1 or 2.
+	 * @throws MqttException for other errors encountered while publishing the message.
+	 * For instance client not connected.
+	 * @see #publish(String, MqttMessage, Object)
+	 */
+	public IMqttDeliveryToken<Void> publish(String topic, IMqttMessage message ) throws MqttException, MqttPersistenceException;
+
+	/**
+	 * Publishes a message to a topic on the server.
+	 * <p>
+	 * Once this method has returned cleanly, the message has been accepted for publication by the
+	 * client and will be delivered on a background thread.
+	 * In the event the connection fails or the client stops. Messages will be delivered to the
+	 * requested quality of service once the connection is re-established to the server on condition that:
+	 * </p>
+	 * <ul>
+	 * <li>The connection is re-established with the same clientID
+	 * <li>The original connection was made with (@link MqttConnectOptions#setCleanSession(boolean)}
+	 * set to false
+	 * <li>The connection is re-established with (@link MqttConnectOptions#setCleanSession(boolean)}
+	 * set to false
+	 * <li>Depending when the failure occurs QoS 0 messages may not be delivered.
+	 * </ul>
+	 *
+	 * <p>When building an application,
+	 * the design of the topic tree should take into account the following principles
+	 * of topic name syntax and semantics:</p>
+	 *
+	 * <ul>
+	 * 	<li>A topic must be at least one character long.</li>
+	 * 	<li>Topic names are case sensitive.  For example, <em>ACCOUNTS</em> and <em>Accounts</em> are
+	 * 	two different topics.</li>
+	 * 	<li>Topic names can include the space character.  For example, <em>Accounts
+	 * 	payable</em> is a valid topic.</li>
+	 * 	<li>A leading "/" creates a distinct topic.  For example, <em>/finance</em> is
+	 * 	different from <em>finance</em>. <em>/finance</em> matches "+/+" and "/+", but
+	 * 	not "+".</li>
+	 * 	<li>Do not include the null character (Unicode <pre>\x0000</pre>) in
+	 * 	any topic.</li>
+	 * </ul>
+	 *
+	 * <p>The following principles apply to the construction and content of a topic
+	 * tree:</p>
+	 * <ul>
+	 * 	<li>The length is limited to 64k but within that there are no limits to the
+	 * 	number of levels in a topic tree.</li>
+	 * 	<li>There can be any number of root nodes; that is, there can be any number
+	 * 	of topic trees.</li>
+	 * 	</ul>
+	 * 
+	 * <p>The method returns control before the publish completes. Completion can
+	 * be tracked by:
+	 * </p>
+	 * <ul>
+	 * <li>Registering a callback with the Promise returned by the token {@link IMqttToken#getPromise()} or</li>
+	 * <li>Waiting on the Promise returned by the token {@link IMqttToken#getPromise()}</li>
+	 * </ul>
+	 *
+	 * @param topic  to deliver the message to, for example "finance/stock/ibm".
+	 * @param message to deliver to the server
+	 * @param userContext optional object used to pass context to the callback. Use
+	 * null if not required.
+	 * @return token used to track and wait for the publish to complete.
+ 	 * @throws MqttPersistenceException when a problem occurs storing the message
+	 * @throws IllegalArgumentException if value of QoS is not 0, 1 or 2.
+	 * @throws MqttException for other errors encountered while publishing the message.
+	 * For instance client not connected.
+	 * @see MqttMessage
+	 */
+	public <C> IMqttDeliveryToken<C> publish(String topic, IMqttMessage message,
+			C userContext) throws MqttException, MqttPersistenceException;
+
+	/**
+	 * Subscribe to a topic, which may include wildcards.
+	 *
+	 * @see #subscribe(String[], int[], Object)
+	 *
+	 * @param topicFilter the topic to subscribe to, which can include wildcards.
+	 * @param qos the maximum quality of service at which to subscribe. Messages
+	 * published at a lower quality of service will be received at the published
+	 * QoS.  Messages published at a higher quality of service will be received using
+	 * the QoS specified on the subscribe.
+	 * @return token used to track and wait for the subscribe to complete. The token
+	 * will be passed to callback methods if set.
+	 * @throws MqttException if there was an error registering the subscription.
+	 */
+	public IMqttSubscriptionToken<Void> subscribe(String topicFilter, int qos) throws MqttException;
+
+	/**
+	 * Subscribe to a topic, which may include wildcards.
+	 *
+	 * @see #subscribe(String[], int[], Object, MqttActionListener) throws MqttException
+	 *
+	 * @param topicFilter the topic to subscribe to, which can include wildcards.
+	 * @param qos the maximum quality of service at which to subscribe. Messages
+	 * published at a lower quality of service will be received at the published
+	 * QoS.  Messages published at a higher quality of service will be received using
+	 * the QoS specified on the subscribe.
+	 * @param userContext optional object used to pass context to the callback. Use
+	 * null if not required.
+	 * @param callback optional listener that will be notified when subscribe
+	 * has completed
+	 * @return token used to track and wait for the subscribe to complete. The token
+	 * will be passed to callback methods if set.
+	 * @throws MqttException if there was an error registering the subscription.
+	 */
+	public <C> IMqttSubscriptionToken<C> subscribe(String topicFilter, int qos, C userContext)
+	throws MqttException;
+
+	/**
+	 * Subscribe to multiple topics, each of which may include wildcards.
+	 *
+	 * <p>Provides an optimized way to subscribe to multiple topics compared to
+	 * subscribing to each one individually.</p>
+	 *
+	 * @see #subscribe(String[], int[], Object)
+	 *
+	 * @param topicFilters one or more topics to subscribe to, which can include wildcards
+	 * @param qos the maximum quality of service at which to subscribe. Messages
+	 * published at a lower quality of service will be received at the published
+	 * QoS.  Messages published at a higher quality of service will be received using
+	 * the QoS specified on the subscribe.
+	 * @return token used to track and wait for the subscribe to complete. The token
+	 * will be passed to callback methods if set.
+	 * @throws MqttException if there was an error registering the subscription.
+	 */
+	public IMqttSubscriptionToken<Void> subscribe(MqttSubscription[] subscriptions) throws MqttException;
+
+	/**
+	 * Subscribes to multiple topics, each of which may include wildcards.
+ 	 * <p>Provides an optimized way to subscribe to multiple topics compared to
+	 * subscribing to each one individually.</p>
+	 * <p>
+	 * If (@link MqttConnectOptions#setCleanSession(boolean)} was set to true
+	 * when when connecting to the server then the subscription remains in place
+	 * until either:</p>
+	 * 
+	 * <ul>
+	 * <li>The client disconnects</li>
+	 * <li>The stream returned by {@link IMqttSubscriptionToken#getStream()} is closed</li>
+	 * <li>Any part of the stream pipeline returns negative backpressure to close the stream</li>
+	 * </ul>
+	 * 
+	 * <p>
+	 * If (@link MqttConnectOptions#setCleanSession(boolean)} was set to false
+	 * when connecting to the server then the subscription remains in place
+	 * until either:</p>
+	 * <ul>
+	 * <li>The stream returned by {@link IMqttSubscriptionToken#getStream()} is closed</li>
+	 * <li>Any part of the stream pipeline returns negative backpressure to close the stream</li>
+	 * <li>The next time the client connects with cleanSession set to true</li>
+	 * </ul>
+	 * <p>
+	 * With cleanSession set to false the MQTT server will store messages on
+	 * behalf of the client when the client is not connected. The next time the
+	 * client connects with the <b>same client ID</b> the server will
+	 * deliver the stored messages to the client.
+	 * </p>
+	 *
+	 * <p>The "topic filter" string used when subscribing
+	 * may contain special characters, which allow you to subscribe to multiple topics
+	 * at once.</p>
+	 * <p>The topic level separator is used to introduce structure into the topic, and
+	 * can therefore be specified within the topic for that purpose.  The multi-level
+	 * wildcard and single-level wildcard can be used for subscriptions, but they
+	 * cannot be used within a topic by the publisher of a message.
+	 * <dl>
+	 * 	<dt>Topic level separator</dt>
+	 * 	<dd>The forward slash (/) is used to separate each level within
+	 * 	a topic tree and provide a hierarchical structure to the topic space. The
+	 * 	use of the topic level separator is significant when the two wildcard characters
+	 * 	are encountered in topics specified by subscribers.</dd>
+	 *
+	 * 	<dt>Multi-level wildcard</dt>
+	 * 	<dd><p>The number sign (#) is a wildcard character that matches
+	 * 	any number of levels within a topic. For example, if you subscribe to
+	 *  <span><span class="filepath">finance/stock/ibm/#</span></span>, you receive
+	 * 	messages on these topics:</p>
+	 *  <ul>
+	 *  <li>finance/stock/ibm</li>
+	 *  <li>finance/stock/ibm/closingprice</li>
+	 *  <li>finance/stock/ibm/currentprice</li>
+	 *  </ul>
+	 *  <p>The multi-level wildcard
+	 *  can represent zero or more levels. Therefore, <em>finance/#</em> can also match
+	 * 	the singular <em>finance</em>, where <em>#</em> represents zero levels. The topic
+	 * 	level separator is meaningless in this context, because there are no levels
+	 * 	to separate.</p>
+	 *
+	 * 	<p>The <span>multi-level</span> wildcard can
+	 * 	be specified only on its own or next to the topic level separator character.
+	 * 	Therefore, <em>#</em> and <em>finance/#</em> are both valid, but <em>finance#</em> is
+	 * 	not valid. <span>The multi-level wildcard must be the last character
+	 *  used within the topic tree. For example, <em>finance/#</em> is valid but
+	 *  <em>finance/#/closingprice</em> is 	not valid.</span></p></dd>
+	 *
+	 * 	<dt>Single-level wildcard</dt>
+	 * 	<dd><p>The plus sign (+) is a wildcard character that matches only one topic
+	 * 	level. For example, <em>finance/stock/+</em> matches
+	 * <em>finance/stock/ibm</em> and <em>finance/stock/xyz</em>,
+	 * 	but not <em>finance/stock/ibm/closingprice</em>. Also, because the single-level
+	 * 	wildcard matches only a single level, <em>finance/+</em> does not match <em>finance</em>.</p>
+	 *
+	 * 	<p>Use
+	 * 	the single-level wildcard at any level in the topic tree, and in conjunction
+	 * 	with the multilevel wildcard. Specify the single-level wildcard next to the
+	 * 	topic level separator, except when it is specified on its own. Therefore,
+	 *  <em>+</em> and <em>finance/+</em> are both valid, but <em>finance+</em> is
+	 *  not valid. <span>The single-level wildcard can be used at the end of the
+	 *  topic tree or within the topic tree.
+	 * 	For example, <em>finance/+</em> and <em>finance/+/ibm</em> are both valid.</span></p>
+	 * 	</dd>
+	 * </dl>
+	 * <p>The method returns control without beginning the subscribe operation. The
+	 * subscribe operation only begins when a terminal operation is called on the
+	 * stream associated with the subscription. Completion can
+	 * be tracked by:</p>
+	 * <ul>
+	 * <li>Registering a callback with the Promise returned by the token {@link IMqttToken#getPromise()} or</li>
+	 * <li>Waiting on the Promise returned by the token {@link IMqttToken#getPromise()}</li>
+	 * </ul>
+	 *
+	 * @param topicFilters one or more topics to subscribe to, which can include wildcards
+	 * @param qos the maximum quality of service to subscribe each topic at.Messages
+	 * published at a lower quality of service will be received at the published
+	 * QoS.  Messages published at a higher quality of service will be received using
+	 * the QoS specified on the subscribe.
+	 * @param userContext optional object used to pass context to the callback. Use
+	 * null if not required.
+	 * @return token used to track and wait for the subscribe to complete. 
+	 * @throws MqttException if there was an error registering the subscription.
+	 * @throws IllegalArgumentException if the two supplied arrays are not the same size.
+	 */
+	public <C> IMqttSubscriptionToken<C> subscribe(MqttSubscription[] subscriptions, C userContext)
+			throws MqttException;
+	
+	/**
+	 * Subscribe to a topic, which may include wildcards.
+	 *
+	 * @see #subscribe(String[], int[], Object)
+	 *
+	 * @param topicFilter the topic to subscribe to, which can include wildcards.
+	 * @param qos the maximum quality of service at which to subscribe. Messages
+	 * published at a lower quality of service will be received at the published
+	 * QoS.  Messages published at a higher quality of service will be received using
+	 * the QoS specified on the subscribe.
+	 * @param userContext optional object used to pass context to the callback. Use
+	 * null if not required.
+	 * @return token used to track and wait for the subscribe to complete. The token
+	 * will be passed to callback methods if set.
+	 * @throws MqttException if there was an error registering the subscription.
+	 */
+	public <C> IMqttSubscriptionToken<C> subscribe(MqttSubscription subscription, C userContext) throws MqttException;
+
+
+	/**
+	 * Subscribe to a topic, which may include wildcards.
+	 *
+	 * @see #subscribe(String[], int[], Object)
+	 *
+	 * @param topicFilter the topic to subscribe to, which can include wildcards.
+	 * @param qos the maximum quality of service at which to subscribe. Messages
+	 * published at a lower quality of service will be received at the published
+	 * QoS.  Messages published at a higher quality of service will be received using
+	 * the QoS specified on the subscribe.
+	 * @return token used to track and wait for the subscribe to complete. The token
+	 * will be passed to callback methods if set.
+	 * @throws MqttException if there was an error registering the subscription.
+	 */
+	public IMqttSubscriptionToken<Void> subscribe(MqttSubscription subscription) throws MqttException;
+
+}

--- a/org.eclipse.paho.mqttv5.client/src/main/java/org/eclipse/paho/mqttv5/client/alpha/IMqttClient.java
+++ b/org.eclipse.paho.mqttv5.client/src/main/java/org/eclipse/paho/mqttv5/client/alpha/IMqttClient.java
@@ -1,0 +1,302 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2015 IBM Corp.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution. 
+ *
+ * The Eclipse Public License is available at 
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at 
+ *   http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * Contributors:
+ *    Dave Locke - initial API and implementation and/or initial documentation
+ *    Ian Craggs - MQTT 3.1.1 support
+ *    Ian Craggs - per subscription message handlers (bug 466579)
+ *    Ian Craggs - ack control (bug 472172)
+ */
+
+package org.eclipse.paho.mqttv5.client.alpha;
+
+import org.eclipse.paho.mqttv5.client.MqttConnectionOptions;
+import org.eclipse.paho.mqttv5.client.alpha.result.IMqttConnectionResult;
+import org.eclipse.paho.mqttv5.common.MqttException;
+import org.eclipse.paho.mqttv5.common.MqttSecurityException;
+
+/**
+ * Enables an application to communicate with an MQTT server using blocking methods.
+ * <p>
+ * This interface allows applications to utilize all features of the MQTT version 3.1
+ * specification including:</p>
+ * <ul>
+ * <li>connect
+ * <li>publish
+ * <li>subscribe
+ * <li>unsubscribe
+ * <li>disconnect
+ * </ul>
+ * <p>
+ * There are two styles of MQTT client, this one and {@link IMqttAsyncClient}.</p>
+ * <ul>
+ * <li>IMqttClient provides a set of methods that block and return control to the application
+ * program once the MQTT action has completed.</li>
+ * <li>IMqttAsyncClient provides a set of non-blocking methods that return control to the
+ * invoking application after initial validation of parameters and state. The main processing is
+ * performed in the background so as not to block the application programs thread. This non
+ * blocking approach is handy when the application wants to carry on processing while the
+ * MQTT action takes place. For instance connecting to an MQTT server can take time, using
+ * the non-blocking connect method allows an application to display a busy indicator while the
+ * connect action is occurring. Non-blocking methods are particularly useful in event-oriented
+ * programs and graphical programs where issuing methods that take time to complete on the the
+ * main or GUI thread can cause problems.</li>
+ * </ul>
+ * <p>
+ * The non-blocking client can also be used in a blocking form by turning a non-blocking
+ * method into a blocking invocation using the following pattern:</p>
+ *     <pre>
+ *     IMqttToken token;
+ *     token = asyncClient.method(parms).getPromise().getValue();
+ *     </pre>
+ * <p>
+ * Using the non-blocking client allows an application to use a mixture of blocking and
+ * non-blocking styles. Using the blocking client only allows an application to use one
+ * style. The blocking client provides compatibility with earlier versions
+ * of the MQTT client.</p>
+ */
+public interface IMqttClient extends IMqttCommonClient {
+	/**
+	 * Connects to an MQTT server using the default options.
+	 * <p>The default options are specified in {@link MqttConnectionOptions} class.
+	 * </p>
+	 *
+	 * @throws MqttSecurityException when the server rejects the connect for security
+	 * reasons
+	 * @throws MqttException  for non security related problems
+	 * @see #connect(MqttConnectionOptions)
+	 */
+  public void connect() throws MqttSecurityException, MqttException;
+
+	/**
+	 * Connects to an MQTT server using the specified options.
+	 * 
+	 * <p>This is a blocking method that returns once connect completes</p>
+	 *
+	 * @param options a set of connection parameters that override the defaults.
+	 * @throws MqttSecurityException when the server rejects the connect for security
+	 * reasons
+	 * @throws MqttException  for non security related problems including communication errors
+	 */
+  public void connect(MqttConnectionOptions options) throws MqttSecurityException, MqttException;
+  
+	/**
+	 * Connects to an MQTT server using the specified options.
+	 *
+	 * <p>This is a blocking method that returns once connect completes</p>
+	 *
+	 * @param options a set of connection parameters that override the defaults.
+	 * @return the MqttToken used for the call.  Can be used to obtain the session present flag
+	 * @throws MqttSecurityException when the server rejects the connect for security
+	 * reasons
+	 * @throws MqttException  for non security related problems including communication errors
+	 */
+public IMqttConnectionResult<Void> connectWithResult(MqttConnectionOptions options) throws MqttSecurityException, MqttException;
+
+	/**
+	 * Disconnects from the server.
+	 *
+	 * <p>This is a blocking method that returns once disconnect completes</p>
+	 *
+	 * @throws MqttException if a problem is encountered while disconnecting
+	 */
+  public void disconnect() throws MqttException;
+
+	/**
+	 * Disconnects from the server.
+	 * <p>
+	 * The client will wait for all callback methods to
+	 * complete. It will then wait for up to the quiesce timeout to allow for
+	 * work which has already been initiated to complete - for example, it will
+	 * wait for the QoS 2 flows from earlier publications to complete. When work has
+	 * completed or after the quiesce timeout, the client will disconnect from
+	 * the server. If the cleanSession flag was set to false and is set to false the
+	 * next time a connection is made QoS 1 and 2 messages that
+	 * were not previously delivered will be delivered.</p>
+	 *
+	 * <p>This is a blocking method that returns once disconnect completes</p>
+	 *
+	 * @param quiesceTimeout the amount of time in milliseconds to allow for
+	 * existing work to finish before disconnecting.  A value of zero or less
+	 * means the client will not quiesce.
+	 * @throws MqttException if a problem is encountered while disconnecting
+	 */
+  public void disconnect(long quiesceTimeout) throws MqttException;
+  
+  /**
+	 * Disconnects from the server forcibly to reset all the states. Could be useful when disconnect attempt failed.
+	 * <p>
+	 * Because the client is able to establish the TCP/IP connection to a none MQTT server and it will certainly fail to
+	 * send the disconnect packet. It will wait for a maximum of 30 seconds for work to quiesce before disconnecting and
+	 * wait for a maximum of 10 seconds for sending the disconnect packet to server.
+	 * 
+	 * @throws MqttException if any unexpected error
+	 * @since 0.4.1
+	 */
+	public void disconnectForcibly() throws MqttException;
+	
+	/**
+	 * Disconnects from the server forcibly to reset all the states. Could be useful when disconnect attempt failed.
+	 * <p>
+	 * Because the client is able to establish the TCP/IP connection to a none MQTT server and it will certainly fail to
+	 * send the disconnect packet. It will wait for a maximum of 30 seconds for work to quiesce before disconnecting.
+	 * 
+	 * @param disconnectTimeout the amount of time in milliseconds to allow send disconnect packet to server.
+	 * @throws MqttException if any unexpected error
+	 * @since 0.4.1
+	 */
+	public void disconnectForcibly(long disconnectTimeout) throws MqttException;
+	
+	/**
+	 * Disconnects from the server forcibly to reset all the states. Could be useful when disconnect attempt failed.
+	 * <p>
+	 * Because the client is able to establish the TCP/IP connection to a none MQTT server and it will certainly fail to
+	 * send the disconnect packet.
+	 * 
+	 * @param quiesceTimeout the amount of time in milliseconds to allow for existing work to finish before
+	 * disconnecting. A value of zero or less means the client will not quiesce.
+	 * @param disconnectTimeout the amount of time in milliseconds to allow send disconnect packet to server.
+	 * @throws MqttException if any unexpected error
+	 * @since 0.4.1
+	 */
+	public void disconnectForcibly(long quiesceTimeout, long disconnectTimeout) throws MqttException;
+
+	/**
+	 * Subscribe to a topic, which may include wildcards using a QoS of 1.
+	 *
+	 * @see #subscribe(String[], int[])
+	 *
+	 * @param topicFilter the topic to subscribe to, which can include wildcards.
+	 * @throws MqttException if there was an error registering the subscription.
+	 * @throws MqttSecurityException if the client is not authorized to register the subscription
+	 */
+  public IMqttSubscriptionToken<Void> subscribe(String topicFilter) throws MqttException, MqttSecurityException;
+
+	/**
+	 * Subscribes to a one or more topics, which may include wildcards using a QoS of 1.
+	 *
+	 * @see #subscribe(String[], int[])
+	 *
+	 * @param topicFilters the topic to subscribe to, which can include wildcards.
+	 * @throws MqttException if there was an error registering the subscription.
+	 */
+  public IMqttSubscriptionToken<Void> subscribe(String[] topicFilters) throws MqttException;
+
+	/**
+	 * Subscribe to a topic, which may include wildcards.
+	 *
+	 * @see #subscribe(String[], int[])
+	 *
+	 * @param topicFilter the topic to subscribe to, which can include wildcards.
+	 * @param qos the maximum quality of service at which to subscribe. Messages
+	 * published at a lower quality of service will be received at the published
+	 * QoS.  Messages published at a higher quality of service will be received using
+	 * the QoS specified on the subscribe.
+	 * @throws MqttException if there was an error registering the subscription.
+	 */
+  public IMqttSubscriptionToken<Void> subscribe(String topicFilter, int qos) throws MqttException;
+
+	/**
+	 * Subscribes to multiple topics, each of which may include wildcards.
+	 * <p>
+	 * If (@link MqttConnectOptions#setCleanSession(boolean)} was set to true
+	 * when when connecting to the server then the subscription remains in place
+	 * until either:
+	 * </p>
+	 * <ul>
+	 * <li>The client disconnects</li>
+	 * <li>An unsubscribe method is called to un-subscribe the topic</li>
+	 * </ul>
+	 * <p>
+	 * If (@link MqttConnectOptions#setCleanSession(boolean)} was set to false
+	 * when when connecting to the server then the subscription remains in place
+	 * until either:</p>
+	 * <ul>
+	 * <li>An unsubscribe method is called to unsubscribe the topic</li>
+	 * <li>The client connects with cleanSession set to true</li>
+	 * </ul>
+	 * <p>
+	 * With cleanSession set to false the MQTT server will store messages on
+	 * behalf of the client when the client is not connected. The next time the
+	 * client connects with the <b>same client ID</b> the server will
+	 * deliver the stored messages to the client.
+	 * </p>
+	 *
+	 * <p>The "topic filter" string used when subscribing
+	 * may contain special characters, which allow you to subscribe to multiple topics
+	 * at once.</p>
+	 * <p>The topic level separator is used to introduce structure into the topic, and
+	 * can therefore be specified within the topic for that purpose.  The multi-level
+	 * wildcard and single-level wildcard can be used for subscriptions, but they
+	 * cannot be used within a topic by the publisher of a message.
+	 * <dl>
+	 * 	<dt>Topic level separator</dt>
+	 * 	<dd>The forward slash (/) is used to separate each level within
+	 * 	a topic tree and provide a hierarchical structure to the topic space. The
+	 * 	use of the topic level separator is significant when the two wildcard characters
+	 * 	are encountered in topics specified by subscribers.</dd>
+	 *
+	 * 	<dt>Multi-level wildcard</dt>
+	 * 	<dd><p>The number sign (#) is a wildcard character that matches
+	 * 	any number of levels within a topic. For example, if you subscribe to
+	 *  <span><span class="filepath">finance/stock/ibm/#</span></span>, you receive
+	 * 	messages on these topics:</p>
+	 * <ul>
+	 * <li><pre>finance/stock/ibm</pre></li>
+	 * <li><pre>finance/stock/ibm/closingprice</pre></li>
+	 * <li><pre>finance/stock/ibm/currentprice</pre></li>
+	 * </ul>
+	 *  
+	 *  <p>The multi-level wildcard
+	 *  can represent zero or more levels. Therefore, <em>finance/#</em> can also match
+	 * 	the singular <em>finance</em>, where <em>#</em> represents zero levels. The topic
+	 * 	level separator is meaningless in this context, because there are no levels
+	 * 	to separate.</p>
+	 *
+	 * 	<p>The <span>multi-level</span> wildcard can
+	 * 	be specified only on its own or next to the topic level separator character.
+	 * 	Therefore, <em>#</em> and <em>finance/#</em> are both valid, but <em>finance#</em> is
+	 * 	not valid. <span>The multi-level wildcard must be the last character
+	 *  used within the topic tree. For example, <em>finance/#</em> is valid but
+	 *  <em>finance/#/closingprice</em> is 	not valid.</span></p></dd>
+	 *
+	 * 	<dt>Single-level wildcard</dt>
+	 * 	<dd><p>The plus sign (+) is a wildcard character that matches only one topic
+	 * 	level. For example, <em>finance/stock/+</em> matches
+	 * <em>finance/stock/ibm</em> and <em>finance/stock/xyz</em>,
+	 * 	but not <em>finance/stock/ibm/closingprice</em>. Also, because the single-level
+	 * 	wildcard matches only a single level, <em>finance/+</em> does not match <em>finance</em>.</p>
+	 *
+	 * 	<p>Use
+	 * 	the single-level wildcard at any level in the topic tree, and in conjunction
+	 * 	with the multilevel wildcard. Specify the single-level wildcard next to the
+	 * 	topic level separator, except when it is specified on its own. Therefore,
+	 *  <em>+</em> and <em>finance/+</em> are both valid, but <em>finance+</em> is
+	 *  not valid. <span>The single-level wildcard can be used at the end of the
+	 *  topic tree or within the topic tree.
+	 * 	For example, <em>finance/+</em> and <em>finance/+/ibm</em> are both valid.</span></p>
+	 * 	</dd>
+	 * </dl>
+	 *
+	 * <p>This is a blocking method that returns once subscribe completes</p>
+	 *
+	 * @param topicFilters one or more topics to subscribe to, which can include wildcards.
+	 * @param qos the maximum quality of service to subscribe each topic at.Messages
+	 * published at a lower quality of service will be received at the published
+	 * QoS.  Messages published at a higher quality of service will be received using
+	 * the QoS specified on the subscribe.
+	 * @throws MqttException if there was an error registering the subscription.
+	 * @throws IllegalArgumentException if the two supplied arrays are not the same size.
+	 */
+  public IMqttSubscriptionToken<Void> subscribe(String[] topicFilters, int[] qos) throws MqttException;
+
+}

--- a/org.eclipse.paho.mqttv5.client/src/main/java/org/eclipse/paho/mqttv5/client/alpha/IMqttCommonClient.java
+++ b/org.eclipse.paho.mqttv5.client/src/main/java/org/eclipse/paho/mqttv5/client/alpha/IMqttCommonClient.java
@@ -1,0 +1,101 @@
+package org.eclipse.paho.mqttv5.client.alpha;
+
+import org.eclipse.paho.mqttv5.client.MqttAsyncClient;
+import org.eclipse.paho.mqttv5.common.MqttException;
+
+public interface IMqttCommonClient {
+	/**
+	 * Determines if this client is currently connected to the server.
+	 *
+	 * @return <code>true</code> if connected, <code>false</code> otherwise.
+	 */
+	public boolean isConnected();
+
+	/**
+	 * Returns the client ID used by this client.
+	 * <p>All clients connected to the
+	 * same server or server farm must have a unique ID.
+	 * </p>
+	 *
+	 * @return the client ID used by this client.
+	 */
+	public String getClientId();
+
+	/**
+	 * Returns the address of the server used by this client, as a URI.
+	 * <p>The format is the same as specified on the constructor.
+	 * </p>
+	 *
+	 * @return the server's address, as a URI String.
+	 * @see MqttAsyncClient#MqttAsyncClient(String, String)
+	 */
+	public String getServerURI();
+	
+	/**
+	 * Requests the Subscriptions known to this client
+	 * 
+	 * @return The open and pending subscriptions known to this client
+	 */
+	public IMqttSubscriptionToken<?>[] getSubscribers();
+	
+	/**
+	 * Requests the Subscriptions known by this client which match the
+	 * supplied topicFilter
+	 * 
+	 * @param topicFilter the topic to search for
+	 * @return The subscriptions which use this topic filter
+	 */
+	public IMqttSubscriptionToken<?>[] getSubscribers(String topicFilter);
+	
+	/**
+	 * Requests the Subscriptions known by this client which match any
+	 * of the supplied topicFilters
+	 * 
+	 * @param topicFilter the topics to search for
+	 * @return The subscriptions which use these topic filters
+	 */
+	public IMqttSubscriptionToken<?>[] getSubscribers(String[] topicFilters);
+
+	/**
+	 * Returns the delivery tokens for any outstanding publish operations.
+	 * <p>If a client has been restarted and there are messages that were in the
+	 * process of being delivered when the client stopped this method
+	 * returns a token for each in-flight message enabling the delivery to be tracked
+	 * </p>
+	 * <p>If a client connects with cleanSession true then there will be no
+	 * delivery tokens as the cleanSession option deletes all earlier state.
+	 * For state to be remembered the client must connect with cleanSession
+	 * set to false</P>
+	 * @return zero or more delivery tokens
+	 */
+	public IMqttDeliveryToken<?>[] getPendingDeliveryTokens();
+	
+	/**
+	 * If manualAcks is set to true, then on completion of the messageArrived callback
+	 * the MQTT acknowledgements are not sent.  You must call messageArrivedComplete
+	 * to send those acknowledgements.  This allows finer control over when the acks are
+	 * sent.  The default behaviour, when manualAcks is false, is to send the MQTT
+	 * acknowledgements automatically at the successful completion of the messageArrived
+	 * callback method.
+	 * @param manualAcks if set to true MQTT acknowledgements are not sent
+	 */
+	public void setManualAcks(boolean manualAcks);
+	
+	/**
+	 * Indicate that the application has completed processing the message with id messageId.
+	 * This will cause the MQTT acknowledgement to be sent to the server.
+	 * @param messageId the MQTT message id to be acknowledged
+	 * @param qos the MQTT QoS of the message to be acknowledged
+	 * @throws MqttException if there was a problem sending the acknowledgement
+	 */
+	public void messageArrivedComplete(int messageId, int qos) throws MqttException;
+
+	/**
+	 * Close the client
+	 * Releases all resource associated with the client. After the client has
+	 * been closed it cannot be reused. For instance attempts to connect will fail.
+	 * @throws MqttException  if the client is not disconnected.
+	 */
+	public void close() throws MqttException;
+	
+}

--- a/org.eclipse.paho.mqttv5.client/src/main/java/org/eclipse/paho/mqttv5/client/alpha/IMqttDeliveryToken.java
+++ b/org.eclipse.paho.mqttv5.client/src/main/java/org/eclipse/paho/mqttv5/client/alpha/IMqttDeliveryToken.java
@@ -1,0 +1,39 @@
+package org.eclipse.paho.mqttv5.client.alpha;
+
+import org.eclipse.paho.mqttv5.client.alpha.result.IMqttDeliveryResult;
+import org.eclipse.paho.mqttv5.common.MqttException;
+
+/**
+ * Provides a mechanism for tracking the delivery of a message.
+ * 
+ * <p>A subclass of IMqttToken that allows the delivery of a message to be tracked. 
+ * Unlike instances of IMqttToken delivery tokens can be used across connection
+ * and client restarts.  This enables the delivery of a messages to be tracked 
+ * after failures.
+ * <p>A list of delivery tokens for in-flight messages can be obtained using 
+ * {@link IMqttAsyncClient#getPendingDeliveryTokens()}.  A getPromise().getValue()
+ * call can then be used to block until the delivery is complete.
+ * 
+ * <p> 
+ * An action is in progress until getPromise().isDone() returns true.
+ * If a client shuts down before delivery is complete
+ * an exception is returned.  As long as the Java Runtime is not stopped a delivery token
+ * is valid across a connection disconnect and reconnect. In the event the client 
+ * is shut down the getPendingDeliveryTokens method can be used once the client is 
+ * restarted to obtain a list of delivery tokens for inflight messages.</li>
+ * </ul>
+ * 
+ */
+
+public interface IMqttDeliveryToken<C> extends IMqttToken<IMqttDeliveryResult<C>,C> {
+	
+	/**
+	 * Returns the message associated with this token.
+	 * <p>Until the message has been delivered, the message being delivered will
+	 * be returned. Once the message has been delivered <code>null</code> will be 
+	 * returned.
+	 * @return the message associated with this token or null if already delivered.
+	 * @throws MqttException if there was a problem completing retrieving the message
+	 */
+	public IMqttMessage getMessage() throws MqttException;
+}

--- a/org.eclipse.paho.mqttv5.client/src/main/java/org/eclipse/paho/mqttv5/client/alpha/IMqttMessage.java
+++ b/org.eclipse.paho.mqttv5.client/src/main/java/org/eclipse/paho/mqttv5/client/alpha/IMqttMessage.java
@@ -1,0 +1,33 @@
+package org.eclipse.paho.mqttv5.client.alpha;
+
+import java.nio.ByteBuffer;
+
+public interface IMqttMessage {
+
+	/**
+	 * Returns the quality of service for this message.
+	 * 
+	 * @return the quality of service to use, either 0, 1, or 2.
+	 * @see #setQos(int)
+	 */
+	public int getQos();
+	
+	
+	/**
+	 * The payload of this message
+	 * @return a read only {@link ByteBuffer}
+	 */
+	public ByteBuffer payload();
+	
+	/**
+	 * Returns whether or not this message should be/was retained by the server. For
+	 * messages received from the server, this method returns whether or not the
+	 * message was from a current publisher, or was "retained" by the server as the
+	 * last message published on the topic.
+	 *
+	 * @return <code>true</code> if the message should be, or was, retained by the
+	 *         server.
+	 * @see #setRetained(boolean)
+	 */
+	public boolean isRetained();
+}

--- a/org.eclipse.paho.mqttv5.client/src/main/java/org/eclipse/paho/mqttv5/client/alpha/IMqttMessageBuilder.java
+++ b/org.eclipse.paho.mqttv5.client/src/main/java/org/eclipse/paho/mqttv5/client/alpha/IMqttMessageBuilder.java
@@ -1,0 +1,122 @@
+package org.eclipse.paho.mqttv5.client.alpha;
+
+import java.nio.ByteBuffer;
+
+import org.eclipse.paho.mqttv5.client.alpha.internal.MqttMessageImpl;
+
+public class IMqttMessageBuilder {
+
+	private ByteBuffer payload;
+	
+	private int qos = 0;
+	
+	private boolean retained = false;
+	
+	public IMqttMessageBuilder fromMessage(IMqttMessage message) {
+		payload = message.payload().asReadOnlyBuffer();
+		qos = message.getQos();
+		retained = message.isRetained();
+		return this;
+	}
+	
+	/**
+	 * Sets the payload by copying the supplied bytes
+	 * <p>
+	 * Equivalent to <code>withPayload(bytes, 0, bytes.length)</code>
+	 * 
+	 * @param bytes
+	 * @return this builder
+	 */
+	public IMqttMessageBuilder withPayload(byte[] bytes) {
+		return withPayload(bytes, 0, bytes.length);
+	}
+
+	/**
+	 * Sets the payload by copying the supplied byte range
+	 * 
+	 * @param bytes
+	 * @param pos
+	 * @param length
+	 * @return this builder
+	 */
+	public IMqttMessageBuilder withPayload(byte[] bytes, int pos, int length) {
+		ByteBuffer copy = ByteBuffer.allocate(length);
+		copy.put(bytes);
+		copy.flip();
+		payload = copy.asReadOnlyBuffer();
+		return this;
+	}
+	
+	/**
+	 * Sets the payload by copying the supplied ByteBuffer
+	 * 
+	 * @param bytes
+	 * @param pos
+	 * @param length
+	 * @return this builder
+	 */
+	public IMqttMessageBuilder withPayload(ByteBuffer buffer) {
+		ByteBuffer copy = ByteBuffer.allocate(buffer.remaining());
+		copy.put(buffer);
+		copy.flip();
+		payload = copy.asReadOnlyBuffer();
+		return this;
+	}
+	
+	/**
+	 * Sets the payload using the supplied byte array without
+	 * copying it. The caller is responsible for making sure that
+	 * the byte array is not subsequently modified
+	 * 
+	 * @param bytes
+	 * @return
+	 */
+	public IMqttMessageBuilder withSafePayload(byte[] bytes) {
+		payload = ByteBuffer.wrap(bytes).asReadOnlyBuffer();
+		return this;
+	}
+
+	/**
+	 * Sets the payload using the supplied byte array without
+	 * copying it. The caller is responsible for making sure that
+	 * the byte array is not subsequently modified
+	 * 
+	 * @param bytes
+	 * @return
+	 */
+	public IMqttMessageBuilder withSafePayload(byte[] bytes, int pos, int length) {
+		payload = ByteBuffer.wrap(bytes, pos, length).asReadOnlyBuffer();
+		return this;
+	}
+
+	/**
+	 * Sets the payload using the supplied ByteBuffer without
+	 * copying it. The caller is responsible for making sure that
+	 * the Byte Buffer is not subsequently modified
+	 * 
+	 * @param bytes
+	 * @return
+	 */
+	public IMqttMessageBuilder withSafePayload(ByteBuffer buffer) {
+		payload = buffer.asReadOnlyBuffer();
+		return this;
+	}
+	
+	public IMqttMessageBuilder withQoS(int qos) {
+		if(qos < 0 || qos > 2) {
+			throw new IllegalArgumentException("The qos must be 0, 1 or 2. " + qos + " is not valid");
+		}
+		this.qos = qos;
+		return this;
+	}
+
+	public IMqttMessageBuilder retained(boolean retained) {
+		this.retained = retained;
+		return this;
+	}
+	
+	public IMqttMessage build() {
+		return new MqttMessageImpl(qos, payload, retained);
+	}
+	
+}

--- a/org.eclipse.paho.mqttv5.client/src/main/java/org/eclipse/paho/mqttv5/client/alpha/IMqttSubscriptionToken.java
+++ b/org.eclipse.paho.mqttv5.client/src/main/java/org/eclipse/paho/mqttv5/client/alpha/IMqttSubscriptionToken.java
@@ -1,0 +1,61 @@
+package org.eclipse.paho.mqttv5.client.alpha;
+
+import java.util.List;
+
+import org.eclipse.paho.mqttv5.client.alpha.result.IMqttSubscriptionResult;
+import org.eclipse.paho.mqttv5.client.alpha.result.IMqttUnsubscriptionResult;
+import org.eclipse.paho.mqttv5.common.MqttException;
+import org.osgi.util.promise.Promise;
+import org.osgi.util.pushstream.PushStream;
+
+/**
+ * Provides a mechanism for tracking a subscription to one or more topics.
+ * 
+ * <p>A subclass of IMqttToken that allows a subscription to be tracked. 
+ * Unlike instances of IMqttToken subscription tokens can be used across connection
+ * and client restarts.  This enables the receipt of messages to continue
+ * after failures.
+ * <p>
+ * A list of subscription tokens for can be obtained using 
+ * {@link IMqttCommonClient#getSubscribers()}.</p>
+ * <p> 
+ * A subscription request is not made until a terminal operation is invoked
+ * on the {@link PushStream} returned by {@link IMqttSubscriptionToken#getStream()}.
+ * The result of this request is reflected in the promise returned by 
+ * {@link IMqttSubscriptionToken}{@link #getPromise()}.</p>
+ * 
+ * 
+ */
+
+public interface IMqttSubscriptionToken<C> extends IMqttToken<IMqttSubscriptionResult<C>,C> {
+	
+	/**
+	 * Returns the stream of messages to which this subscription is subscribed.
+	 * <p>
+	 * Initially this stream is not connected and the subscription request is
+	 * only sent once a terminal operation is called on the returned stream.
+	 * </p>
+	 * 
+	 * <p>
+	 * The subscription is automatically unsubscribed if the stream closes. This
+	 * may be as a result of negative backpressure from one of the stream pipeline
+	 * stages, as a result of calling {@link PushStream#close()} on the returned
+	 * stream. If the stream is closed before it is first connected then no
+	 * subscription request will ever be sent.
+	 * </p>
+	 * @return A stream of messages for this subscription
+	 * @throws MqttException
+	 */
+	public PushStream<IReceivedMessage<C>> getStream() throws MqttException;
+	
+	/**
+	 * Returns the topic string(s) for the action being tracked by this
+	 * token. If the action has not been initiated or the action has not
+	 * topic associated with it such as connect then null will be returned.
+	 *
+	 * @return the topic string(s) for the subscribe being tracked by this token or null
+	 */
+	public List<String> getTopics();
+
+	Promise<IMqttUnsubscriptionResult<C>> getUnsubscribePromise() throws MqttException;
+}

--- a/org.eclipse.paho.mqttv5.client/src/main/java/org/eclipse/paho/mqttv5/client/alpha/IMqttToken.java
+++ b/org.eclipse.paho.mqttv5.client/src/main/java/org/eclipse/paho/mqttv5/client/alpha/IMqttToken.java
@@ -1,0 +1,73 @@
+/**************************************************************************
+ * Copyright (c) 2009, 2012 IBM Corp.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution. 
+ *
+ * The Eclipse Public License is available at 
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at 
+ *   http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * Contributors:
+ *    Dave Locke - initial API and implementation and/or initial documentation
+ *    Ian Craggs - MQTT 3.1.1 support
+ */
+package org.eclipse.paho.mqttv5.client.alpha;
+
+import org.eclipse.paho.mqttv5.client.alpha.result.IMqttResult;
+import org.osgi.util.promise.Promise;
+
+/**
+ * Provides a mechanism for tracking the completion of an asynchronous task.
+ *
+ * <p>When using the asynchronous/non-blocking MQTT programming interface all
+ * methods/operations that take any time (and in particular those that involve
+ * any network operation) return control to the caller immediately. The operation
+ * then proceeds to run in the background so as not to block the invoking thread.
+ * An IMqttToken is used to track the state of the operation. An application can use the
+ * token to wait for an operation to complete. A token is passed to callbacks
+ * once the operation completes and provides context linking it to the original
+ * request. A token is associated with a single operation.</p>
+ * <p>
+ * An action is in progress until either:</p>
+ * <ul>
+ * <li>isComplete() returns true or</li>
+ * <li>getException() is not null.</li>
+ * </ul>
+ * @param <M>
+ *
+ */
+public interface IMqttToken<T extends IMqttResult<C>, C> {
+	
+	public Promise<T> getPromise();
+
+	/**
+	 * Returns the MQTT client that is responsible for processing the asynchronous
+	 * action
+	 * @return the client
+	 */
+	public IMqttCommonClient getClient();
+
+
+	/**
+	 * Retrieve the context associated with an action.
+	 * <p>Allows the ActionListener associated with an action to retrieve any context
+	 * that was associated with the action when the action was invoked. If not
+	 * context was provided null is returned. </p>
+
+	 * @return Object context associated with an action or null if there is none.
+	 */
+	public Object getUserContext();
+
+	/**
+	 * Returns the message ID of the message that is associated with the token.
+	 * A message id of zero will be returned for tokens associated with
+	 * connect, disconnect and ping operations as there can only ever
+	 * be one of these outstanding at a time. For other operations
+	 * the MQTT message id flowed over the network.
+	 * @return the message ID of the message that is associated with the token
+	 */
+	public int getMessageId();
+}

--- a/org.eclipse.paho.mqttv5.client/src/main/java/org/eclipse/paho/mqttv5/client/alpha/IReceivedMessage.java
+++ b/org.eclipse.paho.mqttv5.client/src/main/java/org/eclipse/paho/mqttv5/client/alpha/IReceivedMessage.java
@@ -1,0 +1,17 @@
+package org.eclipse.paho.mqttv5.client.alpha;
+
+public interface IReceivedMessage<C> extends IMqttMessage {
+	
+	String getTopic();
+	
+	C getUserContext();
+	
+	/**
+	 * Returns whether or not this message might be a duplicate of one which has
+	 * already been received.
+	 * 
+	 * @return <code>true</code> if the message might be a duplicate.
+	 */
+	public boolean isDuplicate();
+
+}

--- a/org.eclipse.paho.mqttv5.client/src/main/java/org/eclipse/paho/mqttv5/client/alpha/MqttAsyncClient.java
+++ b/org.eclipse.paho.mqttv5.client/src/main/java/org/eclipse/paho/mqttv5/client/alpha/MqttAsyncClient.java
@@ -1,0 +1,391 @@
+package org.eclipse.paho.mqttv5.client.alpha;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.function.Consumer;
+
+import org.eclipse.paho.mqttv5.client.IMqttMessageListener;
+import org.eclipse.paho.mqttv5.client.MqttActionListener;
+import org.eclipse.paho.mqttv5.client.MqttConnectionOptions;
+import org.eclipse.paho.mqttv5.client.alpha.internal.MqttConnectionResultImpl;
+import org.eclipse.paho.mqttv5.client.alpha.internal.MqttDeliveryResultImpl;
+import org.eclipse.paho.mqttv5.client.alpha.internal.MqttDeliveryToken;
+import org.eclipse.paho.mqttv5.client.alpha.internal.MqttResultImpl;
+import org.eclipse.paho.mqttv5.client.alpha.internal.MqttSubscriptionResultImpl;
+import org.eclipse.paho.mqttv5.client.alpha.internal.MqttSubscriptionToken;
+import org.eclipse.paho.mqttv5.client.alpha.internal.MqttToken;
+import org.eclipse.paho.mqttv5.client.alpha.internal.MqttUnsubscriptionResultImpl;
+import org.eclipse.paho.mqttv5.client.alpha.internal.ReceivedMessageImpl;
+import org.eclipse.paho.mqttv5.client.alpha.result.IMqttConnectionResult;
+import org.eclipse.paho.mqttv5.client.alpha.result.IMqttDeliveryResult;
+import org.eclipse.paho.mqttv5.client.alpha.result.IMqttResult;
+import org.eclipse.paho.mqttv5.client.alpha.result.IMqttSubscriptionResult;
+import org.eclipse.paho.mqttv5.client.alpha.result.IMqttUnsubscriptionResult;
+import org.eclipse.paho.mqttv5.common.MqttException;
+import org.eclipse.paho.mqttv5.common.MqttMessage;
+import org.eclipse.paho.mqttv5.common.MqttPersistenceException;
+import org.eclipse.paho.mqttv5.common.MqttSecurityException;
+import org.eclipse.paho.mqttv5.common.MqttSubscription;
+import org.eclipse.paho.mqttv5.common.packet.MqttReturnCode;
+import org.eclipse.paho.mqttv5.common.packet.UserProperty;
+import org.osgi.util.promise.Deferred;
+import org.osgi.util.promise.Promise;
+import org.osgi.util.pushstream.PushEvent;
+import org.osgi.util.pushstream.PushEventSource;
+import org.osgi.util.pushstream.PushStreamProvider;
+
+public class MqttAsyncClient implements IMqttAsyncClient {
+	
+	static class Callback implements MqttActionListener {
+
+		private final Consumer<org.eclipse.paho.mqttv5.client.IMqttToken> onSuccess;
+		
+		private final Consumer<Throwable> onFailure;
+		
+		public Callback(Consumer<org.eclipse.paho.mqttv5.client.IMqttToken> onSuccess, Consumer<Throwable> onFailure) {
+			super();
+			this.onSuccess = onSuccess;
+			this.onFailure = onFailure;
+		}
+
+		@Override
+		public void onSuccess(org.eclipse.paho.mqttv5.client.IMqttToken asyncActionToken) {
+			onSuccess.accept(asyncActionToken);
+		}
+
+		@Override
+		public void onFailure(org.eclipse.paho.mqttv5.client.IMqttToken asyncActionToken, Throwable exception) {
+			onFailure.accept(exception);
+		}
+		
+	}
+	
+	private final org.eclipse.paho.mqttv5.client.MqttAsyncClient delegate;
+	private final ScheduledExecutorService workers;
+	private final ScheduledExecutorService promiseTimer;
+	private final PushStreamProvider pushStreamProvider;
+	
+	private final Set<IMqttDeliveryToken<?>> pendingDeliveries = new HashSet<>();
+	
+	private final Set<IMqttSubscriptionToken<?>> subscriptions = new HashSet<>();
+	
+	public MqttAsyncClient(String serverURI, String clientId) throws MqttException {
+		workers = Executors.newScheduledThreadPool(10);
+		promiseTimer = Executors.newScheduledThreadPool(1);
+		delegate = new org.eclipse.paho.mqttv5.client.MqttAsyncClient(serverURI, clientId,
+				null, null, workers);
+		pushStreamProvider = new PushStreamProvider();
+	}
+
+	@Override
+	public boolean isConnected() {
+		return delegate.isConnected();
+	}
+
+	@Override
+	public String getClientId() {
+		return delegate.getClientId();
+	}
+
+	@Override
+	public String getServerURI() {
+		return delegate.getServerURI();
+	}
+
+	@Override
+	public IMqttDeliveryToken<?>[] getPendingDeliveryTokens() {
+		synchronized (pendingDeliveries) {
+			return pendingDeliveries.toArray(new IMqttDeliveryToken<?>[0]);
+		}
+	}
+
+	@Override
+	public void setManualAcks(boolean manualAcks) {
+		delegate.setManualAcks(manualAcks);
+	}
+
+	@Override
+	public void messageArrivedComplete(int messageId, int qos) throws MqttException {
+		delegate.messageArrivedComplete(messageId, qos);
+	}
+
+	@Override
+	public void close() throws MqttException {
+		try {
+			delegate.close();
+		} finally {
+			workers.shutdownNow();
+			promiseTimer.shutdownNow();
+		}
+	}
+
+	@Override
+	public IMqttToken<IMqttConnectionResult<Void>, Void> connect() throws MqttException, MqttSecurityException {
+		return connect(null);
+	}
+
+	@Override
+	public IMqttToken<IMqttConnectionResult<Void>, Void> connect(MqttConnectionOptions options)
+			throws MqttException, MqttSecurityException {
+		return connect(options, null);
+	}
+
+	@Override
+	public <C> IMqttToken<IMqttConnectionResult<C>, C> connect(C userContext) throws MqttException, MqttSecurityException {
+		return connect(new MqttConnectionOptions(), userContext);
+	}
+
+	@Override
+	public <C> IMqttToken<IMqttConnectionResult<C>, C> connect(MqttConnectionOptions options, C userContext)
+			throws MqttException, MqttSecurityException {
+		MqttToken<IMqttConnectionResult<C>, C> token = 
+				new MqttToken<>(workers, promiseTimer, this, userContext, 0);
+		
+		delegate.connect(options, userContext, new Callback(
+				t -> token.resolve(new MqttConnectionResultImpl<C>(this, userContext, t.getSessionPresent())), 
+				t -> token.fail(t)));
+		return token;
+	}
+
+	@Override
+	public IMqttToken<IMqttResult<Void>, Void> disconnect() throws MqttException {
+		return disconnect(null);
+	}
+
+	@Override
+	public IMqttToken<IMqttResult<Void>, Void> disconnect(long quiesceTimeout) throws MqttException {
+		return disconnect(quiesceTimeout, null, null, null, null);
+	}
+
+	@Override
+	public <C> IMqttToken<IMqttResult<C>, C> disconnect(C userContext) throws MqttException {
+		return disconnect(30000, userContext, null, null, null);
+	}
+
+	@Override
+	public <C> IMqttToken<IMqttResult<C>, C> disconnect(long quiesceTimeout, C userContext,
+			Integer sessionExpiryInterval, String reasonString, ArrayList<UserProperty> userDefinedProperties)
+			throws MqttException {
+		
+		MqttToken<IMqttResult<C>, C> token = 
+				new MqttToken<>(workers, promiseTimer, this, userContext, 0);
+		
+		delegate.disconnect(quiesceTimeout, userContext, new Callback(
+				t -> token.resolve(new MqttResultImpl<C>(this, userContext)), 
+				t -> token.fail(t)), MqttReturnCode.RETURN_CODE_SUCCESS, sessionExpiryInterval, 
+				reasonString, userDefinedProperties);
+		return token;
+	}
+
+	@Override
+	public void disconnectForcibly() throws MqttException {
+		disconnectForcibly(10000);
+	}
+
+	@Override
+	public void disconnectForcibly(long disconnectTimeout) throws MqttException {
+		disconnectForcibly(30000, disconnectTimeout);
+	}
+
+	@Override
+	public void disconnectForcibly(long quiesceTimeout, long disconnectTimeout) throws MqttException {
+		delegate.disconnectForcibly(quiesceTimeout, disconnectTimeout, true);
+	}
+
+	@Override
+	public IMqttDeliveryToken<Void> publish(String topic, byte[] payload, int qos, boolean retained)
+			throws MqttException, MqttPersistenceException {
+		return publish(topic, payload, qos, retained, null);
+	}
+
+	@Override
+	public <C> IMqttDeliveryToken<C> publish(String topic, byte[] payload, int qos, boolean retained,
+			C userContext) throws MqttException, MqttPersistenceException {
+		IMqttMessage message = new IMqttMessageBuilder()
+			.withPayload(payload)
+			.withQoS(qos)
+			.retained(retained)
+			.build();
+		
+		return publish(topic, message, userContext);
+	}
+
+	@Override
+	public IMqttDeliveryToken<Void> publish(String topic, IMqttMessage message)
+			throws MqttException, MqttPersistenceException {
+		return publish(topic, message, null);
+	}
+
+	@Override
+	public <C> IMqttDeliveryToken<C> publish(String topic, IMqttMessage message, C userContext)
+			throws MqttException, MqttPersistenceException {
+		
+		ByteBuffer buffer = message.payload();
+		byte[] payload = new byte[buffer.remaining()];
+		buffer.get(payload);
+		
+		Deferred<IMqttDeliveryResult<C>> d = new Deferred<>(workers, promiseTimer);
+		
+		int messageId = delegate.publish(topic, new MqttMessage(payload, message.getQos(), message.isRetained()), 
+				userContext, new Callback(
+					t -> d.resolve(new MqttDeliveryResultImpl<C>(this, userContext, message)), 
+					t -> d.fail(t))).getMessageId();
+		
+		MqttDeliveryToken<C> token = 
+				new MqttDeliveryToken<>(workers, promiseTimer, this, userContext, messageId, message);
+		
+		synchronized (pendingDeliveries) {
+			pendingDeliveries.add(token);
+		}
+		
+		d.getPromise().onResolve(() -> {
+				synchronized (pendingDeliveries) {
+					pendingDeliveries.remove(token);
+				}
+			});
+		
+		token.resolveWith(d.getPromise());
+		
+		return token;
+	}
+
+	@Override
+	public IMqttSubscriptionToken<Void> subscribe(String topicFilter, int qos) throws MqttException {
+		return subscribe(topicFilter, qos, null);
+	}
+
+	@Override
+	public <C> IMqttSubscriptionToken<C> subscribe(String topicFilter, int qos, C userContext)
+			throws MqttException {
+		return subscribe(new MqttSubscription(topicFilter, qos), userContext);
+	}
+
+	@Override
+	public IMqttSubscriptionToken<Void> subscribe(MqttSubscription[] subscriptions) throws MqttException {
+		return subscribe(subscriptions, null);
+	}
+
+	@Override
+	public <C> IMqttSubscriptionToken<C> subscribe(MqttSubscription[] subscriptions, C userContext)
+			throws MqttException {
+		
+		String[] topics = new String[subscriptions.length];
+		
+		for (int i = 0; i < subscriptions.length; i++) {
+			topics[i] = subscriptions[i].getTopic();
+		}
+		
+		Deferred<IMqttSubscriptionResult<C>> subscribe = new Deferred<>(workers, promiseTimer);
+		Deferred<IMqttUnsubscriptionResult<C>> unsubscribe = new Deferred<>(workers, promiseTimer);
+		
+		PushEventSource<IReceivedMessage<C>> pes = consumer -> {
+				AutoCloseable cleanup = () -> {
+					try {
+						delegate.unsubscribe(topics, userContext, 
+								new Callback(t -> {
+										unsubscribe.resolve(new MqttUnsubscriptionResultImpl<>(this, userContext, t.getMessageId()));
+									}, t -> {
+										unsubscribe.fail(t);
+									}));
+					} catch (Exception e) {
+						// TODO Should this be logged?
+					}
+				};
+			
+			
+				IMqttMessageListener listener = (t,m) -> {
+					IReceivedMessage<C> received = new ReceivedMessageImpl<>(m.getQos(),
+							ByteBuffer.wrap(m.getPayload()), m.isRetained(), t, userContext, 
+							m.isDuplicate());
+					try {
+						if(consumer.accept(PushEvent.data(received)) < 0) {
+							cleanup.close();
+							consumer.accept(PushEvent.close());
+						}
+					} catch (Exception e) {
+						cleanup.close();
+						consumer.accept(PushEvent.error(e));
+					}
+				};
+				
+				MqttActionListener onConnect = new Callback(t -> {
+						subscribe.resolve(new MqttSubscriptionResultImpl<C>(this, userContext, t.getMessageId(), t.getGrantedQos()));
+					}, t -> {
+						subscribe.fail(t);
+						try {
+							consumer.accept(PushEvent.error((Exception)t));
+						} catch (Exception e) {
+							// TODO Should this be logged?
+						}
+					});
+			
+				IMqttMessageListener[] listeners = new IMqttMessageListener[subscriptions.length];
+				Arrays.fill(listeners, listener);
+				
+				delegate.subscribe(subscriptions, userContext, onConnect, listeners);
+			
+				return cleanup;
+			};
+		
+		MqttSubscriptionToken<C> token = new MqttSubscriptionToken<>(workers, promiseTimer, this, 
+				userContext, Arrays.asList(topics), pushStreamProvider.buildStream(pes).unbuffered().build());
+		
+		synchronized (this.subscriptions) {
+			this.subscriptions.add(token);
+		}
+		
+		token.resolveWith(subscribe.getPromise());
+		
+		Promise<IMqttUnsubscriptionResult<C>> promise = unsubscribe.getPromise()
+				.onResolve(() -> {
+					synchronized (this.subscriptions) {
+						this.subscriptions.remove(token);
+					}
+				});
+		token.resolveUnsubscribeWith(promise);
+		
+		return token;
+	}
+
+	@Override
+	public <C> IMqttSubscriptionToken<C> subscribe(MqttSubscription subscription, C userContext) throws MqttException {
+		return subscribe(new MqttSubscription[] {subscription}, userContext);
+	}
+
+	@Override
+	public IMqttSubscriptionToken<Void> subscribe(MqttSubscription subscription) throws MqttException {
+		return subscribe(subscription, null);
+	}
+
+	@Override
+	public IMqttSubscriptionToken<?>[] getSubscribers() {
+		synchronized (this.subscriptions) {
+			return this.subscriptions.stream().toArray(i -> new IMqttSubscriptionToken<?>[i]);
+		}
+	}
+
+	@Override
+	public IMqttSubscriptionToken<?>[] getSubscribers(String topicFilter) {
+		synchronized (this.subscriptions) {
+			return this.subscriptions.stream()
+					.filter(s -> s.getTopics().contains(topicFilter))
+					.toArray(i -> new IMqttSubscriptionToken<?>[i]);
+		}
+	}
+
+	@Override
+	public IMqttSubscriptionToken<?>[] getSubscribers(String[] topicFilters) {
+		synchronized (this.subscriptions) {
+			return this.subscriptions.stream()
+					.filter(s -> Arrays.stream(topicFilters)
+								.anyMatch(t -> s.getTopics().contains(t)))
+					.toArray(i -> new IMqttSubscriptionToken<?>[i]);
+		}
+	}
+	
+}

--- a/org.eclipse.paho.mqttv5.client/src/main/java/org/eclipse/paho/mqttv5/client/alpha/MqttClientException.java
+++ b/org.eclipse.paho.mqttv5.client/src/main/java/org/eclipse/paho/mqttv5/client/alpha/MqttClientException.java
@@ -1,0 +1,145 @@
+package org.eclipse.paho.mqttv5.client.alpha;
+
+import org.eclipse.paho.mqttv5.common.MqttMessage;
+
+public class MqttClientException {
+	
+	public static final int REASON_CODE_INVALID_TOPIC_ALAS = 50004; // An invalid topic alias combination was recieved.
+	
+	/**
+	 * Client timed out while waiting for a response from the server. The server is
+	 * no longer responding to keep-alive messages.
+	 */
+	public static final short REASON_CODE_CLIENT_TIMEOUT = 32000;
+
+	/**
+	 * Internal error, caused by no new message IDs being available.
+	 */
+	public static final short REASON_CODE_NO_MESSAGE_IDS_AVAILABLE = 32001;
+
+	/**
+	 * Client timed out while waiting to write messages to the server.
+	 */
+	public static final short REASON_CODE_WRITE_TIMEOUT = 32002;
+
+	/**
+	 * The client is already connected.
+	 */
+	public static final short REASON_CODE_CLIENT_CONNECTED = 32100;
+
+	/**
+	 * The client is already disconnected.
+	 */
+	public static final short REASON_CODE_CLIENT_ALREADY_DISCONNECTED = 32101;
+	/**
+	 * The client is currently disconnecting and cannot accept any new work. This
+	 * can occur when waiting on a token, and then disconnecting the client. If the
+	 * message delivery does not complete within the quiesce timeout period, then
+	 * the waiting token will be notified with an exception.
+	 */
+	public static final short REASON_CODE_CLIENT_DISCONNECTING = 32102;
+
+	/** Unable to connect to server */
+	public static final short REASON_CODE_SERVER_CONNECT_ERROR = 32103;
+
+	/**
+	 * The client is not connected to the server. The {@link MqttClient#connect()}
+	 * or {@link MqttClient#connect(MqttConnectOptions)} method must be called
+	 * first. It is also possible that the connection was lost - see
+	 * {@link MqttClient#setCallback(MqttCallback)} for a way to track lost
+	 * connections.
+	 */
+	public static final short REASON_CODE_CLIENT_NOT_CONNECTED = 32104;
+
+	/**
+	 * Server URI and supplied <code>SocketFactory</code> do not match. URIs
+	 * beginning <code>tcp://</code> must use a
+	 * <code>javax.net.SocketFactory</code>, and URIs beginning <code>ssl://</code>
+	 * must use a <code>javax.net.ssl.SSLSocketFactory</code>.
+	 */
+	public static final short REASON_CODE_SOCKET_FACTORY_MISMATCH = 32105;
+
+	/**
+	 * SSL configuration error.
+	 */
+	public static final short REASON_CODE_SSL_CONFIG_ERROR = 32106;
+
+	/**
+	 * Thrown when an attempt to call {@link MqttClient#disconnect()} has been made
+	 * from within a method on {@link MqttCallback}. These methods are invoked by
+	 * the client's thread, and must not be used to control disconnection.
+	 * 
+	 * @see MqttCallback#messageArrived(String, MqttMessage)
+	 */
+	public static final short REASON_CODE_CLIENT_DISCONNECT_PROHIBITED = 32107;
+
+	/**
+	 * Protocol error: the message was not recognized as a valid MQTT packet.
+	 * Possible reasons for this include connecting to a non-MQTT server, or
+	 * connecting to an SSL server port when the client isn't using SSL.
+	 */
+	public static final short REASON_CODE_INVALID_MESSAGE = 32108;
+
+	/**
+	 * The client has been unexpectedly disconnected from the server. The
+	 * {@link #getCause() cause} will provide more details.
+	 */
+	public static final short REASON_CODE_CONNECTION_LOST = 32109;
+
+	/**
+	 * A connect operation in already in progress, only one connect can happen at a
+	 * time.
+	 */
+	public static final short REASON_CODE_CONNECT_IN_PROGRESS = 32110;
+
+	/**
+	 * The client is closed - no operations are permitted on the client in this
+	 * state. New up a new client to continue.
+	 */
+	public static final short REASON_CODE_CLIENT_CLOSED = 32111;
+
+	/**
+	 * A request has been made to use a token that is already associated with
+	 * another action. If the action is complete the reset() can ve called on the
+	 * token to allow it to be reused.
+	 */
+	public static final short REASON_CODE_TOKEN_INUSE = 32201;
+
+	/**
+	 * A request has been made to send a message but the maximum number of inflight
+	 * messages has already been reached. Once one or more messages have been moved
+	 * then new messages can be sent.
+	 */
+	public static final short REASON_CODE_MAX_INFLIGHT = 32202;
+
+	/**
+	 * The Client has attempted to publish a message whilst in the 'resting' /
+	 * offline state with Disconnected Publishing enabled, however the buffer is
+	 * full and deleteOldestMessages is disabled, therefore no more messages can be
+	 * published until the client reconnects, or the application deletes buffered
+	 * message manually.
+	 */
+	public static final short REASON_CODE_DISCONNECTED_BUFFER_FULL = 32203;
+
+	// CONNACK return codes
+	/** The protocol version requested is not supported by the server. */
+	public static final short REASON_CODE_INVALID_PROTOCOL_VERSION = 0x01;
+	/** The server has rejected the supplied client ID */
+	public static final short REASON_CODE_INVALID_CLIENT_ID = 0x02;
+	/** The broker was not available to handle the request. */
+	public static final short REASON_CODE_BROKER_UNAVAILABLE = 0x03;
+	/**
+	 * Authentication with the server has failed, due to a bad user name or
+	 * password.
+	 */
+	public static final short REASON_CODE_FAILED_AUTHENTICATION = 0x04;
+	/** Not authorized to perform the requested operation */
+	public static final short REASON_CODE_NOT_AUTHORIZED = 0x05;
+
+	/** An unexpected error has occurred. */
+	public static final short REASON_CODE_UNEXPECTED_ERROR = 0x06;
+
+	/** Error from subscribe - returned from the server. */
+	public static final short REASON_CODE_SUBSCRIBE_FAILED = 0x80;
+
+}

--- a/org.eclipse.paho.mqttv5.client/src/main/java/org/eclipse/paho/mqttv5/client/alpha/MqttClientPersistence.java
+++ b/org.eclipse.paho.mqttv5.client/src/main/java/org/eclipse/paho/mqttv5/client/alpha/MqttClientPersistence.java
@@ -1,0 +1,102 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2014 IBM Corp.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution. 
+ *
+ * The Eclipse Public License is available at 
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at 
+ *   http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * Contributors:
+ *    Dave Locke - initial API and implementation and/or initial documentation
+ */
+package org.eclipse.paho.mqttv5.client.alpha;
+
+import org.eclipse.paho.mqttv5.common.MqttPersistable;
+import org.eclipse.paho.mqttv5.common.MqttPersistenceException;
+
+/**
+ * Represents a persistent data store, used to store outbound and inbound messages while they
+ * are in flight, enabling delivery to the QoS specified. You can specify an implementation
+ * of this interface using {@link MqttLegacyBlockingClient#MqttClient(String, String, MqttClientPersistence)},
+ * which the {@link MqttLegacyBlockingClient} will use to persist QoS 1 and 2 messages.
+ * <p>
+ * If the methods defined throw the MqttPersistenceException then the state of the data persisted
+ * should remain as prior to the method being called. For example, if {@link #put(String, MqttPersistable)}
+ * throws an exception at any point then the data will be assumed to not be in the persistent store.
+ * Similarly if {@link #remove(String)} throws an exception then the data will be
+ * assumed to still be held in the persistent store.</p>
+ * <p>
+ * It is up to the persistence interface to log any exceptions or error information 
+ * which may be required when diagnosing a persistence failure.</p>
+ */
+public interface MqttClientPersistence {
+	/**
+	 * Initialise the persistent store.
+	 * If a persistent store exists for this client ID then open it, otherwise 
+	 * create a new one. If the persistent store is already open then just return.
+	 * An application may use the same client ID to connect to many different 
+	 * servers, so the client ID in conjunction with the
+	 * connection will uniquely identify the persistence store required.
+	 * 
+	 * @param clientId The client for which the persistent store should be opened.
+	 * @throws MqttPersistenceException if there was a problem opening the persistent store.
+	 */
+	public void open(String clientId) throws MqttPersistenceException;
+
+	/**
+	 * Close the persistent store that was previously opened.
+	 * This will be called when a client application disconnects from the broker.
+	 * @throws MqttPersistenceException if an error occurs closing the persistence store.
+	 */	
+	public void close() throws MqttPersistenceException;
+
+	/**
+	 * Puts the specified data into the persistent store.
+	 * @param key the key for the data, which will be used later to retrieve it.
+	 * @param persistable the data to persist
+	 * @throws MqttPersistenceException if there was a problem putting the data
+	 * into the persistent store.
+	 */
+	public void put(String key, MqttPersistable persistable) throws MqttPersistenceException;
+	
+	/**
+	 * Gets the specified data out of the persistent store.
+	 * @param key the key for the data, which was used when originally saving it.
+	 * @return the un-persisted data
+	 * @throws MqttPersistenceException if there was a problem getting the data
+	 * from the persistent store.
+	 */
+	public MqttPersistable get(String key) throws MqttPersistenceException;
+	
+	/**
+	 * Remove the data for the specified key.
+	 * @param key The key for the data to remove
+	 * @throws MqttPersistenceException if there was a problem removing the data.
+	 */
+	public void remove(String key) throws MqttPersistenceException;
+
+	/**
+	 * Returns an Enumeration over the keys in this persistent data store.
+	 * @return an enumeration of {@link String} objects.
+	 * @throws MqttPersistenceException if there was a problem getting they keys
+	 */
+	public Iterable<String> keys() throws MqttPersistenceException;
+	
+	/**
+	 * Clears persistence, so that it no longer contains any persisted data.
+	 * @throws MqttPersistenceException if there was a problem clearing all data from the persistence store
+	 */
+	public void clear() throws MqttPersistenceException;
+	
+	/**
+	 * Returns whether or not data is persisted using the specified key.
+	 * @param key the key for data, which was used when originally saving it.
+	 * @return True if the persistence store contains the key
+	 * @throws MqttPersistenceException if there was a problem checking whether they key existed.
+	 */
+	public boolean containsKey(String key) throws MqttPersistenceException;
+}

--- a/org.eclipse.paho.mqttv5.client/src/main/java/org/eclipse/paho/mqttv5/client/alpha/internal/MqttConnectionResultImpl.java
+++ b/org.eclipse.paho.mqttv5.client/src/main/java/org/eclipse/paho/mqttv5/client/alpha/internal/MqttConnectionResultImpl.java
@@ -1,0 +1,19 @@
+package org.eclipse.paho.mqttv5.client.alpha.internal;
+
+import org.eclipse.paho.mqttv5.client.alpha.IMqttCommonClient;
+import org.eclipse.paho.mqttv5.client.alpha.result.IMqttConnectionResult;
+
+public class MqttConnectionResultImpl<C> extends MqttResultImpl<C> implements IMqttConnectionResult<C> {
+
+	private final boolean sessionPresent;
+
+	public MqttConnectionResultImpl(IMqttCommonClient client, C userContext, boolean sessionPresent) {
+		super(client, userContext);
+		this.sessionPresent = sessionPresent;
+	}
+
+	@Override
+	public boolean getSessionPresent() {
+		return sessionPresent;
+	}
+}

--- a/org.eclipse.paho.mqttv5.client/src/main/java/org/eclipse/paho/mqttv5/client/alpha/internal/MqttDeliveryResultImpl.java
+++ b/org.eclipse.paho.mqttv5.client/src/main/java/org/eclipse/paho/mqttv5/client/alpha/internal/MqttDeliveryResultImpl.java
@@ -1,0 +1,22 @@
+package org.eclipse.paho.mqttv5.client.alpha.internal;
+
+import org.eclipse.paho.mqttv5.client.alpha.IMqttCommonClient;
+import org.eclipse.paho.mqttv5.client.alpha.IMqttMessage;
+import org.eclipse.paho.mqttv5.client.alpha.result.IMqttDeliveryResult;
+import org.eclipse.paho.mqttv5.common.MqttException;
+
+public class MqttDeliveryResultImpl<C> extends MqttResultImpl<C> implements IMqttDeliveryResult<C> {
+
+	private final IMqttMessage message;
+
+	public MqttDeliveryResultImpl(IMqttCommonClient client, C userContext, IMqttMessage message) {
+		super(client, userContext);
+		this.message = message;
+	}
+
+	@Override
+	public IMqttMessage getMessage() throws MqttException {
+		return message;
+	}
+
+}

--- a/org.eclipse.paho.mqttv5.client/src/main/java/org/eclipse/paho/mqttv5/client/alpha/internal/MqttDeliveryToken.java
+++ b/org.eclipse.paho.mqttv5.client/src/main/java/org/eclipse/paho/mqttv5/client/alpha/internal/MqttDeliveryToken.java
@@ -1,0 +1,27 @@
+package org.eclipse.paho.mqttv5.client.alpha.internal;
+
+import java.util.concurrent.Executor;
+import java.util.concurrent.ScheduledExecutorService;
+
+import org.eclipse.paho.mqttv5.client.alpha.IMqttCommonClient;
+import org.eclipse.paho.mqttv5.client.alpha.IMqttDeliveryToken;
+import org.eclipse.paho.mqttv5.client.alpha.IMqttMessage;
+import org.eclipse.paho.mqttv5.client.alpha.result.IMqttDeliveryResult;
+import org.eclipse.paho.mqttv5.common.MqttException;
+
+public class MqttDeliveryToken<C> extends MqttToken<IMqttDeliveryResult<C>, C> implements IMqttDeliveryToken<C> {
+
+	private final IMqttMessage message;
+
+	public MqttDeliveryToken(Executor executor, ScheduledExecutorService scheduler, IMqttCommonClient client,
+			C userContext, int messageId, IMqttMessage message) {
+		super(executor, scheduler, client, userContext, messageId);
+		this.message = message;
+	}
+
+	@Override
+	public IMqttMessage getMessage() throws MqttException {
+		return message;
+	}
+
+}

--- a/org.eclipse.paho.mqttv5.client/src/main/java/org/eclipse/paho/mqttv5/client/alpha/internal/MqttMessageImpl.java
+++ b/org.eclipse.paho.mqttv5.client/src/main/java/org/eclipse/paho/mqttv5/client/alpha/internal/MqttMessageImpl.java
@@ -1,0 +1,36 @@
+package org.eclipse.paho.mqttv5.client.alpha.internal;
+
+import java.nio.ByteBuffer;
+
+import org.eclipse.paho.mqttv5.client.alpha.IMqttMessage;
+
+public class MqttMessageImpl implements IMqttMessage {
+
+	private final int qos;
+	
+	private final ByteBuffer payload;
+	
+	private final boolean retained;
+	
+	public MqttMessageImpl(int qos, ByteBuffer payload, boolean retained) {
+		this.qos = qos;
+		this.payload = payload;
+		this.retained = retained;
+	}
+
+	@Override
+	public int getQos() {
+		return qos;
+	}
+
+	@Override
+	public ByteBuffer payload() {
+		return payload.asReadOnlyBuffer();
+	}
+
+	@Override
+	public boolean isRetained() {
+		return retained;
+	}
+
+}

--- a/org.eclipse.paho.mqttv5.client/src/main/java/org/eclipse/paho/mqttv5/client/alpha/internal/MqttResultImpl.java
+++ b/org.eclipse.paho.mqttv5.client/src/main/java/org/eclipse/paho/mqttv5/client/alpha/internal/MqttResultImpl.java
@@ -1,0 +1,28 @@
+package org.eclipse.paho.mqttv5.client.alpha.internal;
+
+import org.eclipse.paho.mqttv5.client.alpha.IMqttCommonClient;
+import org.eclipse.paho.mqttv5.client.alpha.result.IMqttResult;
+
+public class MqttResultImpl<C> implements IMqttResult<C> {
+
+	private final IMqttCommonClient client;
+	
+	private final C userContext;
+	
+	public MqttResultImpl(IMqttCommonClient client, C userContext) {
+		super();
+		this.client = client;
+		this.userContext = userContext;
+	}
+
+	@Override
+	public IMqttCommonClient getClient() {
+		return client;
+	}
+
+	@Override
+	public C getUserContext() {
+		return userContext;
+	}
+
+}

--- a/org.eclipse.paho.mqttv5.client/src/main/java/org/eclipse/paho/mqttv5/client/alpha/internal/MqttSubscriptionResultImpl.java
+++ b/org.eclipse.paho.mqttv5.client/src/main/java/org/eclipse/paho/mqttv5/client/alpha/internal/MqttSubscriptionResultImpl.java
@@ -1,0 +1,29 @@
+package org.eclipse.paho.mqttv5.client.alpha.internal;
+
+import java.util.Arrays;
+
+import org.eclipse.paho.mqttv5.client.alpha.IMqttCommonClient;
+import org.eclipse.paho.mqttv5.client.alpha.result.IMqttSubscriptionResult;
+
+public class MqttSubscriptionResultImpl<C> extends MqttResultImpl<C> implements IMqttSubscriptionResult<C> {
+
+	private final int messageId;
+	private final int[] grantedQoS;
+
+	public MqttSubscriptionResultImpl(IMqttCommonClient client, C userContext, int messageId, int[] grantedQoS) {
+		super(client, userContext);
+		this.messageId = messageId;
+		this.grantedQoS = grantedQoS;
+	}
+
+	@Override
+	public int[] getGrantedQos() {
+		return Arrays.copyOf(grantedQoS, grantedQoS.length);
+	}
+
+	@Override
+	public int getMessageId() {
+		return messageId;
+	}
+
+}

--- a/org.eclipse.paho.mqttv5.client/src/main/java/org/eclipse/paho/mqttv5/client/alpha/internal/MqttSubscriptionToken.java
+++ b/org.eclipse.paho.mqttv5.client/src/main/java/org/eclipse/paho/mqttv5/client/alpha/internal/MqttSubscriptionToken.java
@@ -1,0 +1,51 @@
+package org.eclipse.paho.mqttv5.client.alpha.internal;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ScheduledExecutorService;
+
+import org.eclipse.paho.mqttv5.client.alpha.IMqttCommonClient;
+import org.eclipse.paho.mqttv5.client.alpha.IMqttSubscriptionToken;
+import org.eclipse.paho.mqttv5.client.alpha.IReceivedMessage;
+import org.eclipse.paho.mqttv5.client.alpha.result.IMqttSubscriptionResult;
+import org.eclipse.paho.mqttv5.client.alpha.result.IMqttUnsubscriptionResult;
+import org.eclipse.paho.mqttv5.common.MqttException;
+import org.osgi.util.promise.Deferred;
+import org.osgi.util.promise.Promise;
+import org.osgi.util.pushstream.PushStream;
+
+public class MqttSubscriptionToken<C> extends MqttToken<IMqttSubscriptionResult<C>, C>
+		implements IMqttSubscriptionToken<C> {
+
+	private final PushStream<IReceivedMessage<C>> stream;
+	private final List<String> topics;
+	
+	private final Deferred<IMqttUnsubscriptionResult<C>> d = new Deferred<>();
+	
+	public MqttSubscriptionToken(Executor executor, ScheduledExecutorService scheduler, IMqttCommonClient client,
+			C userContext, List<String> topics, PushStream<IReceivedMessage<C>> stream) {
+		super(executor, scheduler, client, userContext, 0);
+		this.topics = Collections.unmodifiableList(topics);
+		this.stream = stream;
+	}
+
+	@Override
+	public PushStream<IReceivedMessage<C>> getStream() throws MqttException {
+		return stream;
+	}
+
+	@Override
+	public List<String> getTopics() {
+		return topics;
+	}
+	
+	@Override
+	public Promise<IMqttUnsubscriptionResult<C>> getUnsubscribePromise() throws MqttException {
+		return d.getPromise();
+	}
+
+	public void resolveUnsubscribeWith(Promise<IMqttUnsubscriptionResult<C>> promise) {
+		d.resolveWith(promise);
+	}
+}

--- a/org.eclipse.paho.mqttv5.client/src/main/java/org/eclipse/paho/mqttv5/client/alpha/internal/MqttToken.java
+++ b/org.eclipse.paho.mqttv5.client/src/main/java/org/eclipse/paho/mqttv5/client/alpha/internal/MqttToken.java
@@ -1,0 +1,61 @@
+package org.eclipse.paho.mqttv5.client.alpha.internal;
+
+import java.util.concurrent.Executor;
+import java.util.concurrent.ScheduledExecutorService;
+
+import org.eclipse.paho.mqttv5.client.alpha.IMqttCommonClient;
+import org.eclipse.paho.mqttv5.client.alpha.IMqttToken;
+import org.eclipse.paho.mqttv5.client.alpha.result.IMqttResult;
+import org.osgi.util.promise.Deferred;
+import org.osgi.util.promise.Promise;
+
+public class MqttToken<T extends IMqttResult<C>, C> implements IMqttToken<T, C> {
+
+	private final Deferred<T> deferred;
+	
+	private final IMqttCommonClient client;
+	
+	private final C userContext;
+	
+	private final int messageId;
+	
+	public MqttToken(Executor executor, ScheduledExecutorService scheduler, 
+			IMqttCommonClient client, C userContext, int messageId) {
+		this.deferred = new Deferred<>(executor, scheduler);
+		this.client = client;
+		this.userContext = userContext;
+		this.messageId = messageId;
+	}
+
+	@Override
+	public Promise<T> getPromise() {
+		return deferred.getPromise();
+	}
+
+	@Override
+	public IMqttCommonClient getClient() {
+		return client;
+	}
+
+	@Override
+	public C getUserContext() {
+		return userContext;
+	}
+
+	@Override
+	public int getMessageId() {
+		return messageId;
+	}
+
+	public void resolve(T value) {
+		deferred.resolve(value);
+	}
+	
+	public void resolveWith(Promise<T> p) {
+		deferred.resolveWith(p);
+	}
+	
+	public void fail(Throwable reason) {
+		deferred.fail(reason);
+	}
+}

--- a/org.eclipse.paho.mqttv5.client/src/main/java/org/eclipse/paho/mqttv5/client/alpha/internal/MqttUnsubscriptionResultImpl.java
+++ b/org.eclipse.paho.mqttv5.client/src/main/java/org/eclipse/paho/mqttv5/client/alpha/internal/MqttUnsubscriptionResultImpl.java
@@ -1,0 +1,20 @@
+package org.eclipse.paho.mqttv5.client.alpha.internal;
+
+import org.eclipse.paho.mqttv5.client.alpha.IMqttCommonClient;
+import org.eclipse.paho.mqttv5.client.alpha.result.IMqttUnsubscriptionResult;
+
+public class MqttUnsubscriptionResultImpl<C> extends MqttResultImpl<C> implements IMqttUnsubscriptionResult<C> {
+
+	private final int messageId;
+
+	public MqttUnsubscriptionResultImpl(IMqttCommonClient client, C userContext, int messageId) {
+		super(client, userContext);
+		this.messageId = messageId;
+	}
+
+	@Override
+	public int getMessageId() {
+		return messageId;
+	}
+
+}

--- a/org.eclipse.paho.mqttv5.client/src/main/java/org/eclipse/paho/mqttv5/client/alpha/internal/ReceivedMessageImpl.java
+++ b/org.eclipse.paho.mqttv5.client/src/main/java/org/eclipse/paho/mqttv5/client/alpha/internal/ReceivedMessageImpl.java
@@ -1,0 +1,36 @@
+package org.eclipse.paho.mqttv5.client.alpha.internal;
+
+import java.nio.ByteBuffer;
+
+import org.eclipse.paho.mqttv5.client.alpha.IReceivedMessage;
+
+public class ReceivedMessageImpl<C> extends MqttMessageImpl implements IReceivedMessage<C> {
+
+	private final String topic;
+	private final C userContext;
+	private final boolean duplicate;
+
+	public ReceivedMessageImpl(int qos, ByteBuffer payload, boolean retained, 
+			String topic, C userContext, boolean duplicate) {
+		super(qos, payload, retained);
+		this.topic = topic;
+		this.userContext = userContext;
+		this.duplicate = duplicate;
+	}
+
+	@Override
+	public String getTopic() {
+		return topic;
+	}
+
+	@Override
+	public C getUserContext() {
+		return userContext;
+	}
+
+	@Override
+	public boolean isDuplicate() {
+		return duplicate;
+	}
+
+}

--- a/org.eclipse.paho.mqttv5.client/src/main/java/org/eclipse/paho/mqttv5/client/alpha/result/IMqttConnectionResult.java
+++ b/org.eclipse.paho.mqttv5.client/src/main/java/org/eclipse/paho/mqttv5/client/alpha/result/IMqttConnectionResult.java
@@ -1,0 +1,10 @@
+package org.eclipse.paho.mqttv5.client.alpha.result;
+
+public interface IMqttConnectionResult<C> extends IMqttResult<C> {
+
+	/**
+	 * @return the session present flag from a connack 
+	 */
+	public boolean getSessionPresent();
+	
+}

--- a/org.eclipse.paho.mqttv5.client/src/main/java/org/eclipse/paho/mqttv5/client/alpha/result/IMqttDeliveryResult.java
+++ b/org.eclipse.paho.mqttv5.client/src/main/java/org/eclipse/paho/mqttv5/client/alpha/result/IMqttDeliveryResult.java
@@ -1,0 +1,15 @@
+package org.eclipse.paho.mqttv5.client.alpha.result;
+
+import org.eclipse.paho.mqttv5.client.alpha.IMqttMessage;
+import org.eclipse.paho.mqttv5.common.MqttException;
+
+public interface IMqttDeliveryResult<C> extends IMqttResult<C> {
+	
+	/**
+	 * Returns the message being delivered.
+	 * 
+	 * @return the message associated with this delivery.
+	 * @throws MqttException if there was a problem completing retrieving the message
+	 */
+	public IMqttMessage getMessage() throws MqttException;
+}

--- a/org.eclipse.paho.mqttv5.client/src/main/java/org/eclipse/paho/mqttv5/client/alpha/result/IMqttResult.java
+++ b/org.eclipse.paho.mqttv5.client/src/main/java/org/eclipse/paho/mqttv5/client/alpha/result/IMqttResult.java
@@ -1,0 +1,23 @@
+package org.eclipse.paho.mqttv5.client.alpha.result;
+
+import org.eclipse.paho.mqttv5.client.alpha.IMqttCommonClient;
+
+public interface IMqttResult<C> {
+
+	/**
+	 * Returns the MQTT client that is responsible for processing the asynchronous
+	 * action
+	 * @return the client
+	 */
+	public IMqttCommonClient getClient();
+	
+	/**
+	 * Retrieve the context associated with an action.
+	 * <p>Allows handler function associated with an action to retrieve any context
+	 * that was associated with the action when the action was invoked. If no
+	 * context was provided null is returned. </p>
+     *
+	 * @return Object context associated with an action or null if there is none.
+	 */
+	public C getUserContext();
+}

--- a/org.eclipse.paho.mqttv5.client/src/main/java/org/eclipse/paho/mqttv5/client/alpha/result/IMqttSubscriptionResult.java
+++ b/org.eclipse.paho.mqttv5.client/src/main/java/org/eclipse/paho/mqttv5/client/alpha/result/IMqttSubscriptionResult.java
@@ -1,0 +1,8 @@
+package org.eclipse.paho.mqttv5.client.alpha.result;
+
+public interface IMqttSubscriptionResult<C> extends IMqttResult<C> {
+
+	public int[] getGrantedQos();
+
+	public int getMessageId();
+}

--- a/org.eclipse.paho.mqttv5.client/src/main/java/org/eclipse/paho/mqttv5/client/alpha/result/IMqttUnsubscriptionResult.java
+++ b/org.eclipse.paho.mqttv5.client/src/main/java/org/eclipse/paho/mqttv5/client/alpha/result/IMqttUnsubscriptionResult.java
@@ -1,0 +1,6 @@
+package org.eclipse.paho.mqttv5.client.alpha.result;
+
+public interface IMqttUnsubscriptionResult<C> extends IMqttResult<C> {
+
+	public int getMessageId();
+}

--- a/org.eclipse.paho.mqttv5.testclient/pom.xml
+++ b/org.eclipse.paho.mqttv5.testclient/pom.xml
@@ -17,7 +17,7 @@
   	<repositories>
 		<repository>
 			<id>OSGi Snapshots</id>
-			<url></url>
+			<url>https://oss.sonatype.org/content/groups/osgi</url>
 			<releases>
 				<enabled>false</enabled>
 			</releases>

--- a/org.eclipse.paho.mqttv5.testclient/pom.xml
+++ b/org.eclipse.paho.mqttv5.testclient/pom.xml
@@ -13,6 +13,20 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
+  
+  	<repositories>
+		<repository>
+			<id>OSGi Snapshots</id>
+			<url></url>
+			<releases>
+				<enabled>false</enabled>
+			</releases>
+			<snapshots>
+				<enabled>true</enabled>
+			</snapshots>
+		</repository>
+	</repositories>
+  
   <dependencies>
     <dependency>
       <groupId>junit</groupId>
@@ -21,10 +35,20 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-			<groupId>org.osgi</groupId>
-			<artifactId>osgi.promise</artifactId>
-			<version>6.0.0</version>
-		</dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.util.promise</artifactId>
+      <version>1.1.0-SNAPSHOT</version>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.util.function</artifactId>
+      <version>1.1.0-SNAPSHOT</version>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.util.pushstream</artifactId>
+      <version>1.0.0-SNAPSHOT</version>
+    </dependency>
     <dependency>
     	<groupId>org.eclipse.paho</groupId>
     	<artifactId>org.eclipse.paho.mqttv5.client</artifactId>

--- a/org.eclipse.paho.mqttv5.testclient/src/main/java/org/eclipse/paho/mqttv5/testclient/AlphaClientTestWithPromisesAndPushStreams.java
+++ b/org.eclipse.paho.mqttv5.testclient/src/main/java/org/eclipse/paho/mqttv5/testclient/AlphaClientTestWithPromisesAndPushStreams.java
@@ -1,0 +1,93 @@
+package org.eclipse.paho.mqttv5.testclient;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.time.temporal.ChronoUnit.SECONDS;
+
+import java.lang.reflect.InvocationTargetException;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Optional;
+
+import org.eclipse.paho.mqttv5.client.MqttConnectionOptions;
+import org.eclipse.paho.mqttv5.client.alpha.IMqttToken;
+import org.eclipse.paho.mqttv5.client.alpha.MqttAsyncClient;
+import org.eclipse.paho.mqttv5.client.alpha.result.IMqttConnectionResult;
+import org.eclipse.paho.mqttv5.client.alpha.result.IMqttSubscriptionResult;
+import org.eclipse.paho.mqttv5.common.MqttException;
+import org.osgi.util.promise.Promise;
+
+public class AlphaClientTestWithPromisesAndPushStreams {
+
+	public static void main(String[] args) throws MqttException, InterruptedException, InvocationTargetException {
+		String broker = "tcp://localhost:1883";
+		String clientId = "TestV5Client";
+
+		String topic = "MQTT Examples";
+		String content = "Message from MqttPublishSample";
+		int qos = 2;
+
+		// MqttAsyncClient asyncClient = new MqttAsyncClient(broker, clientId,
+		// persistence);
+
+		// Test for Server Generated Client ID
+		MqttAsyncClient asyncClient = new MqttAsyncClient(broker, clientId);
+		MqttConnectionOptions connOpts = new MqttConnectionOptions();
+		connOpts.setCleanSession(true);
+		System.out.println("Connecting to broker: " + broker);
+
+
+		IMqttToken<IMqttConnectionResult<Void>, Void> token = asyncClient.connect(connOpts);
+
+		Promise<Optional<String>> result = token.getPromise().then(p -> {
+				// Print the ConAck Properties
+				printConnectDetails(p.getValue());
+				// Do a retained send
+				return asyncClient.publish(topic, content.getBytes(UTF_8), qos, true).getPromise();
+			}).then(p ->  {
+				System.out.println("Delivered");
+				
+				// Subscribe and decode the message
+				return asyncClient.subscribe(topic, 2).getStream()
+						// Give up after 10 seconds with no message
+						.timeout(Duration.of(10, SECONDS))
+						// Get the payload
+						.map(msg -> msg.payload())
+						// Turn the payload back into a String
+						.map(b -> UTF_8.decode(b).toString())
+						// Finish once we receive the first message
+						.findFirst();
+			});
+
+
+		System.out.println("Received the message " + result.getValue().get());
+
+		asyncClient.disconnect().getPromise().getValue();
+		System.out.println("Disconnected");
+
+	}
+
+	public static void printSubscriptionDetails(IMqttSubscriptionResult<Void> result) {
+		System.out.println("Subscription Response: [qos=" + Arrays.toString(result.getGrantedQos()) + "]");
+//		System.out.println("Subscription Response: [reasonString=" + token.getReasonString() + ", user"
+//				+ ", userDefinedProperties=" + token.getUserDefinedProperties());
+
+	}
+
+	public static void printConnectDetails(IMqttConnectionResult<Void> token) {
+		
+		System.out.println("Connection Response: [ sessionPresent=" + token.getSessionPresent() + "]");
+		
+//		System.out.println("Connection Response: [ sessionPresent=" + token.getSessionPresent() + ", responseInfo="
+//				+ token.getResponseInformation() + ", assignedClientIdentifier=" + token.getAssignedClientIdentifier()
+//				+ ", serverKeepAlive=" + token.getServerKeepAlive() + ", authMethod=" + token.getAuthMethod()
+//				+ ", authData=" + token.getAuthData() + ", serverReference=" + token.getServerReference()
+//				+ ", reasonString=" + token.getReasonString() + ", recieveMaximum=" + token.getRecieveMaximum()
+//				+ ", topicAliasMaximum=" + token.getTopicAliasMaximum() + ", maximumQoS=" + token.getMaximumQoS()
+//				+ ", retainAvailable=" + token.isRetainAvailable() + ", userDefinedProperties="
+//				+ token.getUserDefinedProperties() + ", maxPacketSize=" + token.getMaximumPacketSize()
+//				+ ", wildcardSubscriptionAvailable=" + token.isWildcardSubscriptionAvailable()
+//				+ ", subscriptionIdentifiersAvailable=" + token.isSubscriptionIdentifiersAvailable()
+//				+ ", sharedSubscriptionAvailable=" + token.isSharedSubscriptionAvailable() + "]");
+	}
+
+}


### PR DESCRIPTION
This commit adds an example API based purely on Promises and PushStreams. It removes the lifecycle and callback management from the MQTTToken, using it instead as a holder for static information. This allows the API to be simplified quite a lot, and for the API to start using immutable types when calling back into client code.

The new API is in the `org.eclipse.paho.mqttv5.client.alpha package`, and the `MqttAsyncClient` is a simple adapter from the old API to the alpha API. Everything should be using generics to ensure type safety, but I'm sure that a more optimal implementation would be possible with some work in the core code.

There is a simple example of using the code in the test client. As per my comments in issue #389 I'm happy to answer questions, and I thought a concrete example of using Promises/streams might prove helpful.

Signed-off-by: Tim Ward <timothyjward@apache.org>

