### PR TITLE
Closing FileLock on reconnect() while using MqttDefaultFilePersistence

### DIFF
--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/persist/MqttDefaultFilePersistence.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/persist/MqttDefaultFilePersistence.java
@@ -112,6 +112,11 @@ public class MqttDefaultFilePersistence implements MqttClientPersistence {
 			}
 
 			try {
+				//If lock was previously acquired, release before requesting a new one
+				if(fileLock != null){
+					fileLock.release();
+				}
+
 				fileLock = new FileLock(clientDir, LOCK_FILENAME);
 	 		} catch (Exception e) {
 	 			// TODO - This shouldn't be here according to the interface

--- a/org.eclipse.paho.mqttv5.client/src/main/java/org/eclipse/paho/mqttv5/client/persist/MqttDefaultFilePersistence.java
+++ b/org.eclipse.paho.mqttv5.client/src/main/java/org/eclipse/paho/mqttv5/client/persist/MqttDefaultFilePersistence.java
@@ -105,6 +105,11 @@ public class MqttDefaultFilePersistence implements MqttClientPersistence {
 			}
 
 			try {
+				//If lock was previously acquired, release before requesting a new one
+				if(fileLock != null){
+					fileLock.release();
+				}
+
 				fileLock = new FileLock(clientDir, LOCK_FILENAME);
 	 		} catch (Exception e) {
 	 			// TODO - This shouldn't be here according to the interface


### PR DESCRIPTION
Please make sure that the following boxes are checked before submitting your Pull Request, thank you!

- [*] This change is against the develop branch, **not** master.
- [*] You have signed the [Eclipse ECA](https://wiki.eclipse.org/ECA)
- [*] All of your commits have been signed-off with the correct email address (The same one that you used to sign the CLA) _Hint: use the -s argument when committing_.
- [*] If This PR fixes an issue, that you reference the issue below. OR if this is a new issue that you are fixing straight away that you add some Description about the bug and how this will fix it.

Fixes issue #435 