### PR TITLE
Add start-broker script for Windows

### DIFF
--- a/start-broker.bat
+++ b/start-broker.bat
@@ -1,10 +1,11 @@
 @echo off
 rem Simplified Windows version of start-broker.sh
 rem Moquitto broker not supported, only Python Interopability Broker
-rem echo "Installing and starting Python Interop Broker."
+echo "Installing and starting Python Interop Broker."
 if not exist "paho.mqtt.testing" (
 	git clone https://github.com/eclipse/paho.mqtt.testing.git
 )
 copy "java_client_testing.conf" "paho.mqtt.testing/interoperability/java_client_testing.conf" /y
 cd paho.mqtt.testing/interoperability
 start python3 startbroker.py -c java_client_testing.conf
+cd ../..

--- a/start-broker.bat
+++ b/start-broker.bat
@@ -1,0 +1,10 @@
+@echo off
+rem Simplified Windows version of start-broker.sh
+rem Moquitto broker not supported, only Python Interopability Broker
+rem echo "Installing and starting Python Interop Broker."
+if not exist "paho.mqtt.testing" (
+	git clone https://github.com/eclipse/paho.mqtt.testing.git
+)
+copy "java_client_testing.conf" "paho.mqtt.testing/interoperability/java_client_testing.conf" /y
+cd paho.mqtt.testing/interoperability
+start python3 startbroker.py -c java_client_testing.conf


### PR DESCRIPTION
It would be convenient for Windows developers to have the same tools for testing and development, so I added simple batch script that does the same thing as start-broker.sh (except for Mosquitto, as I didn't use it myself). 
It works well on my machine, enables running unit tests on Windows.

Signed-off-by: Daniel Dylag <bisker@op.pl>

- [x] This change is against the develop branch, **not** master.
- [x] You have signed the [Eclipse ECA](https://wiki.eclipse.org/ECA)
- [x] All of your commits have been signed-off with the correct email address (The same one that you used to sign the CLA) _Hint: use the -s argument when committing_.
