### PR TITLE
Makes fields used for synchronization final

### DIFF
--- a/org.eclipse.paho.client.mqttv3.test/src/test/java/org/eclipse/paho/client/mqttv3/test/BasicTest.java
+++ b/org.eclipse.paho.client.mqttv3.test/src/test/java/org/eclipse/paho/client/mqttv3/test/BasicTest.java
@@ -502,7 +502,7 @@ public class BasicTest {
    */
   class MessageListener implements MqttCallback {
 
-    ArrayList<MqttMessage> messages;
+    final ArrayList<MqttMessage> messages;
 
     public MessageListener() {
       messages = new ArrayList<MqttMessage>();

--- a/org.eclipse.paho.client.mqttv3.test/src/test/java/org/eclipse/paho/client/mqttv3/test/LiveTakeOverTest.java
+++ b/org.eclipse.paho.client.mqttv3.test/src/test/java/org/eclipse/paho/client/mqttv3/test/LiveTakeOverTest.java
@@ -193,7 +193,7 @@ public class LiveTakeOverTest {
   class FirstClient implements Runnable {
 
     private FirstClientState state = FirstClientState.INITIAL;
-    public Object stateLock = new Object();
+    public final Object stateLock = new Object();
     IMqttClient mqttClient = null;
     MqttV3Receiver mqttV3Receiver = null;
 

--- a/org.eclipse.paho.client.mqttv3.test/src/test/java/org/eclipse/paho/client/mqttv3/test/PerSubscriptionMessageHandlerTest.java
+++ b/org.eclipse.paho.client.mqttv3.test/src/test/java/org/eclipse/paho/client/mqttv3/test/PerSubscriptionMessageHandlerTest.java
@@ -93,7 +93,7 @@ public class PerSubscriptionMessageHandlerTest {
 	  
 	  class listener implements IMqttMessageListener {
 
-		  ArrayList<MqttMessage> messages;
+		  final ArrayList<MqttMessage> messages;
 
 		  public listener() {
 			  messages = new ArrayList<MqttMessage>();

--- a/org.eclipse.paho.client.mqttv3.test/src/test/java/org/eclipse/paho/client/mqttv3/test/SendReceiveAsyncCallbackTest.java
+++ b/org.eclipse.paho.client.mqttv3.test/src/test/java/org/eclipse/paho/client/mqttv3/test/SendReceiveAsyncCallbackTest.java
@@ -128,7 +128,7 @@ public class SendReceiveAsyncCallbackTest {
 
 	class listener implements IMqttMessageListener {
 
-		ArrayList<MqttMessage> messages;
+		final ArrayList<MqttMessage> messages;
 
 		public listener() {
 			messages = new ArrayList<MqttMessage>();

--- a/org.eclipse.paho.client.mqttv3.test/src/test/java/org/eclipse/paho/client/mqttv3/test/WebSocketTest.java
+++ b/org.eclipse.paho.client.mqttv3.test/src/test/java/org/eclipse/paho/client/mqttv3/test/WebSocketTest.java
@@ -306,7 +306,7 @@ public class WebSocketTest {
    */
   class MessageListener implements MqttCallback {
 
-    ArrayList<MqttMessage> messages;
+    final ArrayList<MqttMessage> messages;
 
     public MessageListener() {
       messages = new ArrayList<MqttMessage>();

--- a/org.eclipse.paho.client.mqttv3.test/src/test/java/org/eclipse/paho/client/mqttv3/test/utilities/ConnectionManipulationProxyServer.java
+++ b/org.eclipse.paho.client.mqttv3.test/src/test/java/org/eclipse/paho/client/mqttv3/test/utilities/ConnectionManipulationProxyServer.java
@@ -16,7 +16,7 @@ public class ConnectionManipulationProxyServer implements Runnable {
 	private String host;
 	private int remotePort;
 	private Thread proxyThread;
-	private Object enableLock = new Object();
+	private final Object enableLock = new Object();
 	private boolean enableProxy = true;
 	private boolean running = true;
 	Socket client = null, server = null;

--- a/org.eclipse.paho.client.mqttv3/src/main/java-templates/org/eclipse/paho/client/mqttv3/internal/ClientComms.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java-templates/org/eclipse/paho/client/mqttv3/internal/ClientComms.java
@@ -79,7 +79,7 @@ public class ClientComms {
 	private boolean 				stoppingComms = false;
 
 	private byte	conState = DISCONNECTED;
-	private Object	conLock = new Object();  	// Used to synchronize connection state
+	private final Object	conLock = new Object();  	// Used to synchronize connection state
 	private boolean	closePending = false;
 	private boolean resting = false;
 	private DisconnectedMessageBuffer disconnectedMessageBuffer;

--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/MqttAsyncClient.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/MqttAsyncClient.java
@@ -111,7 +111,7 @@ public class MqttAsyncClient implements IMqttAsyncClient {
 	private static int reconnectDelay = 1000; // Reconnect delay, starts at 1
 												// second
 	private boolean reconnecting = false;
-	private static Object clientLock = new Object(); // Simple lock
+	private static final Object clientLock = new Object(); // Simple lock
 
 	private ScheduledExecutorService executorService;
 

--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/ClientState.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/ClientState.java
@@ -127,15 +127,15 @@ public class ClientState {
 	private int actualInFlight = 0;
 	private int inFlightPubRels = 0;
 	
-	private Object queueLock = new Object();
-	private Object quiesceLock = new Object();
+	private final Object queueLock = new Object();
+	private final Object quiesceLock = new Object();
 	private boolean quiescing = false;
 	
 	private long lastOutboundActivity = 0;
 	private long lastInboundActivity = 0;
 	private long lastPing = 0;
 	private MqttWireMessage pingCommand;
-	private Object pingOutstandingLock = new Object();
+	private final Object pingOutstandingLock = new Object();
 	private int pingOutstanding = 0;
 
 	private boolean connected = false;

--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/CommsCallback.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/CommsCallback.java
@@ -54,19 +54,19 @@ public class CommsCallback implements Runnable {
 	private MqttCallbackExtended reconnectInternalCallback;
 	private Hashtable<String, IMqttMessageListener> callbacks; // topicFilter -> messageHandler
 	private ClientComms clientComms;
-	private Vector<MqttWireMessage> messageQueue;
-	private Vector<MqttToken> completeQueue;
+	private final Vector<MqttWireMessage> messageQueue;
+	private final Vector<MqttToken> completeQueue;
 	
 	private enum State {STOPPED, RUNNING, QUIESCING};
 	private State current_state = State.STOPPED;
 	private State target_state = State.STOPPED;
-	private Object lifecycle = new Object();
+	private final Object lifecycle = new Object();
 	private Thread callbackThread;
 	private String threadName;
 	private Future<?> callbackFuture;
 	
-	private Object workAvailable = new Object();
-	private Object spaceAvailable = new Object();
+	private final Object workAvailable = new Object();
+	private final Object spaceAvailable = new Object();
 	private ClientState clientState;
 	private boolean manualAcks = false;
 

--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/CommsReceiver.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/CommsReceiver.java
@@ -41,7 +41,7 @@ public class CommsReceiver implements Runnable {
 	private enum State {STOPPED, RUNNING, STARTING, RECEIVING};
 	private State current_state = State.STOPPED;
 	private State target_state = State.STOPPED;
-	private Object lifecycle = new Object();
+	private final Object lifecycle = new Object();
 	private String threadName;
 	private Future<?> receiverFuture;
 	

--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/CommsSender.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/CommsSender.java
@@ -38,7 +38,7 @@ public class CommsSender implements Runnable {
 	private enum State {STOPPED, RUNNING, STARTING};
 	private State current_state = State.STOPPED;
 	private State target_state = State.STOPPED;
-	private Object lifecycle = new Object();
+	private final Object lifecycle = new Object();
 	private Thread 	sendThread		= null;
 	private String threadName;
 	private Future<?> senderFuture;

--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/CommsTokenStore.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/CommsTokenStore.java
@@ -48,7 +48,7 @@ public class CommsTokenStore {
 	private Logger log = LoggerFactory.getLogger(LoggerFactory.MQTT_CLIENT_MSG_CAT, CLASS_NAME);
 
 	// Maps message-specific data (usually message IDs) to tokens
-	private Hashtable tokens;
+	private final Hashtable tokens;
 	private String logContext;
 	private MqttException closedResponse = null;
 

--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/DisconnectedMessageBuffer.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/DisconnectedMessageBuffer.java
@@ -31,7 +31,7 @@ public class DisconnectedMessageBuffer implements Runnable {
 	private Logger log = LoggerFactory.getLogger(LoggerFactory.MQTT_CLIENT_MSG_CAT, CLASS_NAME);
 	private DisconnectedBufferOptions bufferOpts;
 	private ArrayList<BufferedMessage> buffer;
-	private Object bufLock = new Object(); // Used to synchronise the buffer
+	private final Object bufLock = new Object(); // Used to synchronise the buffer
 	private IDisconnectedBufferCallback callback;
 
 	public DisconnectedMessageBuffer(DisconnectedBufferOptions options) {

--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/Token.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/Token.java
@@ -35,8 +35,8 @@ public class Token {
 	private boolean pendingComplete = false;
 	private boolean sent = false;
 	
-	private Object responseLock = new Object();
-	private Object sentLock = new Object();
+	private final Object responseLock = new Object();
+	private final Object sentLock = new Object();
 	
 	protected MqttMessage message = null; 
 	private MqttWireMessage response = null;

--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/websocket/WebSocketReceiver.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/websocket/WebSocketReceiver.java
@@ -30,7 +30,7 @@ public class WebSocketReceiver implements Runnable{
 
 	private boolean running = false;
 	private boolean stopping = false;
-	private Object lifecycle = new Object();
+	private final Object lifecycle = new Object();
 	private InputStream input;
 	private Thread receiverThread = null;
 	private volatile boolean receiving;

--- a/org.eclipse.paho.mqttv5.client/src/main/java/org/eclipse/paho/mqttv5/client/MqttAsyncClient.java
+++ b/org.eclipse.paho.mqttv5.client/src/main/java/org/eclipse/paho/mqttv5/client/MqttAsyncClient.java
@@ -238,7 +238,7 @@ public class MqttAsyncClient implements MqttClientInterface, IMqttAsyncClient {
 	private static int reconnectDelay = 1000; // Reconnect delay, starts at 1
 												// second
 	private boolean reconnecting = false;
-	private static Object clientLock = new Object(); // Simple lock
+	private static final Object clientLock = new Object(); // Simple lock
 
 	// Variables that exist within the life of an MQTT session
 	private MqttSessionState mqttSession = new MqttSessionState();

--- a/org.eclipse.paho.mqttv5.client/src/main/java/org/eclipse/paho/mqttv5/client/internal/ClientComms.java
+++ b/org.eclipse.paho.mqttv5.client/src/main/java/org/eclipse/paho/mqttv5/client/internal/ClientComms.java
@@ -79,7 +79,7 @@ public class ClientComms {
 	private boolean stoppingComms = false;
 
 	private byte conState = DISCONNECTED;
-	private Object conLock = new Object(); // Used to synchronize connection state
+	private final Object conLock = new Object(); // Used to synchronize connection state
 	private boolean closePending = false;
 	private boolean resting = false;
 	private DisconnectedMessageBuffer disconnectedMessageBuffer;

--- a/org.eclipse.paho.mqttv5.client/src/main/java/org/eclipse/paho/mqttv5/client/internal/ClientState.java
+++ b/org.eclipse.paho.mqttv5.client/src/main/java/org/eclipse/paho/mqttv5/client/internal/ClientState.java
@@ -126,15 +126,15 @@ public class ClientState implements MqttState {
 	private int actualInFlight = 0;
 	private int inFlightPubRels = 0;
 
-	private Object queueLock = new Object();
-	private Object quiesceLock = new Object();
+	private final Object queueLock = new Object();
+	private final Object quiesceLock = new Object();
 	private boolean quiescing = false;
 
 	private long lastOutboundActivity = 0;
 	private long lastInboundActivity = 0;
 	private long lastPing = 0;
 	private MqttWireMessage pingCommand;
-	private Object pingOutstandingLock = new Object();
+	private final Object pingOutstandingLock = new Object();
 	private int pingOutstanding = 0;
 
 	private boolean connected = false;

--- a/org.eclipse.paho.mqttv5.client/src/main/java/org/eclipse/paho/mqttv5/client/internal/CommsCallback.java
+++ b/org.eclipse.paho.mqttv5.client/src/main/java/org/eclipse/paho/mqttv5/client/internal/CommsCallback.java
@@ -68,13 +68,13 @@ public class CommsCallback implements Runnable {
 	private enum State {STOPPED, RUNNING, QUIESCING};
 	private State current_state = State.STOPPED;
 	private State target_state = State.STOPPED;	
-	private Object lifecycle = new Object();
+	private final Object lifecycle = new Object();
 	private Thread callbackThread;
 	private String threadName;
 	private Future<?> callbackFuture;
 	
-	private Object workAvailable = new Object();
-	private Object spaceAvailable = new Object();
+	private final Object workAvailable = new Object();
+	private final Object spaceAvailable = new Object();
 	private ClientState clientState;
 	private boolean manualAcks = false;
 

--- a/org.eclipse.paho.mqttv5.client/src/main/java/org/eclipse/paho/mqttv5/client/internal/CommsReceiver.java
+++ b/org.eclipse.paho.mqttv5.client/src/main/java/org/eclipse/paho/mqttv5/client/internal/CommsReceiver.java
@@ -40,7 +40,7 @@ public class CommsReceiver implements Runnable {
 	private enum State {STOPPED, RUNNING, STARTING, RECEIVING};
 	private State current_state = State.STOPPED;
 	private State target_state = State.STOPPED;
-	private Object lifecycle = new Object();
+	private final Object lifecycle = new Object();
 	private String threadName;
 	private Future<?> receiverFuture;
 	

--- a/org.eclipse.paho.mqttv5.client/src/main/java/org/eclipse/paho/mqttv5/client/internal/CommsSender.java
+++ b/org.eclipse.paho.mqttv5.client/src/main/java/org/eclipse/paho/mqttv5/client/internal/CommsSender.java
@@ -39,7 +39,7 @@ public class CommsSender implements Runnable {
 	private enum State {STOPPED, RUNNING, STARTING};
 	private State current_state = State.STOPPED;
 	private State target_state = State.STOPPED;
-	private Object lifecycle = new Object();
+	private final Object lifecycle = new Object();
 	private Thread 	sendThread		= null;
 	private String threadName;
 	private Future<?> senderFuture;

--- a/org.eclipse.paho.mqttv5.client/src/main/java/org/eclipse/paho/mqttv5/client/internal/CommsTokenStore.java
+++ b/org.eclipse.paho.mqttv5.client/src/main/java/org/eclipse/paho/mqttv5/client/internal/CommsTokenStore.java
@@ -48,7 +48,7 @@ public class CommsTokenStore {
 	private Logger log = LoggerFactory.getLogger(LoggerFactory.MQTT_CLIENT_MSG_CAT, CLASS_NAME);
 
 	// Maps message-specific data (usually message IDs) to tokens
-	private Hashtable<String, MqttToken> tokens;
+	private final Hashtable<String, MqttToken> tokens;
 	private String logContext;
 	private MqttException closedResponse = null;
 

--- a/org.eclipse.paho.mqttv5.client/src/main/java/org/eclipse/paho/mqttv5/client/internal/DisconnectedMessageBuffer.java
+++ b/org.eclipse.paho.mqttv5.client/src/main/java/org/eclipse/paho/mqttv5/client/internal/DisconnectedMessageBuffer.java
@@ -32,7 +32,7 @@ public class DisconnectedMessageBuffer implements Runnable {
 	private Logger log = LoggerFactory.getLogger(LoggerFactory.MQTT_CLIENT_MSG_CAT, CLASS_NAME);
 	private DisconnectedBufferOptions bufferOpts;
 	private ArrayList<BufferedMessage> buffer;
-	private Object	bufLock = new Object();  	// Used to synchronise the buffer
+	private final Object	bufLock = new Object();  	// Used to synchronise the buffer
 	private IDisconnectedBufferCallback callback;
 	
 	public DisconnectedMessageBuffer(DisconnectedBufferOptions options){

--- a/org.eclipse.paho.mqttv5.client/src/main/java/org/eclipse/paho/mqttv5/client/internal/Token.java
+++ b/org.eclipse.paho.mqttv5.client/src/main/java/org/eclipse/paho/mqttv5/client/internal/Token.java
@@ -41,8 +41,8 @@ public class Token {
 	private boolean pendingComplete = false;
 	private boolean sent = false;
 
-	private Object responseLock = new Object();
-	private Object sentLock = new Object();
+	private final Object responseLock = new Object();
+	private final Object sentLock = new Object();
 
 	protected MqttMessage message = null;
 	private MqttWireMessage response = null;

--- a/org.eclipse.paho.mqttv5.client/src/main/java/org/eclipse/paho/mqttv5/client/websocket/WebSocketReceiver.java
+++ b/org.eclipse.paho.mqttv5.client/src/main/java/org/eclipse/paho/mqttv5/client/websocket/WebSocketReceiver.java
@@ -30,7 +30,7 @@ public class WebSocketReceiver implements Runnable{
 
 	private boolean running = false;
 	private boolean stopping = false;
-	private Object lifecycle = new Object();
+	private final Object lifecycle = new Object();
 	private InputStream input;
 	private Thread receiverThread = null;
 	private volatile boolean receiving;

--- a/org.eclipse.paho.mqttv5.client/src/test/java/org/eclipse/paho/mqttv5/client/test/utilities/ConnectionManipulationProxyServer.java
+++ b/org.eclipse.paho.mqttv5.client/src/test/java/org/eclipse/paho/mqttv5/client/test/utilities/ConnectionManipulationProxyServer.java
@@ -16,7 +16,7 @@ public class ConnectionManipulationProxyServer implements Runnable {
 	private String host;
 	private int remotePort;
 	private Thread proxyThread;
-	private Object enableLock = new Object();
+	private final Object enableLock = new Object();
 	private boolean enableProxy = true;
 	private boolean running = true;
 	Socket client = null, server = null;

--- a/org.eclipse.paho.sample.utility/src/main/java/org/eclipse/paho/sample/utility/MQTTFrame.java
+++ b/org.eclipse.paho.sample.utility/src/main/java/org/eclipse/paho/sample/utility/MQTTFrame.java
@@ -74,7 +74,7 @@ public class MQTTFrame implements ActionListener, MqttCallback, Runnable {
     private MqttConnectOptions opts = null;
 	private boolean connected = false;
 	private boolean traceEnabled = false;
-	private Object    connLostWait = new Object(); // Object to coordinated ConnectionLost and disconnect threads if
+	private final Object    connLostWait = new Object(); // Object to coordinated ConnectionLost and disconnect threads if
                 	                                // disconnect is hit during connectionLost
 	private JFrame frame= null;
 	

--- a/org.eclipse.paho.sample.utility/src/main/java/org/eclipse/paho/sample/utility/MQTTHist.java
+++ b/org.eclipse.paho.sample.utility/src/main/java/org/eclipse/paho/sample/utility/MQTTHist.java
@@ -37,7 +37,7 @@ import javax.swing.border.EtchedBorder;
  */
 public class MQTTHist extends JDialog implements ActionListener, Runnable {
     private ConnOpts connOptions;
-    private JTextArea histData;
+    private final JTextArea histData;
     private JScrollPane scroller; // Remember the scroll pane object so that we can auto scroll
     private boolean running = true;
     private boolean logEnabled = true;


### PR DESCRIPTION
This patch basically adds an extra layer of protection on fields used for synchronization. The idea here is to prevent those fields from being reassigned which could cause certain non-concurrent parts of the code to run in parallel.

- [x] This change is against the develop branch, **not** master.
- [x] You have signed the [Eclipse ECA](https://wiki.eclipse.org/ECA)
- [x] All of your commits have been signed-off with the correct email address (The same one that you used to sign the CLA) _Hint: use the -s argument when committing_.
- [x] If This PR fixes an issue, that you reference the issue below. OR if this is a new issue that you are fixing straight away that you add some Description about the bug and how this will fix it.
- [x] If this is new functionality, You have added the appropriate Unit tests.
