### PR TITLE
setSSLParameters support for Android version <= 6.0

### DIFF
--- a/org.eclipse.paho.client.mqttv3/src/main/java-templates/org/eclipse/paho/client/mqttv3/internal/ClientComms.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java-templates/org/eclipse/paho/client/mqttv3/internal/ClientComms.java
@@ -599,7 +599,11 @@ public class ClientComms {
 		this.callback.setCallback(mqttCallback);
 	}
 	
-	public void setReconnectCallback(MqttCallbackExtended callback){
+	public void setReconnectCallback(MqttCallbackExtended callback) throws MqttException {
+		if (this.isClosed()) {
+		    throw new MqttException(MqttException.REASON_CODE_CLIENT_CLOSED);
+		}
+
 		this.callback.setReconnectCallback(callback);
 	}
 	

--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/SSLNetworkModule.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/SSLNetworkModule.java
@@ -16,13 +16,9 @@
 package org.eclipse.paho.client.mqttv3.internal;
 
 import java.io.IOException;
+import java.security.NoSuchAlgorithmException;
 
-import javax.net.ssl.HostnameVerifier;
-import javax.net.ssl.SSLParameters;
-import javax.net.ssl.SSLPeerUnverifiedException;
-import javax.net.ssl.SSLSession;
-import javax.net.ssl.SSLSocket;
-import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.*;
 
 import org.eclipse.paho.client.mqttv3.MqttException;
 import org.eclipse.paho.client.mqttv3.logging.Logger;
@@ -132,7 +128,15 @@ public class SSLNetworkModule extends TCPNetworkModule {
 		// If default Hostname verification is enabled, use the same method that is used with HTTPS
 		if(this.httpsHostnameVerificationEnabled) {
 			SSLParameters sslParams = new SSLParameters();
-			sslParams.setEndpointIdentificationAlgorithm("HTTPS");
+			try {
+				sslParams.setEndpointIdentificationAlgorithm("HTTPS");
+			} catch (NoSuchMethodError e) {
+				try {
+					sslParams = SSLContext.getDefault().getDefaultSSLParameters();
+				} catch (NoSuchAlgorithmException e1) {
+					throw new MqttException(e1);
+				}
+			}
 			((SSLSocket) socket).setSSLParameters(sslParams);
 		}
 		((SSLSocket) socket).startHandshake();


### PR DESCRIPTION
Please make sure that the following boxes are checked before submitting your Pull Request, thank you!

- [X] This change is against the develop branch, **not** master.
- [X] You have signed the [Eclipse ECA](https://wiki.eclipse.org/ECA)
- [X] All of your commits have been signed-off with the correct email address (The same one that you used to sign the CLA) _Hint: use the -s argument when committing_.
- [X] If This PR fixes an issue, that you reference the issue below. OR if this is a new issue that you are fixing straight away that you add some Description about the bug and how this will fix it.
- [ ] If this is new functionality, You have added the appropriate Unit tests.

```
Fatal Exception: java.lang.NoSuchMethodError: No virtual method setEndpointIdentificationAlgorithm(Ljava/lang/String;)V in class Ljavax/net/ssl/SSLParameters; or its super classes (declaration of 'javax.net.ssl.SSLParameters' appears in /system/framework/core-libart.jar)
       at org.eclipse.paho.client.mqttv3.internal.SSLNetworkModule.start(SSLNetworkModule.java:135)
       at org.eclipse.paho.client.mqttv3.internal.websocket.WebSocketSecureNetworkModule.start(WebSocketSecureNetworkModule.java:63)
       at org.eclipse.paho.client.mqttv3.internal.ClientComms$a.run(ClientComms.java:722)
```