### PR TITLE
Update target Eclipse version to Mars (fix Jenkins build)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 		<build.level>${maven.build.timestamp}</build.level>
 		<tycho.version>1.1.0</tycho.version>
 		<junit.version>4.12</junit.version>
-		<kepler.repo.url>http://download.eclipse.org/releases/kepler</kepler.repo.url>
+		<mars.repo.url>http://download.eclipse.org/releases/mars</mars.repo.url>
 		<test.exclude>**/*ConformantTest.java</test.exclude>
 		<download.location>/home/data/httpd/download.eclipse.org/paho/releases/${project.version}/Java</download.location>
 	</properties>
@@ -58,8 +58,8 @@
 
 	<repositories>
 		<repository>
-			<id>eclipse-kepler</id>
-			<url>${kepler.repo.url}</url>
+			<id>eclipse-mars</id>
+			<url>${mars.repo.url}</url>
 			<layout>p2</layout>
 		</repository>
 	</repositories>


### PR DESCRIPTION
The updated tycho library requires Mars Eclipse or newer

Signed-off-by: Daniel Dylag <bisker@op.pl>

Please make sure that the following boxes are checked before submitting your Pull Request, thank you!

- [x] You have signed the [Eclipse ECA](https://wiki.eclipse.org/ECA)
- [x] All of your commits have been signed-off with the correct email address (The same one that you used to sign the CLA)
- [x] If This PR fixes an issue, that you reference the issue below. OR if this is a new issue that you are fixing straight away that you add some Description about the bug and how this will fix it.

The latest changes in library versions cause the Maven build to fail on Jenkins. This fixes the problem
