### PR TITLE
Update to the latest OSGi snapshot changes to ensure efficient use of threads

### DIFF
--- a/org.eclipse.paho.mqttv5.client/src/main/java/org/eclipse/paho/mqttv5/client/alpha/internal/MqttDeliveryToken.java
+++ b/org.eclipse.paho.mqttv5.client/src/main/java/org/eclipse/paho/mqttv5/client/alpha/internal/MqttDeliveryToken.java
@@ -1,21 +1,19 @@
 package org.eclipse.paho.mqttv5.client.alpha.internal;
 
-import java.util.concurrent.Executor;
-import java.util.concurrent.ScheduledExecutorService;
-
 import org.eclipse.paho.mqttv5.client.alpha.IMqttCommonClient;
 import org.eclipse.paho.mqttv5.client.alpha.IMqttDeliveryToken;
 import org.eclipse.paho.mqttv5.client.alpha.IMqttMessage;
 import org.eclipse.paho.mqttv5.client.alpha.result.IMqttDeliveryResult;
 import org.eclipse.paho.mqttv5.common.MqttException;
+import org.osgi.util.promise.PromiseExecutors;
 
 public class MqttDeliveryToken<C> extends MqttToken<IMqttDeliveryResult<C>, C> implements IMqttDeliveryToken<C> {
 
 	private final IMqttMessage message;
 
-	public MqttDeliveryToken(Executor executor, ScheduledExecutorService scheduler, IMqttCommonClient client,
+	public MqttDeliveryToken(PromiseExecutors promiseExecutors, IMqttCommonClient client,
 			C userContext, int messageId, IMqttMessage message) {
-		super(executor, scheduler, client, userContext, messageId);
+		super(promiseExecutors, client, userContext, messageId);
 		this.message = message;
 	}
 

--- a/org.eclipse.paho.mqttv5.client/src/main/java/org/eclipse/paho/mqttv5/client/alpha/internal/MqttSubscriptionToken.java
+++ b/org.eclipse.paho.mqttv5.client/src/main/java/org/eclipse/paho/mqttv5/client/alpha/internal/MqttSubscriptionToken.java
@@ -2,8 +2,6 @@ package org.eclipse.paho.mqttv5.client.alpha.internal;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.Executor;
-import java.util.concurrent.ScheduledExecutorService;
 
 import org.eclipse.paho.mqttv5.client.alpha.IMqttCommonClient;
 import org.eclipse.paho.mqttv5.client.alpha.IMqttSubscriptionToken;
@@ -13,6 +11,7 @@ import org.eclipse.paho.mqttv5.client.alpha.result.IMqttUnsubscriptionResult;
 import org.eclipse.paho.mqttv5.common.MqttException;
 import org.osgi.util.promise.Deferred;
 import org.osgi.util.promise.Promise;
+import org.osgi.util.promise.PromiseExecutors;
 import org.osgi.util.pushstream.PushStream;
 
 public class MqttSubscriptionToken<C> extends MqttToken<IMqttSubscriptionResult<C>, C>
@@ -23,9 +22,9 @@ public class MqttSubscriptionToken<C> extends MqttToken<IMqttSubscriptionResult<
 	
 	private final Deferred<IMqttUnsubscriptionResult<C>> d = new Deferred<>();
 	
-	public MqttSubscriptionToken(Executor executor, ScheduledExecutorService scheduler, IMqttCommonClient client,
+	public MqttSubscriptionToken(PromiseExecutors promiseExecutors, IMqttCommonClient client,
 			C userContext, List<String> topics, PushStream<IReceivedMessage<C>> stream) {
-		super(executor, scheduler, client, userContext, 0);
+		super(promiseExecutors, client, userContext, 0);
 		this.topics = Collections.unmodifiableList(topics);
 		this.stream = stream;
 	}

--- a/org.eclipse.paho.mqttv5.client/src/main/java/org/eclipse/paho/mqttv5/client/alpha/internal/MqttToken.java
+++ b/org.eclipse.paho.mqttv5.client/src/main/java/org/eclipse/paho/mqttv5/client/alpha/internal/MqttToken.java
@@ -1,13 +1,11 @@
 package org.eclipse.paho.mqttv5.client.alpha.internal;
 
-import java.util.concurrent.Executor;
-import java.util.concurrent.ScheduledExecutorService;
-
 import org.eclipse.paho.mqttv5.client.alpha.IMqttCommonClient;
 import org.eclipse.paho.mqttv5.client.alpha.IMqttToken;
 import org.eclipse.paho.mqttv5.client.alpha.result.IMqttResult;
 import org.osgi.util.promise.Deferred;
 import org.osgi.util.promise.Promise;
+import org.osgi.util.promise.PromiseExecutors;
 
 public class MqttToken<T extends IMqttResult<C>, C> implements IMqttToken<T, C> {
 
@@ -19,9 +17,9 @@ public class MqttToken<T extends IMqttResult<C>, C> implements IMqttToken<T, C> 
 	
 	private final int messageId;
 	
-	public MqttToken(Executor executor, ScheduledExecutorService scheduler, 
+	public MqttToken(PromiseExecutors promiseExecutors, 
 			IMqttCommonClient client, C userContext, int messageId) {
-		this.deferred = new Deferred<>(executor, scheduler);
+		this.deferred = promiseExecutors.deferred();
 		this.client = client;
 		this.userContext = userContext;
 		this.messageId = messageId;


### PR DESCRIPTION
There have been some minor API updates in the OSGi Promise 1.1 and Pushstream libraries to help better encapsulate threading. These should be used in the Paho code.

Signed-off-by: Tim Ward <timothyjward@apache.org>

Please make sure that the following boxes are checked before submitting your Pull Request, thank you!

- [x] You have signed the [Eclipse ECA](https://wiki.eclipse.org/ECA)
- [x] All of your commits have been signed-off with the correct email address (The same one that you used to sign the CLA)
- [x] If This PR fixes an issue, that you reference the issue below. OR if this is a new issue that you are fixing straight away that you add some Description about the bug and how this will fix it.
- [x] If this is new functionality, You have added the appropriate Unit tests.
