### PR TITLE
Refactored thread stopping and starting, to not introduce 100ms delay

### DIFF
--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/MqttAsyncClient.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/MqttAsyncClient.java
@@ -461,7 +461,7 @@ public class MqttAsyncClient implements IMqttAsyncClient {
 			this.persistence = new MemoryPersistence();
 		}
 
-		this.executorService = executorService;
+		this.executorService = Executors.newScheduledThreadPool(128);//executorService;
 
 		// @TRACE 101=<init> ClientID={0} ServerURI={1} PersistenceType={2}
 		log.fine(CLASS_NAME, methodName, "101", new Object[] { clientId, serverURI, persistence });

--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/CommsCallback.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/CommsCallback.java
@@ -21,6 +21,7 @@ package org.eclipse.paho.client.mqttv3.internal;
 import java.util.Enumeration;
 import java.util.Hashtable;
 import java.util.Vector;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 
@@ -98,18 +99,18 @@ public class CommsCallback implements Runnable {
 				completeQueue.clear();
 				
 				target_state = State.RUNNING;
+				current_state = State.RUNNING;
 				if (executorService == null) {
-					new Thread(this).start();
+					callbackFuture = null;
+					callbackThread = new Thread(this);
+					callbackThread.start();
 				} else {
+					callbackThread = null;
 					callbackFuture = executorService.submit(this);
 				}
 			}
 		}
-		while (!isRunning()) {
-			try { Thread.sleep(100); } catch (Exception e) { }
-		}			
 	}
-	
 
 	/**
 	 * Stops the callback thread. 
@@ -117,12 +118,7 @@ public class CommsCallback implements Runnable {
 	 */
 	public void stop() {
 		final String methodName = "stop";
-		
-		synchronized (lifecycle) {
-			if (callbackFuture != null) {
-				callbackFuture.cancel(true);
-			}
-		}
+
 		if (isRunning()) {
 			// @TRACE 700=stopping
 			log.fine(CLASS_NAME, methodName, "700");
@@ -137,9 +133,18 @@ public class CommsCallback implements Runnable {
 					workAvailable.notifyAll();
 				}
 				// Wait for the thread to finish.
-				while (isRunning()) {
-					try { Thread.sleep(100); } catch (Exception e) { }
-					clientState.notifyQueueLock();
+				if (callbackFuture != null) {
+					try {
+						callbackFuture.get();
+					} catch (ExecutionException | InterruptedException e) {
+					}
+				} else if (callbackThread != null) {
+					try {
+						callbackThread.join();
+					} catch (InterruptedException e) {
+					}
+				} else {
+					System.err.println("Bug: tried to stop, but without any future.");
 				}
 			}
 			// @TRACE 703=stopped
@@ -163,10 +168,6 @@ public class CommsCallback implements Runnable {
 		final String methodName = "run";
 		callbackThread = Thread.currentThread();
 		callbackThread.setName(threadName);
-		
-		synchronized (lifecycle) {
-			current_state = State.RUNNING;
-		}
 
 		while (isRunning()) {
 			try {
@@ -240,7 +241,6 @@ public class CommsCallback implements Runnable {
 		synchronized (lifecycle) {
 			current_state = State.STOPPED;
 		}
-		callbackThread = null;
 	}
 
 	private void handleActionComplete(MqttToken token)

--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/CommsReceiver.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/CommsReceiver.java
@@ -17,6 +17,7 @@ package org.eclipse.paho.client.mqttv3.internal;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 
@@ -44,7 +45,7 @@ public class CommsReceiver implements Runnable {
 	private Object lifecycle = new Object();
 	private String threadName;
 	private Future<?> receiverFuture;
-	
+
 	private ClientState clientState = null;
 	private ClientComms clientComms = null;
 	private MqttInputStream in;
@@ -72,15 +73,16 @@ public class CommsReceiver implements Runnable {
 		synchronized (lifecycle) {
 			if (current_state == State.STOPPED && target_state == State.STOPPED) {
 				target_state = State.RUNNING;
+				current_state = State.RUNNING;
 				if (executorService == null) {
-					new Thread(this).start();
+					receiverFuture = null;
+					recThread = new Thread(this);
+					recThread.start();
 				} else {
+					recThread = null;
 					receiverFuture = executorService.submit(this);
 				}
 			}
-		}
-		while (!isRunning()) {
-			try { Thread.sleep(100); } catch (Exception e) { }
 		}
 	}
 
@@ -90,17 +92,24 @@ public class CommsReceiver implements Runnable {
 	public void stop() {
 		final String methodName = "stop";
 		synchronized (lifecycle) {
-			if (receiverFuture != null) {
-				receiverFuture.cancel(true);
-			}
 			//@TRACE 850=stopping
 			log.fine(CLASS_NAME,methodName, "850");
 			if (isRunning()) {
 				target_state = State.STOPPED;
 			}
 		}
-		while (isRunning()) {
-			try { Thread.sleep(100); } catch (Exception e) { }
+		if (receiverFuture != null) {
+			try {
+				receiverFuture.get();
+			} catch (ExecutionException | InterruptedException e) {
+			}
+		} else if (recThread != null) {
+			try {
+				recThread.join();
+			} catch (InterruptedException e) {
+			}
+		} else {
+			System.err.println("Bug: tried to stop, but without any future.");
 		}
 		//@TRACE 851=stopped
 		log.fine(CLASS_NAME,methodName,"851");
@@ -110,15 +119,10 @@ public class CommsReceiver implements Runnable {
 	 * Run loop to receive messages from the server.
 	 */
 	public void run() {
-		recThread = Thread.currentThread();
-		recThread.setName(threadName);
+		Thread.currentThread().setName(threadName);
 		final String methodName = "run";
 		MqttToken token = null;
 
-		synchronized (lifecycle) {
-			current_state = State.RUNNING;
-		}
-		
 		try {
 			State my_target;
 			synchronized (lifecycle) {
@@ -204,7 +208,6 @@ public class CommsReceiver implements Runnable {
 			}
 		} // end try
 
-		recThread = null;
 		//@TRACE 854=<
 		log.fine(CLASS_NAME,methodName,"854");
 	}


### PR DESCRIPTION
Please make sure that the following boxes are checked before submitting your Pull Request, thank you!

- [X] This change is against the develop branch, **not** master.
- [X] You have signed the [Eclipse ECA](https://wiki.eclipse.org/ECA)
- [X] All of your commits have been signed-off with the correct email address (The same one that you used to sign the CLA) _Hint: use the -s argument when committing_.
- [X] If This PR fixes an issue, that you reference the issue below. OR if this is a new issue that you are fixing straight away that you add some Description about the bug and how this will fix it.
- [ ] If this is new functionality, You have added the appropriate Unit tests.

Related to #651.

Related commits: a6faf77, 4b23f12

Do not wait for threads to start & stop with Thread.sleep(), as this causes the amount of time taken for a project that initiates many connections to start up, to grow exponentially.

Threads will enter the running state immediately when start() is called, to avoid the need to synchronize with the thread.
If the ExecutorService is used, gracefully terminate threads by waiting for their completion, rather than interupting. This will keep the behaviour of Paho uniform, regardless of whether an ExecutorService is used or not.

Signed-off-by: Liu Woon Yung <pirorin187@gmail.com>