### PR TITLE
FIX TCPNetworkModule for proxy support

### DIFF
--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/TCPNetworkModule.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/TCPNetworkModule.java
@@ -76,9 +76,16 @@ public class TCPNetworkModule implements NetworkModule {
 			SocketAddress sockaddr = new InetSocketAddress(host, port);
 			if (factory instanceof SSLSocketFactory) {
 				// SNI support
-				Socket tempsocket = new Socket();
-				tempsocket.connect(sockaddr, conTimeout*1000);
-				socket = ((SSLSocketFactory)factory).createSocket(tempsocket, host, port, true);
+				Socket tempsocket = null;
+				try {
+					tempsocket = new Socket();
+					tempsocket.connect(sockaddr, conTimeout*1000);
+					socket = ((SSLSocketFactory)factory).createSocket(tempsocket, host, port, true);
+				} catch (Exception exc) {
+					// problem with socket generation
+					tempsocket.close();
+					socket = ((SSLSocketFactory)factory).createSocket(null, host, port, true);
+				}
 			} else {
 				socket = factory.createSocket();
 				socket.connect(sockaddr, conTimeout*1000);


### PR DESCRIPTION
ve got a problem with proxy support... The socket connect try to resolve the host but this cannot be done on the network (only my proxy can do it).
So a created a patch that try without the direct socket connection if this do not work!