### PR TITLE
Delete ussername constraints that does not match in the MQTT v3.1.1 r…

### DIFF
--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/MqttConnectOptions.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/MqttConnectOptions.java
@@ -128,13 +128,8 @@ public class MqttConnectOptions {
 	/**
 	 * Sets the user name to use for the connection.
 	 * @param userName The Username as a String
-	 * @throws IllegalArgumentException if the user name is blank or only
-	 * contains whitespace characters.
 	 */
 	public void setUserName(String userName) {
-		if ((userName != null) && (userName.trim().equals(""))) {
-			throw new IllegalArgumentException();
-		}
 		this.userName = userName;
 	}
 


### PR DESCRIPTION
…equirements.

Signed-off-by: ogis-yamazaki <Yamazaki_Shoji@ogis-ri.co.jp>

Please make sure that the following boxes are checked before submitting your Pull Request, thank you!

- [x] You have signed the [Eclipse ECA](https://wiki.eclipse.org/ECA)
- [x] All of your commits have been signed-off with the correct email address (The same one that you used to sign the CLA)
- [x] If This PR fixes an issue, that you reference the issue below. OR if this is a new issue that you are fixing straight away that you add some Description about the bug and how this will fix it.
- [ ] If this is new functionality, You have added the appropriate Unit tests.

Delete ussername constraints that does not match in the MQTT v3.1.1 requirements.
---------------------------------------------------------------------------------------------------------------

### changes

Removed username length 0 check.

### reason 

1. Username string of length 0 is allowed.
2. Space (U+0020)is also allowed as UTF 8 characters. shuld not trim space.

The following is the definition.

OASIS MQTT v3.1.1
http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc398718031

>3.1.3.4 User Name
>
>If the User Name Flag is set to 1, this is the next field in the payload. The User Name MUST be a UTF-8 encoded string as defined in Section 1.5.3 [MQTT-3.1.3-11]. 
>>1.5.3 UTF-8 encoded strings
>>
>>Text fields in the Control Packets described later are encoded as UTF-8 strings. UTF-8 [RFC3629] is an efficient encoding of Unicode [Unicode] characters that optimizes the encoding of ASCII characters in support of text-based communications.
>>
>>Each of these strings is prefixed with a two byte length field that gives the number of bytes in a UTF-8 encoded string itself, as illustrated in Figure 1.1 Structure of UTF-8 encoded strings below. Consequently there is a limit on the size of a string that can be passed in one of these UTF-8 encoded string components; you cannot use a string that would encode to more than 65535 bytes.
>>
>>Unless stated otherwise all UTF-8 encoded strings can have any length in the range 0 to 65535 bytes.


