### PR TITLE
Fix issues on Maximum QoS and Receive Maximum properties for MQTT 5.0

### DIFF
--- a/org.eclipse.paho.mqttv5.client/src/main/java/org/eclipse/paho/mqttv5/client/internal/MqttConnectionState.java
+++ b/org.eclipse.paho.mqttv5.client/src/main/java/org/eclipse/paho/mqttv5/client/internal/MqttConnectionState.java
@@ -53,6 +53,9 @@ public class MqttConnectionState {
 
 
 	public Integer getReceiveMaximum() {
+		if (receiveMaximum == null) {
+			return 65535;
+		}
 		return receiveMaximum;
 	}
 

--- a/org.eclipse.paho.mqttv5.common/src/main/java/org/eclipse/paho/mqttv5/common/packet/MqttProperties.java
+++ b/org.eclipse.paho.mqttv5.common/src/main/java/org/eclipse/paho/mqttv5/common/packet/MqttProperties.java
@@ -336,7 +336,7 @@ public class MqttProperties {
 			// Maximum QoS
 			if (maximumQoS != null && validProperties.contains(MAXIMUM_QOS_IDENTIFIER)) {
 				outputStream.write(MAXIMUM_QOS_IDENTIFIER);
-				outputStream.writeShort(maximumQoS);
+				outputStream.writeByte(maximumQoS);
 			}
 
 			// Retain Available

--- a/org.eclipse.paho.mqttv5.common/src/main/java/org/eclipse/paho/mqttv5/common/packet/MqttProperties.java
+++ b/org.eclipse.paho.mqttv5.common/src/main/java/org/eclipse/paho/mqttv5/common/packet/MqttProperties.java
@@ -476,7 +476,7 @@ public class MqttProperties {
 					} else if (identifier == TOPIC_ALIAS_IDENTIFIER) {
 						topicAlias = (int) inputStream.readShort();
 					} else if (identifier == MAXIMUM_QOS_IDENTIFIER) {
-						maximumQoS = (int) inputStream.readShort();
+						maximumQoS = inputStream.read();
 					} else if (identifier == RETAIN_AVAILABLE_IDENTIFIER) {
 						retainAvailable = inputStream.readBoolean();
 					} else if (identifier == USER_DEFINED_PAIR_IDENTIFIER) {


### PR DESCRIPTION
Please make sure that the following boxes are checked before submitting your Pull Request, thank you!

  This change is against the develop branch, not master.
  You have signed the Eclipse ECA
  All of your commits have been signed-off with the correct email address (The same one that you used to sign the CLA) Hint: use the -s argument when committing.
  If This PR fixes an issue, that you reference the issue below. OR if this is a new issue that you are fixing straight away that you add some Description about the bug and how this will fix it.
2 issues regarding the Properties for MQTT 5.0:
1.	for CONNACK, the Maximum QoS Property should be 1 byte, not 2 bytes.
2.	for CONNECT/CONNACK, the Receive Maximum Property should have the default value of 65535 if no value is presented, not null.

Signed-off-by: ChongYuan Yin yinchongyuan@xmeter.net