### PR TITLE
Refactor NetworkModule creation; support custom protocols/schemes

### DIFF
--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/network/NetworkModuleFactory.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/network/NetworkModuleFactory.java
@@ -1,0 +1,106 @@
+package org.eclipse.paho.client.mqttv3.network;
+
+import org.eclipse.paho.client.mqttv3.MqttConnectOptions;
+import org.eclipse.paho.client.mqttv3.MqttException;
+import org.eclipse.paho.client.mqttv3.internal.NetworkModule;
+import org.eclipse.paho.client.mqttv3.logging.Logger;
+import org.eclipse.paho.client.mqttv3.logging.LoggerFactory;
+
+import java.lang.reflect.Field;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Aggregates all {@link ProtocolModuleFactory} implementations
+ */
+public class NetworkModuleFactory {
+
+    private static final String CLASS_NAME = NetworkModuleFactory.class.getName();
+    private static final Logger log = LoggerFactory.getLogger(LoggerFactory.MQTT_CLIENT_MSG_CAT, CLASS_NAME);
+
+    private Map<String, ProtocolModuleFactory> factories;
+
+    private static NetworkModuleFactory INSTANCE;
+
+    public static NetworkModuleFactory getInstance() {
+        if (INSTANCE == null) {
+            Map<String, ProtocolModuleFactory> factories = new HashMap<>();
+            factories.put("tcp", new TCPModuleFactory());
+            factories.put("ssl", new SSLModuleFactory());
+            factories.put("ws", new WebSocketModuleFactory());
+            factories.put("wss", new WebSocketSecureModuleFactory());
+            INSTANCE = new NetworkModuleFactory(factories);
+        }
+        return INSTANCE;
+    }
+
+    private NetworkModuleFactory(Map<String, ProtocolModuleFactory> factories) {
+        this.factories = factories;
+    }
+
+    /**
+     * This method should be called if custom protocols are implemented - support for each of
+     * them requires single implementation of ProtocolModuleFactory interface.
+     * @param scheme scheme (e.g. "tcp", "ws")
+     * @param factory implementation of {@link ProtocolModuleFactory} for specified scheme
+     *
+     */
+    public static void addFactory(String scheme, ProtocolModuleFactory factory) {
+        getInstance().factories.put(scheme, factory);
+    }
+
+    public void validateURI(String address) { // for validation only
+        URI uri = parseURI(address);
+        validateURI(uri);
+    }
+
+    private void validateURI(URI uri) {
+        if (!factories.containsKey(uri.getScheme())) {
+            throw new IllegalArgumentException("Unknown scheme \"" + uri.getScheme() + "\" of URI \"" + uri + "\"");
+        }
+        factories.get(uri.getScheme()).validateURI(uri);
+    }
+
+    public NetworkModule create(String address, MqttConnectOptions options, String clientId) throws MqttException {
+        URI uri = parseURI(address);
+        validateURI(uri);
+        return factories.get(uri.getScheme()).create(uri, address, clientId, options);
+
+    }
+
+    private URI parseURI(String address) {
+        try {
+            URI uri = new URI(address);
+            // If the returned uri contains no host and the address contains underscores,
+            // then it's likely that Java did not parse the URI
+            if(uri.getHost() == null && address.contains("_")){
+                try {
+                    final Field hostField = URI.class.getDeclaredField("host");
+                    hostField.setAccessible(true);
+                    // Get everything after the scheme://
+                    String shortAddress = address.substring(uri.getScheme().length() + 3);
+                    hostField.set(uri, getHostName(shortAddress));
+                } catch (ReflectiveOperationException e) {
+                    throw new IllegalArgumentException(e);
+                }
+
+            }
+            return uri;
+        } catch (URISyntaxException e) {
+            throw new IllegalArgumentException("Can't parse string to URI \"" + address + "\"", e);
+        }
+    }
+
+    private String getHostName(String uri) {
+        int portIndex = uri.indexOf(':');
+        if (portIndex == -1) {
+            portIndex = uri.indexOf('/');
+        }
+        if (portIndex == -1) {
+            portIndex = uri.length();
+        }
+        return uri.substring(0, portIndex);
+    }
+}

--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/network/ProtocolModuleFactory.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/network/ProtocolModuleFactory.java
@@ -1,0 +1,19 @@
+package org.eclipse.paho.client.mqttv3.network;
+
+import org.eclipse.paho.client.mqttv3.MqttConnectOptions;
+import org.eclipse.paho.client.mqttv3.MqttException;
+import org.eclipse.paho.client.mqttv3.internal.NetworkModule;
+
+import java.net.URI;
+
+/**
+ * Each of its implementation should be able to produce {@link NetworkModule} for a single protocol: e.g. SSL, Websocket
+ */
+public interface ProtocolModuleFactory {
+    /**
+     * Assuming that URI has scheme that matches this factory, validate if it is otherwise correct
+     */
+    void validateURI(URI uri);
+
+    NetworkModule create(URI uri, String address, String clientId, MqttConnectOptions options) throws MqttException;
+}

--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/network/SSLModuleFactory.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/network/SSLModuleFactory.java
@@ -1,0 +1,61 @@
+package org.eclipse.paho.client.mqttv3.network;
+
+import org.eclipse.paho.client.mqttv3.MqttConnectOptions;
+import org.eclipse.paho.client.mqttv3.MqttException;
+import org.eclipse.paho.client.mqttv3.internal.ExceptionHelper;
+import org.eclipse.paho.client.mqttv3.internal.NetworkModule;
+import org.eclipse.paho.client.mqttv3.internal.SSLNetworkModule;
+import org.eclipse.paho.client.mqttv3.internal.security.SSLSocketFactoryFactory;
+
+import javax.net.SocketFactory;
+import javax.net.ssl.SSLSocketFactory;
+import java.net.URI;
+import java.util.Properties;
+
+public class SSLModuleFactory implements ProtocolModuleFactory {
+
+    @Override
+    public void validateURI(URI uri) {
+        if (uri.getPath() != null && !uri.getPath().isEmpty()) {
+            throw new IllegalArgumentException("URI path must be empty in SSL scheme: \"" + uri + "\"");
+        }
+    }
+
+    @Override
+    public NetworkModule create(URI uri, String address, String clientId, MqttConnectOptions options) throws MqttException {
+        int port = uri.getPort();
+        if (port == -1) {
+            port = 8883;
+        }
+        SocketFactory factory = options.getSocketFactory();
+        SSLSocketFactoryFactory factoryFactory = null;
+        if (factory == null) {
+//				try {
+            factoryFactory = new SSLSocketFactoryFactory();
+            Properties sslClientProps = options.getSSLProperties();
+            if (null != sslClientProps)
+                factoryFactory.initialize(sslClientProps, null);
+            factory = factoryFactory.createSocketFactory(null);
+//				}
+//				catch (MqttDirectException ex) {
+//					throw ExceptionHelper.createMqttException(ex.getCause());
+//				}
+        }
+        else if (!(factory instanceof SSLSocketFactory)) {
+            throw ExceptionHelper.createMqttException(MqttException.REASON_CODE_SOCKET_FACTORY_MISMATCH);
+        }
+
+        // Create the network module...
+        SSLNetworkModule netModule = new SSLNetworkModule((SSLSocketFactory) factory, uri.getHost(), port, clientId);
+        ((SSLNetworkModule)netModule).setSSLhandshakeTimeout(options.getConnectionTimeout());
+        ((SSLNetworkModule)netModule).setSSLHostnameVerifier(options.getSSLHostnameVerifier());
+        // Ciphers suites need to be set, if they are available
+        if (factoryFactory != null) {
+            String[] enabledCiphers = factoryFactory.getEnabledCipherSuites(null);
+            if (enabledCiphers != null) {
+                ((SSLNetworkModule) netModule).setEnabledCiphers(enabledCiphers);
+            }
+        }
+        return netModule;
+    }
+}

--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/network/TCPModuleFactory.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/network/TCPModuleFactory.java
@@ -1,0 +1,39 @@
+package org.eclipse.paho.client.mqttv3.network;
+
+import org.eclipse.paho.client.mqttv3.MqttConnectOptions;
+import org.eclipse.paho.client.mqttv3.MqttException;
+import org.eclipse.paho.client.mqttv3.internal.ExceptionHelper;
+import org.eclipse.paho.client.mqttv3.internal.NetworkModule;
+import org.eclipse.paho.client.mqttv3.internal.TCPNetworkModule;
+
+import javax.net.SocketFactory;
+import javax.net.ssl.SSLSocketFactory;
+import java.net.URI;
+
+public class TCPModuleFactory implements ProtocolModuleFactory {
+
+    @Override
+    public void validateURI(URI uri) {
+        if (uri.getPath() != null && !uri.getPath().isEmpty()) {
+            throw new IllegalArgumentException("URI path must be empty in TCP scheme: \"" + uri + "\"");
+        }
+    }
+
+    @Override
+    public NetworkModule create(URI uri, String address, String clientId, MqttConnectOptions options) throws MqttException {
+        int port = uri.getPort();
+        if (port == -1) {
+            port = 1883;
+        }
+        SocketFactory factory = options.getSocketFactory();
+        if (factory == null) {
+            factory = SocketFactory.getDefault();
+        }
+        else if (factory instanceof SSLSocketFactory) {
+            throw ExceptionHelper.createMqttException(MqttException.REASON_CODE_SOCKET_FACTORY_MISMATCH);
+        }
+        TCPNetworkModule netModule = new TCPNetworkModule(factory, uri.getHost(), port, clientId);
+        netModule.setConnectTimeout(options.getConnectionTimeout());
+        return netModule;
+    }
+}

--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/network/WebSocketModuleFactory.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/network/WebSocketModuleFactory.java
@@ -1,0 +1,35 @@
+package org.eclipse.paho.client.mqttv3.network;
+
+import org.eclipse.paho.client.mqttv3.MqttConnectOptions;
+import org.eclipse.paho.client.mqttv3.MqttException;
+import org.eclipse.paho.client.mqttv3.internal.ExceptionHelper;
+import org.eclipse.paho.client.mqttv3.internal.NetworkModule;
+import org.eclipse.paho.client.mqttv3.internal.websocket.WebSocketNetworkModule;
+
+import javax.net.SocketFactory;
+import javax.net.ssl.SSLSocketFactory;
+import java.net.URI;
+
+public class WebSocketModuleFactory implements ProtocolModuleFactory {
+    @Override
+    public void validateURI(URI uri) {
+    }
+
+    @Override
+    public NetworkModule create(URI uri, String address, String clientId, MqttConnectOptions options) throws MqttException {
+        int port = uri.getPort();
+        if (port == -1) {
+            port = 80;
+        }
+        SocketFactory factory = options.getSocketFactory();
+        if (factory == null) {
+            factory = SocketFactory.getDefault();
+        }
+        else if (factory instanceof SSLSocketFactory) {
+            throw ExceptionHelper.createMqttException(MqttException.REASON_CODE_SOCKET_FACTORY_MISMATCH);
+        }
+        WebSocketNetworkModule netModule = new WebSocketNetworkModule(factory, address, uri.getHost(), port, clientId);
+        netModule.setConnectTimeout(options.getConnectionTimeout());
+        return netModule;
+    }
+}

--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/network/WebSocketSecureModuleFactory.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/network/WebSocketSecureModuleFactory.java
@@ -1,0 +1,52 @@
+package org.eclipse.paho.client.mqttv3.network;
+
+import org.eclipse.paho.client.mqttv3.MqttConnectOptions;
+import org.eclipse.paho.client.mqttv3.MqttException;
+import org.eclipse.paho.client.mqttv3.internal.ExceptionHelper;
+import org.eclipse.paho.client.mqttv3.internal.NetworkModule;
+import org.eclipse.paho.client.mqttv3.internal.security.SSLSocketFactoryFactory;
+import org.eclipse.paho.client.mqttv3.internal.websocket.WebSocketSecureNetworkModule;
+
+import javax.net.SocketFactory;
+import javax.net.ssl.SSLSocketFactory;
+import java.net.URI;
+import java.util.Properties;
+
+public class WebSocketSecureModuleFactory implements ProtocolModuleFactory {
+    @Override
+    public void validateURI(URI uri) {
+    }
+
+    @Override
+    public NetworkModule create(URI uri, String address, String clientId, MqttConnectOptions options) throws MqttException {
+        int port = uri.getPort();
+        if (port == -1) {
+            port = 443;
+        }
+        SSLSocketFactoryFactory wSSFactoryFactory = null;
+        SocketFactory factory = options.getSocketFactory();
+        if (factory == null) {
+            wSSFactoryFactory = new SSLSocketFactoryFactory();
+            Properties sslClientProps = options.getSSLProperties();
+            if (null != sslClientProps)
+                wSSFactoryFactory.initialize(sslClientProps, null);
+            factory = wSSFactoryFactory.createSocketFactory(null);
+
+        }
+        else if (!(factory instanceof SSLSocketFactory)) {
+            throw ExceptionHelper.createMqttException(MqttException.REASON_CODE_SOCKET_FACTORY_MISMATCH);
+        }
+
+        // Create the network module...
+        WebSocketSecureNetworkModule netModule = new WebSocketSecureNetworkModule((SSLSocketFactory) factory, address, uri.getHost(), port, clientId);
+        netModule.setSSLhandshakeTimeout(options.getConnectionTimeout());
+        // Ciphers suites need to be set, if they are available
+        if (wSSFactoryFactory != null) {
+            String[] enabledCiphers = wSSFactoryFactory.getEnabledCipherSuites(null);
+            if (enabledCiphers != null) {
+                netModule.setEnabledCiphers(enabledCiphers);
+            }
+        }
+        return netModule;
+    }
+}


### PR DESCRIPTION
- [x] You have signed the [Eclipse ECA](https://wiki.eclipse.org/ECA)
- [x] All of your commits have been signed-off with the correct email address (The same one that you used to sign the CLA)
- [x] If This PR fixes an issue, that you reference the issue below. OR if this is a new issue that you are fixing straight away that you add some Description about the bug and how this will fix it.
- [-] If this is new functionality, You have added the appropriate Unit tests.

Implements #486
Creating network modules is now split into protocol-specific classes
Custom protocol-specific implementations can be added
Removed dead code