### PR TITLE
 added custom headers support for websocket connection

### DIFF
--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/MqttAsyncClient.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/MqttAsyncClient.java
@@ -636,6 +636,7 @@ public class MqttAsyncClient implements IMqttAsyncClient {
 			}
 			netModule = new WebSocketNetworkModule(factory, address, host, port, clientId);
 			((WebSocketNetworkModule)netModule).setConnectTimeout(options.getConnectionTimeout());
+			((WebSocketNetworkModule)netModule).setCustomHeaders(options.getCustomHeaders());
 			break;
 		case MqttConnectOptions.URI_TYPE_WSS:
 			if (port == -1) {
@@ -655,8 +656,10 @@ public class MqttAsyncClient implements IMqttAsyncClient {
 			}
 
 			// Create the network module...
+
 			netModule = new WebSocketSecureNetworkModule((SSLSocketFactory) factory, address, host, port, clientId);
 			((WebSocketSecureNetworkModule)netModule).setSSLhandshakeTimeout(options.getConnectionTimeout());
+			((WebSocketSecureNetworkModule)netModule).setCustomHeaders(options.getCustomHeaders());
 			// Ciphers suites need to be set, if they are available
 			if (wSSFactoryFactory != null) {
 				String[] enabledCiphers = wSSFactoryFactory.getEnabledCipherSuites(null);

--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/MqttConnectOptions.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/MqttConnectOptions.java
@@ -17,6 +17,7 @@
  */
 package org.eclipse.paho.client.mqttv3;
 
+import java.util.Map;
 import java.util.Properties;
 
 import javax.net.SocketFactory;
@@ -80,7 +81,7 @@ public class MqttConnectOptions {
 	private String[] serverURIs = null;
 	private int MqttVersion = MQTT_VERSION_DEFAULT;
 	private boolean automaticReconnect = false;
-
+	private Properties customHeaders = null;
 	/**
 	 * Constructs a new <code>MqttConnectOptions</code> object using the
 	 * default values.
@@ -627,7 +628,22 @@ public class MqttConnectOptions {
 		return p;
 	}
 
+	/**
+	 * Sets the Custom Headers for the WebSocket Connection.
+	 * @param props The custom headers {@link Properties}
+	 */
+	public void setCustomHeaders(Properties props) {
+		this.customHeaders = props;
+	}
+
+	public Properties getCustomHeaders() {
+		return customHeaders;
+	}
+
 	public String toString() {
 		return Debug.dumpProperties(getDebug(), "Connection options");
 	}
+
+
+
 }

--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/websocket/WebSocketHandshake.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/websocket/WebSocketHandshake.java
@@ -25,10 +25,8 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.UUID;
+import java.util.*;
+
 /**
  * Helper class to execute a WebSocket Handshake.
  */
@@ -52,14 +50,15 @@ public class WebSocketHandshake {
 	String uri;
 	String host;
 	int port;
+	Properties customHeaders;
 
-
-	public WebSocketHandshake(InputStream input, OutputStream output, String uri, String host, int port){
+	public WebSocketHandshake(InputStream input, OutputStream output, String uri, String host, int port, Properties customHeaders){
 		this.input = input;
 		this.output = output;
 		this.uri = uri;
 		this.host = host;
 		this.port = port;
+		this.customHeaders = customHeaders;
 	}
 
 
@@ -107,6 +106,16 @@ public class WebSocketHandshake {
 			pw.print("Sec-WebSocket-Key: " + key + LINE_SEPARATOR);
 			pw.print("Sec-WebSocket-Protocol: mqtt" + LINE_SEPARATOR);
 			pw.print("Sec-WebSocket-Version: 13" + LINE_SEPARATOR);
+
+			if (customHeaders != null) {
+				Set keys = customHeaders.keySet();
+				Iterator i = keys.iterator();
+				while (i.hasNext()) {
+					String k = (String) i.next();
+					String value = customHeaders.getProperty(k);
+					pw.print(k+": " + value + LINE_SEPARATOR);
+				}
+			}
 
 			String userInfo = srvUri.getUserInfo();
 			if(userInfo != null) {

--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/websocket/WebSocketNetworkModule.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/websocket/WebSocketNetworkModule.java
@@ -21,6 +21,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.PipedInputStream;
 import java.nio.ByteBuffer;
+import java.util.Properties;
 
 import javax.net.SocketFactory;
 
@@ -37,6 +38,7 @@ public class WebSocketNetworkModule extends TCPNetworkModule {
 	private String uri;
 	private String host;
 	private int port;
+	private Properties customHeaders;
 	private PipedInputStream pipedInputStream;
 	private WebSocketReceiver webSocketReceiver;
 	ByteBuffer recievedPayload;
@@ -47,7 +49,7 @@ public class WebSocketNetworkModule extends TCPNetworkModule {
 	 *  Frame before passing it through to the real socket.
 	 */
 	private ByteArrayOutputStream outputStream = new ExtendedByteArrayOutputStream(this);
-	
+
 	public WebSocketNetworkModule(SocketFactory factory, String uri, String host, int port, String resourceContext){
 		super(factory, host, port, resourceContext);
 		this.uri = uri;
@@ -60,7 +62,7 @@ public class WebSocketNetworkModule extends TCPNetworkModule {
 	
 	public void start() throws IOException, MqttException {
 		super.start();
-		WebSocketHandshake handshake = new WebSocketHandshake(getSocketInputStream(), getSocketOutputStream(), uri, host, port);
+		WebSocketHandshake handshake = new WebSocketHandshake(getSocketInputStream(), getSocketOutputStream(), uri, host, port, customHeaders);
 		handshake.execute();
 		this.webSocketReceiver = new WebSocketReceiver(getSocketInputStream(), pipedInputStream);
 		webSocketReceiver.start("webSocketReceiver");
@@ -101,5 +103,8 @@ public class WebSocketNetworkModule extends TCPNetworkModule {
 	public String getServerURI() {
 		return "ws://" + host + ":" + port;
 	}
-	
+
+	public void setCustomHeaders(Properties customHeaders) {
+		this.customHeaders = customHeaders;
+	}
 }

--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/websocket/WebSocketSecureNetworkModule.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/websocket/WebSocketSecureNetworkModule.java
@@ -21,6 +21,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.PipedInputStream;
 import java.nio.ByteBuffer;
+import java.util.Properties;
 
 import javax.net.ssl.SSLSocketFactory;
 
@@ -39,6 +40,7 @@ public class WebSocketSecureNetworkModule extends SSLNetworkModule{
 	private String uri;
 	private String host;
 	private int port;
+	private Properties customHeaders;
 	ByteBuffer recievedPayload;
 	
 	/**
@@ -59,7 +61,7 @@ public class WebSocketSecureNetworkModule extends SSLNetworkModule{
 
 	public void start() throws IOException, MqttException {
 		super.start();
-		WebSocketHandshake handshake = new WebSocketHandshake(super.getInputStream(), super.getOutputStream(), uri, host, port);
+		WebSocketHandshake handshake = new WebSocketHandshake(super.getInputStream(), super.getOutputStream(), uri, host, port, customHeaders);
 		handshake.execute();
 		this.webSocketReceiver = new WebSocketReceiver(getSocketInputStream(), pipedInputStream);
 		webSocketReceiver.start("WssSocketReceiver");
@@ -98,8 +100,9 @@ public class WebSocketSecureNetworkModule extends SSLNetworkModule{
 	public String getServerURI() {
 		return "wss://" + host + ":" + port;
 	}
-	
-	
 
 
+	public void setCustomHeaders(Properties customHeaders) {
+		this.customHeaders = customHeaders;
+	}
 }


### PR DESCRIPTION
https://github.com/eclipse/paho.mqtt.java/issues/502

Minor fix that allow use custom headers in request using WebSockets :

Added new parameter "customHeaders" to MqttConnectOptions
Pass this param to WebSocketHandshake
Added new custom headers to handshake request

Please make sure that the following boxes are checked before submitting your Pull Request, thank you!

- [*] You have signed the [Eclipse ECA](https://wiki.eclipse.org/ECA)
- [*] All of your commits have been signed-off with the correct email address (The same one that you used to sign the CLA)
- [*] If This PR fixes an issue, that you reference the issue below. OR if this is a new issue that you are fixing straight away that you add some Description about the bug and how this will fix it.
- [ ] If this is new functionality, You have added the appropriate Unit tests.
