### PR TITLE
Fix TCPNetworkModule to close SSLSocket.

### DIFF
--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/CommsReceiver.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/CommsReceiver.java
@@ -20,6 +20,7 @@ import java.io.InputStream;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
 
 import org.eclipse.paho.client.mqttv3.MqttException;
 import org.eclipse.paho.client.mqttv3.MqttToken;
@@ -39,7 +40,7 @@ public class CommsReceiver implements Runnable {
 	private static final String CLASS_NAME = CommsReceiver.class.getName();
 	private static final Logger log = LoggerFactory.getLogger(LoggerFactory.MQTT_CLIENT_MSG_CAT, CLASS_NAME);
 
-	private boolean running = false;
+	private volatile boolean running = false;
 	private Object lifecycle = new Object();
 	private ClientState clientState = null;
 	private ClientComms clientComms = null;
@@ -95,7 +96,22 @@ public class CommsReceiver implements Runnable {
 				if (!Thread.currentThread().equals(recThread)) {
 					try {
 						// Wait for the thread to finish.
-						runningSemaphore.acquire();
+						// We need to set a certain timeout since there is no universal way
+						// to wake up the worker thread from blocking read.
+						// If network module is websocket, the worker thread returns from read with InterruptedIOException
+						// in response to receiverFuture.cancel(true) above.
+						//
+						// If network module is tcp or ssl, however, InterruptedIOException is not thrown on read.
+						// In normal cases, the worker thread returns from read with EOFException when
+						// the connection is terminated from the broker side in response to DISCONNECT packet.
+						// In this case, the SSL session is preserved and available for reuse in later connections.
+						//
+						// If stop is called because the broker connection is unexpectedly lost,
+						// the worker thread will keep waiting on read, and tryAcquire below will return on timeout expiration.
+						// The worker thread wakes up with SocketException when the socket is closed later.
+						// In this case, the SSL session is invalidated by SSLSocket implementation.
+						// 
+						runningSemaphore.tryAcquire(3000, TimeUnit.MILLISECONDS);
 					}
 					catch (InterruptedException ex) {
 					} finally {
@@ -124,67 +140,70 @@ public class CommsReceiver implements Runnable {
 			running = false;
 			return;
 		}
+		
+		try {
+			while (running && (in != null)) {
+				try {
+					//@TRACE 852=network read message
+					log.fine(CLASS_NAME,methodName,"852");
+					receiving = in.available() > 0;
+					MqttWireMessage message = in.readMqttWireMessage();
+					receiving = false;
 
-		while (running && (in != null)) {
-			try {
-				//@TRACE 852=network read message
-				log.fine(CLASS_NAME,methodName,"852");
-				receiving = in.available() > 0;
-				MqttWireMessage message = in.readMqttWireMessage();
-				receiving = false;
-
-				// instanceof checks if message is null
-				if (message instanceof MqttAck) {
-					token = tokenStore.getToken(message);
-					if (token!=null) {
-						synchronized (token) {
-							// Ensure the notify processing is done under a lock on the token
-							// This ensures that the send processing can complete  before the
-							// receive processing starts! ( request and ack and ack processing
-							// can occur before request processing is complete if not!
-							clientState.notifyReceivedAck((MqttAck)message);
+					// instanceof checks if message is null
+					if (message instanceof MqttAck) {
+						token = tokenStore.getToken(message);
+						if (token!=null) {
+							synchronized (token) {
+								// Ensure the notify processing is done under a lock on the token
+								// This ensures that the send processing can complete  before the
+								// receive processing starts! ( request and ack and ack processing
+								// can occur before request processing is complete if not!
+								clientState.notifyReceivedAck((MqttAck)message);
+							}
+						} else if(message instanceof MqttPubRec || message instanceof MqttPubComp || message instanceof MqttPubAck) {
+							//This is an ack for a message we no longer have a ticket for.
+							//This probably means we already received this message and it's being send again
+							//because of timeouts, crashes, disconnects, restarts etc.
+							//It should be safe to ignore these unexpected messages.
+							log.fine(CLASS_NAME, methodName, "857");
+						} else {
+							// It its an ack and there is no token then something is not right.
+							// An ack should always have a token assoicated with it.
+							throw new MqttException(MqttException.REASON_CODE_UNEXPECTED_ERROR);
 						}
-					} else if(message instanceof MqttPubRec || message instanceof MqttPubComp || message instanceof MqttPubAck) {
-						//This is an ack for a message we no longer have a ticket for.
-						//This probably means we already received this message and it's being send again
-						//because of timeouts, crashes, disconnects, restarts etc.
-						//It should be safe to ignore these unexpected messages.
-						log.fine(CLASS_NAME, methodName, "857");
 					} else {
-						// It its an ack and there is no token then something is not right.
-						// An ack should always have a token assoicated with it.
-						throw new MqttException(MqttException.REASON_CODE_UNEXPECTED_ERROR);
-					}
-				} else {
-					if (message != null) {
-						// A new message has arrived
-						clientState.notifyReceivedMsg(message);
+						if (message != null) {
+							// A new message has arrived
+							clientState.notifyReceivedMsg(message);
+						}
 					}
 				}
-			}
-			catch (MqttException ex) {
-				//@TRACE 856=Stopping, MQttException
-				log.fine(CLASS_NAME,methodName,"856",null,ex);
-				running = false;
-				// Token maybe null but that is handled in shutdown
-				clientComms.shutdownConnection(token, ex);
-			}
-			catch (IOException ioe) {
-				//@TRACE 853=Stopping due to IOException
-				log.fine(CLASS_NAME,methodName,"853");
+				catch (MqttException ex) {
+					//@TRACE 856=Stopping, MQttException
+					log.fine(CLASS_NAME,methodName,"856",null,ex);
+					running = false;
+					// Token maybe null but that is handled in shutdown
+					clientComms.shutdownConnection(token, ex);
+				}
+				catch (IOException ioe) {
+					//@TRACE 853=Stopping due to IOException
+					log.fine(CLASS_NAME,methodName,"853");
 
-				running = false;
-				// An EOFException could be raised if the broker processes the
-				// DISCONNECT and ends the socket before we complete. As such,
-				// only shutdown the connection if we're not already shutting down.
-				if (!clientComms.isDisconnecting()) {
-					clientComms.shutdownConnection(token, new MqttException(MqttException.REASON_CODE_CONNECTION_LOST, ioe));
+					running = false;
+					// An EOFException could be raised if the broker processes the
+					// DISCONNECT and ends the socket before we complete. As such,
+					// only shutdown the connection if we're not already shutting down.
+					if (!clientComms.isDisconnecting()) {
+						clientComms.shutdownConnection(token, new MqttException(MqttException.REASON_CODE_CONNECTION_LOST, ioe));
+					}
+				}
+				finally {
+					receiving = false;
 				}
 			}
-			finally {
-				receiving = false;
-				runningSemaphore.release();
-			}
+		} finally {
+			runningSemaphore.release();
 		}
 
 		//@TRACE 854=<

--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/TCPNetworkModule.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/TCPNetworkModule.java
@@ -102,25 +102,6 @@ public class TCPNetworkModule implements NetworkModule {
 	 */
 	public void stop() throws IOException {
 		if (socket != null) {
-			// CDA: an attempt is made to stop the receiver cleanly before closing the socket.
-			// If the socket is forcibly closed too early, the blocking socket read in
-			// the receiver thread throws a SocketException.
-			// While this causes the receiver thread to exit, it also invalidates the
-			// SSL session preventing to perform an accelerated SSL handshake in the
-			// next connection.
-			//
-			// Also note that due to the blocking socket reads in the receiver thread,
-			// it's not possible to interrupt the thread. Using non blocking reads in
-			// combination with a socket timeout (see setSoTimeout()) would be a better approach.
-			//
-			// Please note that the Javadoc only says that an EOF is returned on
-			// subsequent reads of the socket stream.
-			// Anyway, at least with Oracle Java SE 7 on Linux systems, this causes a blocked read
-			// to return EOF immediately.
-			// This workaround should not cause any harm in general but you might
-			// want to move it in SSLNetworkModule.
-
-			socket.shutdownInput();
 			socket.close();
 		}
 	}


### PR DESCRIPTION
This PR fixes #467.

- Remove unnecessary shutdownInput call in `TCPNetworkModule#stop`
`TCPNetworkModule#stop` calls shutdownInput before calling close.
The comment says it is for enabling SSL session resumption,
but close is never called if the socket is SSLSocket as shutdownInput always throws exception.

I find simply removing `shutdownInput()` call from `TCPNetworkModule#stop()` sometimes breaks
SSL session resumption.
When shutting down connection, `CommsReceiver#stop()` fails to wait until the receiver thread exits. As `CommsReceiver#stop()` returns too early, SSLSocket might be closed while the receiver thread is waiting on read, which invalidates the SSL session.

To avoid invalidating the SSL session, I changed `CommsReceiver` as well.

- Fix CommsReceiver to properly use `runningSemaphore` for stopping the receiver task
In `run()` method, `runningSemaphore` is inproperly released on every while loop run.
This change moves `runningSemaphore.release()` to outside of while loop.

Signed-off-by: Akira Saito <saiaki@jp.ibm.com>

Please make sure that the following boxes are checked before submitting your Pull Request, thank you!

- [x] This change is against the develop branch, **not** master.
- [x] You have signed the [Eclipse ECA](https://wiki.eclipse.org/ECA)
- [x] All of your commits have been signed-off with the correct email address (The same one that you used to sign the CLA) _Hint: use the -s argument when committing_.
- [x] If This PR fixes an issue, that you reference the issue below. OR if this is a new issue that you are fixing straight away that you add some Description about the bug and how this will fix it.
- [ ] If this is new functionality, You have added the appropriate Unit tests.
