### PR TITLE
Added topic subscription with null handlers

### DIFF
--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/MqttAsyncClient.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/MqttAsyncClient.java
@@ -1141,9 +1141,14 @@ public class MqttAsyncClient implements IMqttAsyncClient {
 
 		IMqttToken token = this.subscribe(topicFilters, qos, userContext, callback);
 
-		// add message handlers to the list for this client
+		// add or remove message handlers to the list for this client
 		for (int i = 0; i < topicFilters.length; ++i) {
-			this.comms.setMessageListener(topicFilters[i], messageListeners[i]);
+            if (messageListeners[i] == null) {
+                this.comms.removeMessageListener(topicFilters[i]);
+            }
+            else {
+                this.comms.setMessageListener(topicFilters[i], messageListeners[i]);
+            }
 		}
 
 		return token;

--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/MqttClient.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/MqttClient.java
@@ -468,9 +468,14 @@ public class MqttClient implements IMqttClient { //), DestinationProvider {
 	public void subscribe(String[] topicFilters, int[] qos, IMqttMessageListener[] messageListeners) throws MqttException {
 		this.subscribe(topicFilters, qos);
 
-		// add message handlers to the list for this client
+		// add or remove message handlers to the list for this client
 		for (int i = 0; i < topicFilters.length; ++i) {
-			aClient.comms.setMessageListener(topicFilters[i], messageListeners[i]);
+            if (messageListeners[i] == null) {
+                aClient.comms.removeMessageListener(topicFilters[i]);
+            }
+            else {
+                aClient.comms.setMessageListener(topicFilters[i], messageListeners[i]);
+            }
 		}
 	}
 
@@ -542,10 +547,16 @@ public class MqttClient implements IMqttClient { //), DestinationProvider {
 			throws MqttException {
 		IMqttToken tok = this.subscribeWithResponse(topicFilters, qos);
 
-		// add message handlers to the list for this client
+		// add or remove message handlers to the list for this client
 		for (int i = 0; i < topicFilters.length; ++i) {
-			aClient.comms.setMessageListener(topicFilters[i], messageListeners[i]);
+            if (messageListeners[i] == null) {
+                aClient.comms.removeMessageListener(topicFilters[i]);
+            }
+            else {
+                aClient.comms.setMessageListener(topicFilters[i], messageListeners[i]);
+            }
 		}
+
 		return tok;
 	}
 


### PR DESCRIPTION
Clients can now subscribe to several topics at once and provide IMqttMessageListener's only for the needed topics. A null value means the current handler will simply be removed.

Prior to this pull request, receiving a message for a topic where a null IMqttMessageListener has been registested would throw a NullPointerException. The expected behavior is rather that in absence of a specific handler, the message would be dispatched to the provided MqttCallback.


Please make sure that the following boxes are checked before submitting your Pull Request, thank you!

- [x] You have signed the [Eclipse ECA](https://wiki.eclipse.org/ECA)
- [x] All of your commits have been signed-off with the correct email address (The same one that you used to sign the CLA)
- [x] If This PR fixes an issue, that you reference the issue below. OR if this is a new issue that you are fixing straight away that you add some Description about the bug and how this will fix it.
- [x] If this is new functionality, You have added the appropriate Unit tests.
