### PR TITLE
Introduces the ability to disable the execution of online tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,9 @@ To then build the library run the following maven command: ```mvn package -Dskip
 
 This will build the client library without running the tests. The jars for the library, source and javadoc can be found in the ```org.eclipse.paho.client.mqttv3/target``` directory.
 
+To build this library offline, use the command: ```mvn -Plocal clean package```
+
+
 ## Documentation
 Reference documentation is online at: [http://www.eclipse.org/paho/files/javadoc/index.html](http://www.eclipse.org/paho/files/javadoc/index.html)
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,17 @@ To then build the library run the following maven command: ```mvn package -Dskip
 
 This will build the client library without running the tests. The jars for the library, source and javadoc can be found in the ```org.eclipse.paho.client.mqttv3/target``` directory.
 
-To build this library offline, use the command: ```mvn -Plocal clean package```
+#### Test Selection and Setup
+
+By default, Paho will try to execute all tests available in the code base. This may not be ideal in all situations and, 
+as such, the code provides the ability to turn on/off certain categories of tests. This is done by filtering out the
+tests by using the categories they are assigned along with the exclude-test profile. The test categories are defined in
+the package org.eclipse.paho.common.test.categories. For example, to filter out MQTT v5 tests:
+
+```mvn -Pexclude-tests -Dexclude.groups="org.eclipse.paho.common.test.categories.MQTTV5Test" clean package```
+
+Filters can be combined to disable a larger set of tests. For example, to disable both MQTT v5, SSL and
+WebSockets, run: ```mvn -Pexclude-tests -Dexclude.groups="org.eclipse.paho.common.test.categories.MQTTV5Test,org.eclipse.paho.common.test.categories.ExternalTest,org.eclipse.paho.common.test.categories.SSLTest,org.eclipse.paho.common.test.categories.WebSockTest" clean package```
 
 
 ## Documentation

--- a/org.eclipse.paho.client.mqttv3.test/pom.xml
+++ b/org.eclipse.paho.client.mqttv3.test/pom.xml
@@ -102,22 +102,4 @@
 			<artifactId>junit</artifactId>
 		</dependency>
 	</dependencies>
-
-	<profiles>
-		<profile>
-			<id>local</id>
-			<build>
-				<plugins>
-					<plugin>
-						<groupId>org.apache.maven.plugins</groupId>
-						<artifactId>maven-surefire-plugin</artifactId>
-						<version>3.0.0-M3</version>
-						<configuration>
-							<excludedGroups>org.eclipse.paho.common.test.categories.OnlineTest</excludedGroups>
-						</configuration>
-					</plugin>
-				</plugins>
-			</build>
-		</profile>
-	</profiles>
 </project>

--- a/org.eclipse.paho.client.mqttv3.test/pom.xml
+++ b/org.eclipse.paho.client.mqttv3.test/pom.xml
@@ -85,6 +85,14 @@
 	<dependencies>
 		<dependency>
 			<groupId>org.eclipse.paho</groupId>
+			<artifactId>org.eclipse.paho.common</artifactId>
+			<version>1.2.1-SNAPSHOT</version>
+			<scope>test</scope>
+			<type>test-jar</type>
+		</dependency>
+
+		<dependency>
+			<groupId>org.eclipse.paho</groupId>
 			<artifactId>org.eclipse.paho.client.mqttv3</artifactId>
 			<version>1.2.1-SNAPSHOT</version>
 		</dependency>
@@ -94,4 +102,22 @@
 			<artifactId>junit</artifactId>
 		</dependency>
 	</dependencies>
+
+	<profiles>
+		<profile>
+			<id>local</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-surefire-plugin</artifactId>
+						<version>3.0.0-M3</version>
+						<configuration>
+							<excludedGroups>org.eclipse.paho.common.test.categories.OnlineTest</excludedGroups>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
 </project>

--- a/org.eclipse.paho.client.mqttv3.test/src/test/java/org/eclipse/paho/client/mqttv3/test/BasicSSLTest.java
+++ b/org.eclipse.paho.client.mqttv3.test/src/test/java/org/eclipse/paho/client/mqttv3/test/BasicSSLTest.java
@@ -26,21 +26,21 @@ import org.eclipse.paho.client.mqttv3.test.logging.LoggingUtilities;
 import org.eclipse.paho.client.mqttv3.test.properties.TestProperties;
 import org.eclipse.paho.client.mqttv3.test.utilities.MqttV3Receiver;
 import org.eclipse.paho.client.mqttv3.test.utilities.Utility;
+import org.eclipse.paho.common.test.categories.MQTTV3Test;
 import org.eclipse.paho.common.test.categories.OnlineTest;
+import org.eclipse.paho.common.test.categories.SSLTest;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
 
 
 /**
  * This test aims to run some basic SSL functionality tests of the MQTT client
  */
 
-@Category(OnlineTest.class)
+@Category({OnlineTest.class, MQTTV3Test.class, SSLTest.class})
 public class BasicSSLTest {
 
   static final Class<?> cclass = BasicSSLTest.class;

--- a/org.eclipse.paho.client.mqttv3.test/src/test/java/org/eclipse/paho/client/mqttv3/test/BasicSSLTest.java
+++ b/org.eclipse.paho.client.mqttv3.test/src/test/java/org/eclipse/paho/client/mqttv3/test/BasicSSLTest.java
@@ -26,16 +26,21 @@ import org.eclipse.paho.client.mqttv3.test.logging.LoggingUtilities;
 import org.eclipse.paho.client.mqttv3.test.properties.TestProperties;
 import org.eclipse.paho.client.mqttv3.test.utilities.MqttV3Receiver;
 import org.eclipse.paho.client.mqttv3.test.utilities.Utility;
+import org.eclipse.paho.common.test.categories.OnlineTest;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
 
 
 /**
  * This test aims to run some basic SSL functionality tests of the MQTT client
  */
 
+@Category(OnlineTest.class)
 public class BasicSSLTest {
 
   static final Class<?> cclass = BasicSSLTest.class;

--- a/org.eclipse.paho.client.mqttv3.test/src/test/java/org/eclipse/paho/client/mqttv3/test/BasicTest.java
+++ b/org.eclipse.paho.client.mqttv3.test/src/test/java/org/eclipse/paho/client/mqttv3/test/BasicTest.java
@@ -33,6 +33,8 @@ import org.eclipse.paho.client.mqttv3.test.client.MqttClientFactoryPaho;
 import org.eclipse.paho.client.mqttv3.test.logging.LoggingUtilities;
 import org.eclipse.paho.client.mqttv3.test.properties.TestProperties;
 import org.eclipse.paho.client.mqttv3.test.utilities.Utility;
+import org.eclipse.paho.common.test.categories.ExternalTest;
+import org.eclipse.paho.common.test.categories.MQTTV3Test;
 import org.eclipse.paho.common.test.categories.OnlineTest;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -44,7 +46,7 @@ import org.junit.experimental.categories.Category;
 /**
  * Tests providing a basic general coverage for the MQTT client API
  */
-@Category(OnlineTest.class)
+@Category({OnlineTest.class, MQTTV3Test.class})
 public class BasicTest {
 
   static final Class<?> cclass = BasicTest.class;
@@ -332,6 +334,8 @@ public class BasicTest {
   }
 
 
+
+  @Category(ExternalTest.class)
   @Test
   public void test330() throws Exception {
     String methodName = Utility.getMethodName();

--- a/org.eclipse.paho.client.mqttv3.test/src/test/java/org/eclipse/paho/client/mqttv3/test/BasicTest.java
+++ b/org.eclipse.paho.client.mqttv3.test/src/test/java/org/eclipse/paho/client/mqttv3/test/BasicTest.java
@@ -33,16 +33,18 @@ import org.eclipse.paho.client.mqttv3.test.client.MqttClientFactoryPaho;
 import org.eclipse.paho.client.mqttv3.test.logging.LoggingUtilities;
 import org.eclipse.paho.client.mqttv3.test.properties.TestProperties;
 import org.eclipse.paho.client.mqttv3.test.utilities.Utility;
+import org.eclipse.paho.common.test.categories.OnlineTest;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 
 /**
  * Tests providing a basic general coverage for the MQTT client API
  */
-
+@Category(OnlineTest.class)
 public class BasicTest {
 
   static final Class<?> cclass = BasicTest.class;

--- a/org.eclipse.paho.client.mqttv3.test/src/test/java/org/eclipse/paho/client/mqttv3/test/Bug443142Test.java
+++ b/org.eclipse.paho.client.mqttv3.test/src/test/java/org/eclipse/paho/client/mqttv3/test/Bug443142Test.java
@@ -13,6 +13,7 @@ import org.eclipse.paho.client.mqttv3.MqttMessage;
 import org.eclipse.paho.client.mqttv3.test.logging.LoggingUtilities;
 import org.eclipse.paho.client.mqttv3.test.properties.TestProperties;
 import org.eclipse.paho.client.mqttv3.test.utilities.Utility;
+import org.eclipse.paho.common.test.categories.MQTTV3Test;
 import org.eclipse.paho.common.test.categories.OnlineTest;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -28,7 +29,7 @@ import org.junit.experimental.categories.Category;
  * condition will never be false when the {@code messageQueue} is full and not {@code quiescing}, even when the callback
  * thread is trying to stop.
  */
-@Category(OnlineTest.class)
+@Category({OnlineTest.class, MQTTV3Test.class})
 public class Bug443142Test {
     private static final Logger log = Logger.getLogger(Bug443142Test.class.getName());
     private static URI serverURI;

--- a/org.eclipse.paho.client.mqttv3.test/src/test/java/org/eclipse/paho/client/mqttv3/test/Bug443142Test.java
+++ b/org.eclipse.paho.client.mqttv3.test/src/test/java/org/eclipse/paho/client/mqttv3/test/Bug443142Test.java
@@ -13,9 +13,11 @@ import org.eclipse.paho.client.mqttv3.MqttMessage;
 import org.eclipse.paho.client.mqttv3.test.logging.LoggingUtilities;
 import org.eclipse.paho.client.mqttv3.test.properties.TestProperties;
 import org.eclipse.paho.client.mqttv3.test.utilities.Utility;
+import org.eclipse.paho.common.test.categories.OnlineTest;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 /**
  * <a href="https://bugs.eclipse.org/bugs/show_bug.cgi?id=443142"> Bug 443142 </a>: Deadlocked "MQTT Rec:" When
@@ -26,6 +28,7 @@ import org.junit.Test;
  * condition will never be false when the {@code messageQueue} is full and not {@code quiescing}, even when the callback
  * thread is trying to stop.
  */
+@Category(OnlineTest.class)
 public class Bug443142Test {
     private static final Logger log = Logger.getLogger(Bug443142Test.class.getName());
     private static URI serverURI;

--- a/org.eclipse.paho.client.mqttv3.test/src/test/java/org/eclipse/paho/client/mqttv3/test/Issue370Test.java
+++ b/org.eclipse.paho.client.mqttv3.test/src/test/java/org/eclipse/paho/client/mqttv3/test/Issue370Test.java
@@ -17,11 +17,14 @@ package org.eclipse.paho.client.mqttv3.test;
 
 import org.eclipse.paho.client.mqttv3.MqttAsyncClient;
 import org.eclipse.paho.client.mqttv3.MqttException;
+import org.eclipse.paho.common.test.categories.OnlineTest;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 /**
  * This is a reproducer for issue #370
  */
+@Category(OnlineTest.class)
 public class Issue370Test {
     @Test
     public void noOpenClose() throws MqttException {

--- a/org.eclipse.paho.client.mqttv3.test/src/test/java/org/eclipse/paho/client/mqttv3/test/Issue370Test.java
+++ b/org.eclipse.paho.client.mqttv3.test/src/test/java/org/eclipse/paho/client/mqttv3/test/Issue370Test.java
@@ -17,6 +17,7 @@ package org.eclipse.paho.client.mqttv3.test;
 
 import org.eclipse.paho.client.mqttv3.MqttAsyncClient;
 import org.eclipse.paho.client.mqttv3.MqttException;
+import org.eclipse.paho.common.test.categories.MQTTV3Test;
 import org.eclipse.paho.common.test.categories.OnlineTest;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -24,7 +25,7 @@ import org.junit.experimental.categories.Category;
 /**
  * This is a reproducer for issue #370
  */
-@Category(OnlineTest.class)
+@Category({OnlineTest.class, MQTTV3Test.class})
 public class Issue370Test {
     @Test
     public void noOpenClose() throws MqttException {

--- a/org.eclipse.paho.client.mqttv3.test/src/test/java/org/eclipse/paho/client/mqttv3/test/LiveTakeOverTest.java
+++ b/org.eclipse.paho.client.mqttv3.test/src/test/java/org/eclipse/paho/client/mqttv3/test/LiveTakeOverTest.java
@@ -29,11 +29,15 @@ import org.eclipse.paho.client.mqttv3.test.properties.TestProperties;
 import org.eclipse.paho.client.mqttv3.test.utilities.MqttV3Receiver;
 import org.eclipse.paho.client.mqttv3.test.utilities.MqttV3Receiver.ReceivedMessage;
 import org.eclipse.paho.client.mqttv3.test.utilities.Utility;
+import org.eclipse.paho.common.test.categories.OnlineTest;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+
+@Category(OnlineTest.class)
 public class LiveTakeOverTest {
 
   private static final Class<?> cclass = LiveTakeOverTest.class;

--- a/org.eclipse.paho.client.mqttv3.test/src/test/java/org/eclipse/paho/client/mqttv3/test/LiveTakeOverTest.java
+++ b/org.eclipse.paho.client.mqttv3.test/src/test/java/org/eclipse/paho/client/mqttv3/test/LiveTakeOverTest.java
@@ -29,6 +29,7 @@ import org.eclipse.paho.client.mqttv3.test.properties.TestProperties;
 import org.eclipse.paho.client.mqttv3.test.utilities.MqttV3Receiver;
 import org.eclipse.paho.client.mqttv3.test.utilities.MqttV3Receiver.ReceivedMessage;
 import org.eclipse.paho.client.mqttv3.test.utilities.Utility;
+import org.eclipse.paho.common.test.categories.MQTTV3Test;
 import org.eclipse.paho.common.test.categories.OnlineTest;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -37,7 +38,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 
-@Category(OnlineTest.class)
+@Category({OnlineTest.class, MQTTV3Test.class})
 public class LiveTakeOverTest {
 
   private static final Class<?> cclass = LiveTakeOverTest.class;

--- a/org.eclipse.paho.client.mqttv3.test/src/test/java/org/eclipse/paho/client/mqttv3/test/ModelTestCase.java
+++ b/org.eclipse.paho.client.mqttv3.test/src/test/java/org/eclipse/paho/client/mqttv3/test/ModelTestCase.java
@@ -45,9 +45,11 @@ import org.eclipse.paho.client.mqttv3.test.client.MqttClientFactoryPaho;
 import org.eclipse.paho.client.mqttv3.test.logging.LoggingUtilities;
 import org.eclipse.paho.client.mqttv3.test.properties.TestProperties;
 import org.eclipse.paho.client.mqttv3.test.utilities.Utility;
+import org.eclipse.paho.common.test.categories.MQTTV3Test;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 /**
  * Client test which rapidly tries random combinations of connect,
@@ -56,7 +58,7 @@ import org.junit.Test;
  * of the history of commands tried which can be fed back into the
  * test to re-produce a previous run (See run(String filename)
  */
-
+@Category(MQTTV3Test.class)
 public class ModelTestCase implements MqttCallback {
 
   private static final Class<?> cclass = ModelTestCase.class;

--- a/org.eclipse.paho.client.mqttv3.test/src/test/java/org/eclipse/paho/client/mqttv3/test/MqttConnectOptionsTest.java
+++ b/org.eclipse.paho.client.mqttv3.test/src/test/java/org/eclipse/paho/client/mqttv3/test/MqttConnectOptionsTest.java
@@ -6,8 +6,12 @@ import static org.eclipse.paho.client.mqttv3.MqttConnectOptions.MQTT_VERSION_3_1
 import static org.eclipse.paho.client.mqttv3.MqttConnectOptions.MQTT_VERSION_3_1_1;
 import static org.eclipse.paho.client.mqttv3.MqttConnectOptions.MQTT_VERSION_DEFAULT;
 import static org.junit.Assert.*;
-import org.junit.Test;
 
+import org.eclipse.paho.common.test.categories.MQTTV3Test;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(MQTTV3Test.class)
 public class MqttConnectOptionsTest {
 
 	@Test

--- a/org.eclipse.paho.client.mqttv3.test/src/test/java/org/eclipse/paho/client/mqttv3/test/MqttDataTypesTest.java
+++ b/org.eclipse.paho.client.mqttv3.test/src/test/java/org/eclipse/paho/client/mqttv3/test/MqttDataTypesTest.java
@@ -11,9 +11,12 @@ import java.io.IOException;
 
 import org.eclipse.paho.client.mqttv3.MqttException;
 import org.eclipse.paho.client.mqttv3.internal.wire.MqttWireMessage;
+import org.eclipse.paho.common.test.categories.MQTTV3Test;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@Category(MQTTV3Test.class)
 public class MqttDataTypesTest {
 
 

--- a/org.eclipse.paho.client.mqttv3.test/src/test/java/org/eclipse/paho/client/mqttv3/test/MqttTopicTest.java
+++ b/org.eclipse.paho.client.mqttv3.test/src/test/java/org/eclipse/paho/client/mqttv3/test/MqttTopicTest.java
@@ -18,14 +18,17 @@ import java.util.logging.Logger;
 import org.eclipse.paho.client.mqttv3.MqttTopic;
 import org.eclipse.paho.client.mqttv3.test.logging.LoggingUtilities;
 import org.eclipse.paho.client.mqttv3.test.utilities.Utility;
+import org.eclipse.paho.common.test.categories.MQTTV3Test;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 /**
  * Tests mqtt topic wildcards
  */
+@Category(MQTTV3Test.class)
 public class MqttTopicTest {
 
 	static final Class<?> cclass = MqttTopicTest.class;

--- a/org.eclipse.paho.client.mqttv3.test/src/test/java/org/eclipse/paho/client/mqttv3/test/NetworkModuleServiceTest.java
+++ b/org.eclipse.paho.client.mqttv3.test/src/test/java/org/eclipse/paho/client/mqttv3/test/NetworkModuleServiceTest.java
@@ -13,8 +13,11 @@ import org.eclipse.paho.client.mqttv3.MqttException;
 import org.eclipse.paho.client.mqttv3.internal.NetworkModule;
 import org.eclipse.paho.client.mqttv3.internal.NetworkModuleService;
 import org.eclipse.paho.client.mqttv3.internal.TCPNetworkModule;
+import org.eclipse.paho.common.test.categories.MQTTV3Test;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@Category(MQTTV3Test.class)
 public class NetworkModuleServiceTest {
 
 	@Test

--- a/org.eclipse.paho.client.mqttv3.test/src/test/java/org/eclipse/paho/client/mqttv3/test/PerSubscriptionMessageHandlerTest.java
+++ b/org.eclipse.paho.client.mqttv3.test/src/test/java/org/eclipse/paho/client/mqttv3/test/PerSubscriptionMessageHandlerTest.java
@@ -22,6 +22,7 @@ import java.util.UUID;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import org.eclipse.paho.common.test.categories.OnlineTest;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -38,7 +39,12 @@ import org.eclipse.paho.client.mqttv3.test.client.MqttClientFactoryPaho;
 import org.eclipse.paho.client.mqttv3.test.logging.LoggingUtilities;
 import org.eclipse.paho.client.mqttv3.test.properties.TestProperties;
 import org.eclipse.paho.client.mqttv3.test.utilities.Utility;
+import org.junit.experimental.categories.Categories;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
+
+@Category(OnlineTest.class)
 public class PerSubscriptionMessageHandlerTest {
 	
 	  static final Class<?> cclass = PerSubscriptionMessageHandlerTest.class;

--- a/org.eclipse.paho.client.mqttv3.test/src/test/java/org/eclipse/paho/client/mqttv3/test/PerSubscriptionMessageHandlerTest.java
+++ b/org.eclipse.paho.client.mqttv3.test/src/test/java/org/eclipse/paho/client/mqttv3/test/PerSubscriptionMessageHandlerTest.java
@@ -22,6 +22,7 @@ import java.util.UUID;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import org.eclipse.paho.common.test.categories.MQTTV3Test;
 import org.eclipse.paho.common.test.categories.OnlineTest;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -39,12 +40,10 @@ import org.eclipse.paho.client.mqttv3.test.client.MqttClientFactoryPaho;
 import org.eclipse.paho.client.mqttv3.test.logging.LoggingUtilities;
 import org.eclipse.paho.client.mqttv3.test.properties.TestProperties;
 import org.eclipse.paho.client.mqttv3.test.utilities.Utility;
-import org.junit.experimental.categories.Categories;
 import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
 
 
-@Category(OnlineTest.class)
+@Category({OnlineTest.class, MQTTV3Test.class})
 public class PerSubscriptionMessageHandlerTest {
 	
 	  static final Class<?> cclass = PerSubscriptionMessageHandlerTest.class;

--- a/org.eclipse.paho.client.mqttv3.test/src/test/java/org/eclipse/paho/client/mqttv3/test/SSLSessionResumptionTest.java
+++ b/org.eclipse.paho.client.mqttv3.test/src/test/java/org/eclipse/paho/client/mqttv3/test/SSLSessionResumptionTest.java
@@ -37,7 +37,9 @@ import org.eclipse.paho.client.mqttv3.MqttConnectOptions;
 import org.eclipse.paho.client.mqttv3.test.logging.LoggingUtilities;
 import org.eclipse.paho.client.mqttv3.test.properties.TestProperties;
 import org.eclipse.paho.client.mqttv3.test.utilities.Utility;
+import org.eclipse.paho.common.test.categories.MQTTV3Test;
 import org.eclipse.paho.common.test.categories.OnlineTest;
+import org.eclipse.paho.common.test.categories.SSLTest;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -45,7 +47,7 @@ import org.junit.experimental.categories.Category;
 /**
  * This test aims to run some basic SSL functionality tests of the MQTT client
  */
-@Category(OnlineTest.class)
+@Category({OnlineTest.class, MQTTV3Test.class, SSLTest.class})
 public class SSLSessionResumptionTest {
 
 	static final Class<?> cclass = SSLSessionResumptionTest.class;

--- a/org.eclipse.paho.client.mqttv3.test/src/test/java/org/eclipse/paho/client/mqttv3/test/SSLSessionResumptionTest.java
+++ b/org.eclipse.paho.client.mqttv3.test/src/test/java/org/eclipse/paho/client/mqttv3/test/SSLSessionResumptionTest.java
@@ -37,13 +37,15 @@ import org.eclipse.paho.client.mqttv3.MqttConnectOptions;
 import org.eclipse.paho.client.mqttv3.test.logging.LoggingUtilities;
 import org.eclipse.paho.client.mqttv3.test.properties.TestProperties;
 import org.eclipse.paho.client.mqttv3.test.utilities.Utility;
+import org.eclipse.paho.common.test.categories.OnlineTest;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 /**
  * This test aims to run some basic SSL functionality tests of the MQTT client
  */
-
+@Category(OnlineTest.class)
 public class SSLSessionResumptionTest {
 
 	static final Class<?> cclass = SSLSessionResumptionTest.class;

--- a/org.eclipse.paho.client.mqttv3.test/src/test/java/org/eclipse/paho/client/mqttv3/test/SendReceiveAsyncCallbackTest.java
+++ b/org.eclipse.paho.client.mqttv3.test/src/test/java/org/eclipse/paho/client/mqttv3/test/SendReceiveAsyncCallbackTest.java
@@ -25,20 +25,20 @@ import org.eclipse.paho.client.mqttv3.IMqttActionListener;
 import org.eclipse.paho.client.mqttv3.IMqttDeliveryToken;
 import org.eclipse.paho.client.mqttv3.IMqttMessageListener;
 import org.eclipse.paho.client.mqttv3.IMqttToken;
-import org.eclipse.paho.client.mqttv3.MqttCallback;
 import org.eclipse.paho.client.mqttv3.MqttMessage;
 import org.eclipse.paho.client.mqttv3.test.client.MqttClientFactoryPaho;
 import org.eclipse.paho.client.mqttv3.test.logging.LoggingUtilities;
 import org.eclipse.paho.client.mqttv3.test.properties.TestProperties;
 import org.eclipse.paho.client.mqttv3.test.utilities.Utility;
+import org.eclipse.paho.common.test.categories.OnlineTest;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
-/**
- *
- */
+
+@Category(OnlineTest.class)
 public class SendReceiveAsyncCallbackTest {
 
 	static final Class<?> cclass = SendReceiveAsyncTest.class;

--- a/org.eclipse.paho.client.mqttv3.test/src/test/java/org/eclipse/paho/client/mqttv3/test/SendReceiveAsyncCallbackTest.java
+++ b/org.eclipse.paho.client.mqttv3.test/src/test/java/org/eclipse/paho/client/mqttv3/test/SendReceiveAsyncCallbackTest.java
@@ -30,6 +30,7 @@ import org.eclipse.paho.client.mqttv3.test.client.MqttClientFactoryPaho;
 import org.eclipse.paho.client.mqttv3.test.logging.LoggingUtilities;
 import org.eclipse.paho.client.mqttv3.test.properties.TestProperties;
 import org.eclipse.paho.client.mqttv3.test.utilities.Utility;
+import org.eclipse.paho.common.test.categories.MQTTV3Test;
 import org.eclipse.paho.common.test.categories.OnlineTest;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -38,7 +39,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 
-@Category(OnlineTest.class)
+@Category({OnlineTest.class, MQTTV3Test.class})
 public class SendReceiveAsyncCallbackTest {
 
 	static final Class<?> cclass = SendReceiveAsyncTest.class;

--- a/org.eclipse.paho.client.mqttv3.test/src/test/java/org/eclipse/paho/client/mqttv3/test/SendReceiveAsyncTest.java
+++ b/org.eclipse.paho.client.mqttv3.test/src/test/java/org/eclipse/paho/client/mqttv3/test/SendReceiveAsyncTest.java
@@ -31,6 +31,8 @@ import org.eclipse.paho.client.mqttv3.test.logging.LoggingUtilities;
 import org.eclipse.paho.client.mqttv3.test.properties.TestProperties;
 import org.eclipse.paho.client.mqttv3.test.utilities.MqttV3Receiver;
 import org.eclipse.paho.client.mqttv3.test.utilities.Utility;
+import org.eclipse.paho.common.test.categories.ExternalTest;
+import org.eclipse.paho.common.test.categories.MQTTV3Test;
 import org.eclipse.paho.common.test.categories.OnlineTest;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -38,7 +40,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
-@Category(OnlineTest.class)
+@Category({OnlineTest.class, MQTTV3Test.class})
 public class SendReceiveAsyncTest {
 
   static final Class<?> cclass = SendReceiveAsyncTest.class;
@@ -603,6 +605,7 @@ public class SendReceiveAsyncTest {
    * Test the behavior of the connection timeout when connecting to a non MQTT server.
    * i.e. ssh port 22
    */
+  @Category(ExternalTest.class)
   @Test
   public void testConnectTimeout() throws Exception {
 	  final String methodName = Utility.getMethodName();

--- a/org.eclipse.paho.client.mqttv3.test/src/test/java/org/eclipse/paho/client/mqttv3/test/SendReceiveAsyncTest.java
+++ b/org.eclipse.paho.client.mqttv3.test/src/test/java/org/eclipse/paho/client/mqttv3/test/SendReceiveAsyncTest.java
@@ -31,14 +31,14 @@ import org.eclipse.paho.client.mqttv3.test.logging.LoggingUtilities;
 import org.eclipse.paho.client.mqttv3.test.properties.TestProperties;
 import org.eclipse.paho.client.mqttv3.test.utilities.MqttV3Receiver;
 import org.eclipse.paho.client.mqttv3.test.utilities.Utility;
+import org.eclipse.paho.common.test.categories.OnlineTest;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
-/**
- *
- */
+@Category(OnlineTest.class)
 public class SendReceiveAsyncTest {
 
   static final Class<?> cclass = SendReceiveAsyncTest.class;

--- a/org.eclipse.paho.client.mqttv3.test/src/test/java/org/eclipse/paho/client/mqttv3/test/SendReceiveTest.java
+++ b/org.eclipse.paho.client.mqttv3.test/src/test/java/org/eclipse/paho/client/mqttv3/test/SendReceiveTest.java
@@ -27,6 +27,7 @@ import org.eclipse.paho.client.mqttv3.test.logging.LoggingUtilities;
 import org.eclipse.paho.client.mqttv3.test.properties.TestProperties;
 import org.eclipse.paho.client.mqttv3.test.utilities.MqttV3Receiver;
 import org.eclipse.paho.client.mqttv3.test.utilities.Utility;
+import org.eclipse.paho.common.test.categories.MQTTV3Test;
 import org.eclipse.paho.common.test.categories.OnlineTest;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -38,7 +39,7 @@ import org.junit.experimental.categories.Category;
  * This test expects an MQTT Server to be listening on the port 
  * given by the SERVER_URI property (which is 1883 by default)
  */
-@Category(OnlineTest.class)
+@Category({OnlineTest.class, MQTTV3Test.class})
 public class SendReceiveTest {
 
   static final Class<?> cclass = SendReceiveTest.class;

--- a/org.eclipse.paho.client.mqttv3.test/src/test/java/org/eclipse/paho/client/mqttv3/test/SendReceiveTest.java
+++ b/org.eclipse.paho.client.mqttv3.test/src/test/java/org/eclipse/paho/client/mqttv3/test/SendReceiveTest.java
@@ -27,15 +27,18 @@ import org.eclipse.paho.client.mqttv3.test.logging.LoggingUtilities;
 import org.eclipse.paho.client.mqttv3.test.properties.TestProperties;
 import org.eclipse.paho.client.mqttv3.test.utilities.MqttV3Receiver;
 import org.eclipse.paho.client.mqttv3.test.utilities.Utility;
+import org.eclipse.paho.common.test.categories.OnlineTest;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 /**
  * This test expects an MQTT Server to be listening on the port 
  * given by the SERVER_URI property (which is 1883 by default)
  */
+@Category(OnlineTest.class)
 public class SendReceiveTest {
 
   static final Class<?> cclass = SendReceiveTest.class;

--- a/org.eclipse.paho.client.mqttv3.test/src/test/java/org/eclipse/paho/client/mqttv3/test/TLSHostnameVerificationTest.java
+++ b/org.eclipse.paho.client.mqttv3.test/src/test/java/org/eclipse/paho/client/mqttv3/test/TLSHostnameVerificationTest.java
@@ -24,14 +24,18 @@ import org.eclipse.paho.client.mqttv3.MqttConnectOptions;
 import org.eclipse.paho.client.mqttv3.test.logging.LoggingUtilities;
 import org.eclipse.paho.client.mqttv3.test.properties.TestProperties;
 import org.eclipse.paho.client.mqttv3.test.utilities.Utility;
+import org.eclipse.paho.common.test.categories.OnlineTest;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.experimental.categories.Categories;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 /**
  * This test aims to run some basic SSL functionality tests of the MQTT client
  */
-
+@Category(OnlineTest.class)
 public class TLSHostnameVerificationTest {
 
 	static final Class<?> cclass = TLSHostnameVerificationTest.class;

--- a/org.eclipse.paho.client.mqttv3.test/src/test/java/org/eclipse/paho/client/mqttv3/test/TLSHostnameVerificationTest.java
+++ b/org.eclipse.paho.client.mqttv3.test/src/test/java/org/eclipse/paho/client/mqttv3/test/TLSHostnameVerificationTest.java
@@ -24,18 +24,18 @@ import org.eclipse.paho.client.mqttv3.MqttConnectOptions;
 import org.eclipse.paho.client.mqttv3.test.logging.LoggingUtilities;
 import org.eclipse.paho.client.mqttv3.test.properties.TestProperties;
 import org.eclipse.paho.client.mqttv3.test.utilities.Utility;
+import org.eclipse.paho.common.test.categories.MQTTV3Test;
 import org.eclipse.paho.common.test.categories.OnlineTest;
+import org.eclipse.paho.common.test.categories.SSLTest;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.junit.experimental.categories.Categories;
 import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
 
 /**
  * This test aims to run some basic SSL functionality tests of the MQTT client
  */
-@Category(OnlineTest.class)
+@Category({OnlineTest.class, MQTTV3Test.class, SSLTest.class})
 public class TLSHostnameVerificationTest {
 
 	static final Class<?> cclass = TLSHostnameVerificationTest.class;

--- a/org.eclipse.paho.client.mqttv3.test/src/test/java/org/eclipse/paho/client/mqttv3/test/WebSocketTest.java
+++ b/org.eclipse.paho.client.mqttv3.test/src/test/java/org/eclipse/paho/client/mqttv3/test/WebSocketTest.java
@@ -31,7 +31,9 @@ import org.eclipse.paho.client.mqttv3.test.client.MqttClientFactoryPaho;
 import org.eclipse.paho.client.mqttv3.test.logging.LoggingUtilities;
 import org.eclipse.paho.client.mqttv3.test.properties.TestProperties;
 import org.eclipse.paho.client.mqttv3.test.utilities.Utility;
+import org.eclipse.paho.common.test.categories.MQTTV3Test;
 import org.eclipse.paho.common.test.categories.OnlineTest;
+import org.eclipse.paho.common.test.categories.WebSockTest;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -42,7 +44,7 @@ import org.junit.experimental.categories.Category;
 /**
  * Tests providing a basic general coverage for the MQTT WebSocket Functionality
  */
-@Category(OnlineTest.class)
+@Category({OnlineTest.class, MQTTV3Test.class, WebSockTest.class})
 public class WebSocketTest {
 
   static final Class<?> cclass = WebSocketTest.class;

--- a/org.eclipse.paho.client.mqttv3.test/src/test/java/org/eclipse/paho/client/mqttv3/test/WebSocketTest.java
+++ b/org.eclipse.paho.client.mqttv3.test/src/test/java/org/eclipse/paho/client/mqttv3/test/WebSocketTest.java
@@ -31,16 +31,18 @@ import org.eclipse.paho.client.mqttv3.test.client.MqttClientFactoryPaho;
 import org.eclipse.paho.client.mqttv3.test.logging.LoggingUtilities;
 import org.eclipse.paho.client.mqttv3.test.properties.TestProperties;
 import org.eclipse.paho.client.mqttv3.test.utilities.Utility;
+import org.eclipse.paho.common.test.categories.OnlineTest;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 
 /**
  * Tests providing a basic general coverage for the MQTT WebSocket Functionality
  */
-
+@Category(OnlineTest.class)
 public class WebSocketTest {
 
   static final Class<?> cclass = WebSocketTest.class;

--- a/org.eclipse.paho.client.mqttv3.test/src/test/java/org/eclipse/paho/client/mqttv3/test/automaticReconnect/AutomaticReconnectTest.java
+++ b/org.eclipse.paho.client.mqttv3.test/src/test/java/org/eclipse/paho/client/mqttv3/test/automaticReconnect/AutomaticReconnectTest.java
@@ -27,6 +27,7 @@ import org.eclipse.paho.client.mqttv3.test.logging.LoggingUtilities;
 import org.eclipse.paho.client.mqttv3.test.properties.TestProperties;
 import org.eclipse.paho.client.mqttv3.test.utilities.ConnectionManipulationProxyServer;
 import org.eclipse.paho.client.mqttv3.test.utilities.Utility;
+import org.eclipse.paho.common.test.categories.MQTTV3Test;
 import org.eclipse.paho.common.test.categories.OnlineTest;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -35,7 +36,7 @@ import org.junit.Assert;
 import org.junit.experimental.categories.Category;
 
 
-@Category(OnlineTest.class)
+@Category({OnlineTest.class, MQTTV3Test.class})
 public class AutomaticReconnectTest{
 	
 	static final Class<?> cclass = AutomaticReconnectTest.class;

--- a/org.eclipse.paho.client.mqttv3.test/src/test/java/org/eclipse/paho/client/mqttv3/test/automaticReconnect/AutomaticReconnectTest.java
+++ b/org.eclipse.paho.client.mqttv3.test/src/test/java/org/eclipse/paho/client/mqttv3/test/automaticReconnect/AutomaticReconnectTest.java
@@ -27,11 +27,15 @@ import org.eclipse.paho.client.mqttv3.test.logging.LoggingUtilities;
 import org.eclipse.paho.client.mqttv3.test.properties.TestProperties;
 import org.eclipse.paho.client.mqttv3.test.utilities.ConnectionManipulationProxyServer;
 import org.eclipse.paho.client.mqttv3.test.utilities.Utility;
+import org.eclipse.paho.common.test.categories.OnlineTest;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.AfterClass;
 import org.junit.Assert;
+import org.junit.experimental.categories.Category;
 
+
+@Category(OnlineTest.class)
 public class AutomaticReconnectTest{
 	
 	static final Class<?> cclass = AutomaticReconnectTest.class;

--- a/org.eclipse.paho.client.mqttv3.test/src/test/java/org/eclipse/paho/client/mqttv3/test/automaticReconnect/OfflineBufferingTest.java
+++ b/org.eclipse.paho.client.mqttv3.test/src/test/java/org/eclipse/paho/client/mqttv3/test/automaticReconnect/OfflineBufferingTest.java
@@ -38,12 +38,13 @@ import org.eclipse.paho.client.mqttv3.test.utilities.MqttV3Receiver;
 import org.eclipse.paho.client.mqttv3.test.utilities.TestMemoryPersistence;
 import org.eclipse.paho.client.mqttv3.test.utilities.Utility;
 import org.eclipse.paho.client.mqttv3.util.Debug;
+import org.eclipse.paho.common.test.categories.MQTTV3Test;
 import org.eclipse.paho.common.test.categories.OnlineTest;
 import org.junit.*;
 import org.junit.experimental.categories.Category;
 
 
-@Category(OnlineTest.class)
+@Category({OnlineTest.class, MQTTV3Test.class})
 public class OfflineBufferingTest {
 
 	static final Class<?> cclass = OfflineBufferingTest.class;

--- a/org.eclipse.paho.client.mqttv3.test/src/test/java/org/eclipse/paho/client/mqttv3/test/automaticReconnect/OfflineBufferingTest.java
+++ b/org.eclipse.paho.client.mqttv3.test/src/test/java/org/eclipse/paho/client/mqttv3/test/automaticReconnect/OfflineBufferingTest.java
@@ -38,11 +38,12 @@ import org.eclipse.paho.client.mqttv3.test.utilities.MqttV3Receiver;
 import org.eclipse.paho.client.mqttv3.test.utilities.TestMemoryPersistence;
 import org.eclipse.paho.client.mqttv3.test.utilities.Utility;
 import org.eclipse.paho.client.mqttv3.util.Debug;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.eclipse.paho.common.test.categories.OnlineTest;
+import org.junit.*;
+import org.junit.experimental.categories.Category;
 
+
+@Category(OnlineTest.class)
 public class OfflineBufferingTest {
 
 	static final Class<?> cclass = OfflineBufferingTest.class;

--- a/org.eclipse.paho.client.mqttv3.test/src/test/java/org/eclipse/paho/client/mqttv3/test/connectionLoss/ConnectionLossTest.java
+++ b/org.eclipse.paho.client.mqttv3.test/src/test/java/org/eclipse/paho/client/mqttv3/test/connectionLoss/ConnectionLossTest.java
@@ -33,6 +33,7 @@ import org.eclipse.paho.client.mqttv3.test.logging.LoggingUtilities;
 import org.eclipse.paho.client.mqttv3.test.properties.TestProperties;
 import org.eclipse.paho.client.mqttv3.test.utilities.ConnectionManipulationProxyServer;
 import org.eclipse.paho.client.mqttv3.test.utilities.Utility;
+import org.eclipse.paho.common.test.categories.MQTTV3Test;
 import org.eclipse.paho.common.test.categories.OnlineTest;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -51,7 +52,7 @@ import org.junit.experimental.categories.Category;
  * 
  * @author mcarrer
  */
-@Category(OnlineTest.class)
+@Category({OnlineTest.class, MQTTV3Test.class})
 public class ConnectionLossTest implements MqttCallback
 {
 	static final Class<?> cclass = ConnectionLossTest.class;

--- a/org.eclipse.paho.client.mqttv3.test/src/test/java/org/eclipse/paho/client/mqttv3/test/connectionLoss/ConnectionLossTest.java
+++ b/org.eclipse.paho.client.mqttv3.test/src/test/java/org/eclipse/paho/client/mqttv3/test/connectionLoss/ConnectionLossTest.java
@@ -33,11 +33,13 @@ import org.eclipse.paho.client.mqttv3.test.logging.LoggingUtilities;
 import org.eclipse.paho.client.mqttv3.test.properties.TestProperties;
 import org.eclipse.paho.client.mqttv3.test.utilities.ConnectionManipulationProxyServer;
 import org.eclipse.paho.client.mqttv3.test.utilities.Utility;
+import org.eclipse.paho.common.test.categories.OnlineTest;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 /**
  * These tests verify whether paho can successfully detect a loss of connection with a broker.
@@ -49,7 +51,7 @@ import org.junit.Test;
  * 
  * @author mcarrer
  */
-
+@Category(OnlineTest.class)
 public class ConnectionLossTest implements MqttCallback
 {
 	static final Class<?> cclass = ConnectionLossTest.class;

--- a/org.eclipse.paho.common/pom.xml
+++ b/org.eclipse.paho.common/pom.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>java-parent</artifactId>
+        <groupId>org.eclipse.paho</groupId>
+        <version>1.2.1-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>org.eclipse.paho.common</artifactId>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.0.2</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>test-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+
+</project>

--- a/org.eclipse.paho.common/src/test/java/org/eclipse/paho/common/test/categories/ExternalTest.java
+++ b/org.eclipse.paho.common/src/test/java/org/eclipse/paho/common/test/categories/ExternalTest.java
@@ -1,0 +1,7 @@
+package org.eclipse.paho.common.test.categories;
+
+/**
+ * A subset of OnlineTest that tries to access external resources even if local testing resources are available
+ */
+public interface ExternalTest extends OnlineTest {
+}

--- a/org.eclipse.paho.common/src/test/java/org/eclipse/paho/common/test/categories/MQTTV3Test.java
+++ b/org.eclipse.paho.common/src/test/java/org/eclipse/paho/common/test/categories/MQTTV3Test.java
@@ -1,0 +1,7 @@
+package org.eclipse.paho.common.test.categories;
+
+/**
+ * This test category is used by MQTT v3 tests
+ */
+public interface MQTTV3Test {
+}

--- a/org.eclipse.paho.common/src/test/java/org/eclipse/paho/common/test/categories/MQTTV5Test.java
+++ b/org.eclipse.paho.common/src/test/java/org/eclipse/paho/common/test/categories/MQTTV5Test.java
@@ -1,0 +1,7 @@
+package org.eclipse.paho.common.test.categories;
+
+/**
+ * This test category is used by MQTT v5 tests
+ */
+public interface MQTTV5Test {
+}

--- a/org.eclipse.paho.common/src/test/java/org/eclipse/paho/common/test/categories/OnlineTest.java
+++ b/org.eclipse.paho.common/src/test/java/org/eclipse/paho/common/test/categories/OnlineTest.java
@@ -1,0 +1,7 @@
+package org.eclipse.paho.common.test.categories;
+
+/**
+ * This category of tests identifies tests that require an internet connection to work
+ */
+public interface OnlineTest {
+}

--- a/org.eclipse.paho.common/src/test/java/org/eclipse/paho/common/test/categories/SSLTest.java
+++ b/org.eclipse.paho.common/src/test/java/org/eclipse/paho/common/test/categories/SSLTest.java
@@ -1,0 +1,7 @@
+package org.eclipse.paho.common.test.categories;
+
+/**
+ * This test category identify SSL tests
+ */
+public interface SSLTest {
+}

--- a/org.eclipse.paho.common/src/test/java/org/eclipse/paho/common/test/categories/WebSockTest.java
+++ b/org.eclipse.paho.common/src/test/java/org/eclipse/paho/common/test/categories/WebSockTest.java
@@ -1,0 +1,7 @@
+package org.eclipse.paho.common.test.categories;
+
+/**
+ * This category of tests identify WebSocketTests
+ */
+public interface WebSockTest {
+}

--- a/org.eclipse.paho.mqttv5.client.test/pom.xml
+++ b/org.eclipse.paho.mqttv5.client.test/pom.xml
@@ -29,7 +29,7 @@
 						</goals>
 					</execution>
 					<execution>
-          		<id>generate-test-report</id>
+          		    <id>generate-test-report</id>
         			<phase>test</phase>
         			<goals>
             		<goal>report-aggregate</goal>

--- a/org.eclipse.paho.mqttv5.client.vertx/pom.xml
+++ b/org.eclipse.paho.mqttv5.client.vertx/pom.xml
@@ -93,23 +93,4 @@
 			</plugin>
 		</plugins>
 	</build>
-
-	<profiles>
-		<profile>
-			<id>local</id>
-			<build>
-				<plugins>
-					<plugin>
-						<groupId>org.apache.maven.plugins</groupId>
-						<artifactId>maven-surefire-plugin</artifactId>
-						<version>3.0.0-M3</version>
-						<configuration>
-							<excludedGroups>org.eclipse.paho.common.test.categories.OnlineTest</excludedGroups>
-						</configuration>
-					</plugin>
-				</plugins>
-			</build>
-		</profile>
-	</profiles>
-  
 </project>

--- a/org.eclipse.paho.mqttv5.client.vertx/pom.xml
+++ b/org.eclipse.paho.mqttv5.client.vertx/pom.xml
@@ -22,9 +22,16 @@
   		<artifactId>junit</artifactId>
   		<version>${junit.version}</version>
   	</dependency>
+	  <dependency>
+		  <groupId>org.eclipse.paho</groupId>
+		  <artifactId>org.eclipse.paho.common</artifactId>
+		  <version>1.2.1-SNAPSHOT</version>
+		  <scope>test</scope>
+		  <type>test-jar</type>
+	  </dependency>
   </dependencies>
   
- <build>
+ 	<build>
 		<plugins>
 			<plugin>
  				<groupId>org.jacoco</groupId>
@@ -86,5 +93,23 @@
 			</plugin>
 		</plugins>
 	</build>
+
+	<profiles>
+		<profile>
+			<id>local</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-surefire-plugin</artifactId>
+						<version>3.0.0-M3</version>
+						<configuration>
+							<excludedGroups>org.eclipse.paho.common.test.categories.OnlineTest</excludedGroups>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
   
 </project>

--- a/org.eclipse.paho.mqttv5.client.vertx/src/test/java/org/eclipse/paho/mqttv5/client/vertx/test/BasicSSLTest.java
+++ b/org.eclipse.paho.mqttv5.client.vertx/src/test/java/org/eclipse/paho/mqttv5/client/vertx/test/BasicSSLTest.java
@@ -19,7 +19,9 @@ import java.util.UUID;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import org.eclipse.paho.common.test.categories.MQTTV5Test;
 import org.eclipse.paho.common.test.categories.OnlineTest;
+import org.eclipse.paho.common.test.categories.SSLTest;
 import org.eclipse.paho.mqttv5.client.vertx.IMqttClient;
 import org.eclipse.paho.mqttv5.client.vertx.MqttClient;
 import org.eclipse.paho.mqttv5.client.vertx.MqttTopic;
@@ -36,7 +38,7 @@ import org.junit.experimental.categories.Category;
 /**
  * This test aims to run some basic SSL functionality tests of the MQTT client
  */
-@Category(OnlineTest.class)
+@Category({OnlineTest.class, MQTTV5Test.class, SSLTest.class})
 public class BasicSSLTest {
 
   static final Class<?> cclass = BasicSSLTest.class;

--- a/org.eclipse.paho.mqttv5.client.vertx/src/test/java/org/eclipse/paho/mqttv5/client/vertx/test/BasicSSLTest.java
+++ b/org.eclipse.paho.mqttv5.client.vertx/src/test/java/org/eclipse/paho/mqttv5/client/vertx/test/BasicSSLTest.java
@@ -19,6 +19,7 @@ import java.util.UUID;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import org.eclipse.paho.common.test.categories.OnlineTest;
 import org.eclipse.paho.mqttv5.client.vertx.IMqttClient;
 import org.eclipse.paho.mqttv5.client.vertx.MqttClient;
 import org.eclipse.paho.mqttv5.client.vertx.MqttTopic;
@@ -26,16 +27,16 @@ import org.eclipse.paho.mqttv5.client.vertx.test.logging.LoggingUtilities;
 import org.eclipse.paho.mqttv5.client.vertx.test.properties.TestProperties;
 import org.eclipse.paho.mqttv5.client.vertx.test.utilities.MqttV5Receiver;
 import org.eclipse.paho.mqttv5.client.vertx.test.utilities.Utility;
-import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 
 /**
  * This test aims to run some basic SSL functionality tests of the MQTT client
  */
-
+@Category(OnlineTest.class)
 public class BasicSSLTest {
 
   static final Class<?> cclass = BasicSSLTest.class;

--- a/org.eclipse.paho.mqttv5.client.vertx/src/test/java/org/eclipse/paho/mqttv5/client/vertx/test/BasicTest.java
+++ b/org.eclipse.paho.mqttv5.client.vertx/src/test/java/org/eclipse/paho/mqttv5/client/vertx/test/BasicTest.java
@@ -5,6 +5,7 @@ import java.util.UUID;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import org.eclipse.paho.common.test.categories.MQTTV5Test;
 import org.eclipse.paho.common.test.categories.OnlineTest;
 import org.eclipse.paho.mqttv5.client.vertx.MqttConnectionOptions;
 import org.eclipse.paho.mqttv5.client.vertx.IMqttDeliveryToken;
@@ -34,7 +35,7 @@ import org.junit.experimental.categories.Category;
  * </ul>
  *
  */
-@Category(OnlineTest.class)
+@Category({OnlineTest.class, MQTTV5Test.class})
 public class BasicTest {
 	
 	static final Class<?> cclass = BasicTest.class;

--- a/org.eclipse.paho.mqttv5.client.vertx/src/test/java/org/eclipse/paho/mqttv5/client/vertx/test/BasicTest.java
+++ b/org.eclipse.paho.mqttv5.client.vertx/src/test/java/org/eclipse/paho/mqttv5/client/vertx/test/BasicTest.java
@@ -5,6 +5,7 @@ import java.util.UUID;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import org.eclipse.paho.common.test.categories.OnlineTest;
 import org.eclipse.paho.mqttv5.client.vertx.MqttConnectionOptions;
 import org.eclipse.paho.mqttv5.client.vertx.IMqttDeliveryToken;
 import org.eclipse.paho.mqttv5.client.vertx.IMqttToken;
@@ -20,6 +21,7 @@ import org.eclipse.paho.mqttv5.common.MqttSubscription;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 /**
  * A series of basic connectivity tests to validate that basic functions work:
@@ -32,6 +34,7 @@ import org.junit.Test;
  * </ul>
  *
  */
+@Category(OnlineTest.class)
 public class BasicTest {
 	
 	static final Class<?> cclass = BasicTest.class;

--- a/org.eclipse.paho.mqttv5.client.vertx/src/test/java/org/eclipse/paho/mqttv5/client/vertx/test/ClientIdTest.java
+++ b/org.eclipse.paho.mqttv5.client.vertx/src/test/java/org/eclipse/paho/mqttv5/client/vertx/test/ClientIdTest.java
@@ -6,6 +6,7 @@ import java.net.URI;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import org.eclipse.paho.common.test.categories.MQTTV5Test;
 import org.eclipse.paho.common.test.categories.OnlineTest;
 import org.eclipse.paho.mqttv5.client.vertx.MqttAsyncClient;
 import org.eclipse.paho.mqttv5.client.vertx.persist.MemoryPersistence;
@@ -22,7 +23,7 @@ import org.junit.experimental.categories.Category;
 /**
  * 
  */
-@Category(OnlineTest.class)
+@Category({OnlineTest.class, MQTTV5Test.class})
 public class ClientIdTest {
 	private static final Logger log = Logger.getLogger(ClientIdTest.class.getName());
 

--- a/org.eclipse.paho.mqttv5.client.vertx/src/test/java/org/eclipse/paho/mqttv5/client/vertx/test/ClientIdTest.java
+++ b/org.eclipse.paho.mqttv5.client.vertx/src/test/java/org/eclipse/paho/mqttv5/client/vertx/test/ClientIdTest.java
@@ -6,6 +6,7 @@ import java.net.URI;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import org.eclipse.paho.common.test.categories.OnlineTest;
 import org.eclipse.paho.mqttv5.client.vertx.MqttAsyncClient;
 import org.eclipse.paho.mqttv5.client.vertx.persist.MemoryPersistence;
 import org.eclipse.paho.mqttv5.client.vertx.test.logging.LoggingUtilities;
@@ -16,10 +17,12 @@ import org.eclipse.paho.mqttv5.common.packet.MqttDataTypes;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 /**
  * 
  */
+@Category(OnlineTest.class)
 public class ClientIdTest {
 	private static final Logger log = Logger.getLogger(ClientIdTest.class.getName());
 

--- a/org.eclipse.paho.mqttv5.client.vertx/src/test/java/org/eclipse/paho/mqttv5/client/vertx/test/PersistenceTests.java
+++ b/org.eclipse.paho.mqttv5.client.vertx/src/test/java/org/eclipse/paho/mqttv5/client/vertx/test/PersistenceTests.java
@@ -8,6 +8,7 @@ import java.util.TimerTask;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import org.eclipse.paho.common.test.categories.MQTTV5Test;
 import org.eclipse.paho.common.test.categories.OnlineTest;
 import org.eclipse.paho.mqttv5.client.vertx.IMqttDeliveryToken;
 import org.eclipse.paho.mqttv5.client.vertx.IMqttToken;
@@ -36,7 +37,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
-@Category(OnlineTest.class)
+@Category({OnlineTest.class, MQTTV5Test.class})
 public class PersistenceTests implements MqttCallback {
 	static final Class<?> cclass = PersistenceTests.class;
 	private static final String className = cclass.getName();

--- a/org.eclipse.paho.mqttv5.client.vertx/src/test/java/org/eclipse/paho/mqttv5/client/vertx/test/PersistenceTests.java
+++ b/org.eclipse.paho.mqttv5.client.vertx/src/test/java/org/eclipse/paho/mqttv5/client/vertx/test/PersistenceTests.java
@@ -8,6 +8,7 @@ import java.util.TimerTask;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import org.eclipse.paho.common.test.categories.OnlineTest;
 import org.eclipse.paho.mqttv5.client.vertx.IMqttDeliveryToken;
 import org.eclipse.paho.mqttv5.client.vertx.IMqttToken;
 import org.eclipse.paho.mqttv5.client.vertx.MqttAsyncClient;
@@ -33,7 +34,9 @@ import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@Category(OnlineTest.class)
 public class PersistenceTests implements MqttCallback {
 	static final Class<?> cclass = PersistenceTests.class;
 	private static final String className = cclass.getName();

--- a/org.eclipse.paho.mqttv5.client.vertx/src/test/java/org/eclipse/paho/mqttv5/client/vertx/test/PublishTests.java
+++ b/org.eclipse.paho.mqttv5.client.vertx/src/test/java/org/eclipse/paho/mqttv5/client/vertx/test/PublishTests.java
@@ -6,6 +6,7 @@ import java.util.UUID;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import org.eclipse.paho.common.test.categories.OnlineTest;
 import org.eclipse.paho.mqttv5.client.vertx.IMqttDeliveryToken;
 import org.eclipse.paho.mqttv5.client.vertx.IMqttToken;
 import org.eclipse.paho.mqttv5.client.vertx.MqttAsyncClient;
@@ -20,7 +21,10 @@ import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+
+@Category(OnlineTest.class)
 public class PublishTests {
 
 	static final Class<?> cclass = PublishTests.class;

--- a/org.eclipse.paho.mqttv5.client.vertx/src/test/java/org/eclipse/paho/mqttv5/client/vertx/test/PublishTests.java
+++ b/org.eclipse.paho.mqttv5.client.vertx/src/test/java/org/eclipse/paho/mqttv5/client/vertx/test/PublishTests.java
@@ -6,6 +6,7 @@ import java.util.UUID;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import org.eclipse.paho.common.test.categories.MQTTV5Test;
 import org.eclipse.paho.common.test.categories.OnlineTest;
 import org.eclipse.paho.mqttv5.client.vertx.IMqttDeliveryToken;
 import org.eclipse.paho.mqttv5.client.vertx.IMqttToken;
@@ -24,7 +25,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 
-@Category(OnlineTest.class)
+@Category({OnlineTest.class, MQTTV5Test.class})
 public class PublishTests {
 
 	static final Class<?> cclass = PublishTests.class;

--- a/org.eclipse.paho.mqttv5.client.vertx/src/test/java/org/eclipse/paho/mqttv5/client/vertx/test/SendReceiveAsyncTest.java
+++ b/org.eclipse.paho.mqttv5.client.vertx/src/test/java/org/eclipse/paho/mqttv5/client/vertx/test/SendReceiveAsyncTest.java
@@ -19,6 +19,7 @@ import java.util.UUID;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import org.eclipse.paho.common.test.categories.OnlineTest;
 import org.eclipse.paho.mqttv5.client.vertx.IMqttAsyncClient;
 import org.eclipse.paho.mqttv5.client.vertx.IMqttDeliveryToken;
 import org.eclipse.paho.mqttv5.client.vertx.IMqttToken;
@@ -34,10 +35,9 @@ import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
-/**
- *
- */
+@Category(OnlineTest.class)
 public class SendReceiveAsyncTest {
 
   static final Class<?> cclass = SendReceiveAsyncTest.class;

--- a/org.eclipse.paho.mqttv5.client.vertx/src/test/java/org/eclipse/paho/mqttv5/client/vertx/test/SendReceiveAsyncTest.java
+++ b/org.eclipse.paho.mqttv5.client.vertx/src/test/java/org/eclipse/paho/mqttv5/client/vertx/test/SendReceiveAsyncTest.java
@@ -19,6 +19,8 @@ import java.util.UUID;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import org.eclipse.paho.common.test.categories.ExternalTest;
+import org.eclipse.paho.common.test.categories.MQTTV5Test;
 import org.eclipse.paho.common.test.categories.OnlineTest;
 import org.eclipse.paho.mqttv5.client.vertx.IMqttAsyncClient;
 import org.eclipse.paho.mqttv5.client.vertx.IMqttDeliveryToken;
@@ -31,13 +33,10 @@ import org.eclipse.paho.mqttv5.client.vertx.test.properties.TestProperties;
 import org.eclipse.paho.mqttv5.client.vertx.test.utilities.MqttV5Receiver;
 import org.eclipse.paho.mqttv5.client.vertx.test.utilities.Utility;
 import org.eclipse.paho.mqttv5.client.vertx.test.logging.LoggingUtilities;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.*;
 import org.junit.experimental.categories.Category;
 
-@Category(OnlineTest.class)
+@Category({OnlineTest.class, MQTTV5Test.class})
 public class SendReceiveAsyncTest {
 
   static final Class<?> cclass = SendReceiveAsyncTest.class;
@@ -606,7 +605,8 @@ public class SendReceiveAsyncTest {
    * Test the behavior of the connection timeout when connecting to a non MQTT server.
    * i.e. ssh port 22
    */
-  //@Test
+  @Ignore
+  @Category(ExternalTest.class)
   public void testConnectTimeout() throws Exception {
 	  final String methodName = Utility.getMethodName();
 	  LoggingUtilities.banner(log, cclass, methodName);

--- a/org.eclipse.paho.mqttv5.client.vertx/src/test/java/org/eclipse/paho/mqttv5/client/vertx/test/ServerAssignedClientIdentifierTest.java
+++ b/org.eclipse.paho.mqttv5.client.vertx/src/test/java/org/eclipse/paho/mqttv5/client/vertx/test/ServerAssignedClientIdentifierTest.java
@@ -4,6 +4,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.logging.Logger;
 
+import org.eclipse.paho.common.test.categories.OnlineTest;
 import org.eclipse.paho.mqttv5.client.vertx.IMqttToken;
 import org.eclipse.paho.mqttv5.client.vertx.MqttAsyncClient;
 import org.eclipse.paho.mqttv5.client.vertx.test.properties.TestProperties;
@@ -12,7 +13,10 @@ import org.eclipse.paho.mqttv5.common.MqttException;
 import org.eclipse.paho.mqttv5.common.packet.MqttProperties;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+
+@Category(OnlineTest.class)
 public class ServerAssignedClientIdentifierTest {
 	private static URI serverURI;
 	private static final String className = ServerAssignedClientIdentifierTest.class.getName();

--- a/org.eclipse.paho.mqttv5.client.vertx/src/test/java/org/eclipse/paho/mqttv5/client/vertx/test/ServerAssignedClientIdentifierTest.java
+++ b/org.eclipse.paho.mqttv5.client.vertx/src/test/java/org/eclipse/paho/mqttv5/client/vertx/test/ServerAssignedClientIdentifierTest.java
@@ -4,6 +4,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.logging.Logger;
 
+import org.eclipse.paho.common.test.categories.MQTTV5Test;
 import org.eclipse.paho.common.test.categories.OnlineTest;
 import org.eclipse.paho.mqttv5.client.vertx.IMqttToken;
 import org.eclipse.paho.mqttv5.client.vertx.MqttAsyncClient;
@@ -16,7 +17,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 
-@Category(OnlineTest.class)
+@Category({OnlineTest.class, MQTTV5Test.class})
 public class ServerAssignedClientIdentifierTest {
 	private static URI serverURI;
 	private static final String className = ServerAssignedClientIdentifierTest.class.getName();

--- a/org.eclipse.paho.mqttv5.client.vertx/src/test/java/org/eclipse/paho/mqttv5/client/vertx/test/SubscribeTests.java
+++ b/org.eclipse.paho.mqttv5.client.vertx/src/test/java/org/eclipse/paho/mqttv5/client/vertx/test/SubscribeTests.java
@@ -7,6 +7,7 @@ import java.util.UUID;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import org.eclipse.paho.common.test.categories.OnlineTest;
 import org.eclipse.paho.mqttv5.client.vertx.IMqttDeliveryToken;
 import org.eclipse.paho.mqttv5.client.vertx.IMqttToken;
 import org.eclipse.paho.mqttv5.client.vertx.MqttAsyncClient;
@@ -25,7 +26,10 @@ import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+
+@Category(OnlineTest.class)
 public class SubscribeTests {
 
 	static final Class<?> cclass = SubscribeTests.class;

--- a/org.eclipse.paho.mqttv5.client.vertx/src/test/java/org/eclipse/paho/mqttv5/client/vertx/test/SubscribeTests.java
+++ b/org.eclipse.paho.mqttv5.client.vertx/src/test/java/org/eclipse/paho/mqttv5/client/vertx/test/SubscribeTests.java
@@ -7,6 +7,7 @@ import java.util.UUID;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import org.eclipse.paho.common.test.categories.MQTTV5Test;
 import org.eclipse.paho.common.test.categories.OnlineTest;
 import org.eclipse.paho.mqttv5.client.vertx.IMqttDeliveryToken;
 import org.eclipse.paho.mqttv5.client.vertx.IMqttToken;
@@ -29,7 +30,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 
-@Category(OnlineTest.class)
+@Category({OnlineTest.class, MQTTV5Test.class})
 public class SubscribeTests {
 
 	static final Class<?> cclass = SubscribeTests.class;

--- a/org.eclipse.paho.mqttv5.client.vertx/src/test/java/org/eclipse/paho/mqttv5/client/vertx/test/automaticReconnect/AutomaticReconnectTest.java
+++ b/org.eclipse.paho.mqttv5.client.vertx/src/test/java/org/eclipse/paho/mqttv5/client/vertx/test/automaticReconnect/AutomaticReconnectTest.java
@@ -4,6 +4,7 @@ import java.net.URI;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import org.eclipse.paho.common.test.categories.MQTTV5Test;
 import org.eclipse.paho.common.test.categories.OnlineTest;
 import org.eclipse.paho.mqttv5.client.vertx.MqttConnectionOptions;
 import org.eclipse.paho.mqttv5.client.vertx.MqttClient;
@@ -20,7 +21,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 
-@Category(OnlineTest.class)
+@Category({OnlineTest.class, MQTTV5Test.class})
 public class AutomaticReconnectTest {
 
 	static final Class<?> cclass = AutomaticReconnectTest.class;

--- a/org.eclipse.paho.mqttv5.client.vertx/src/test/java/org/eclipse/paho/mqttv5/client/vertx/test/automaticReconnect/AutomaticReconnectTest.java
+++ b/org.eclipse.paho.mqttv5.client.vertx/src/test/java/org/eclipse/paho/mqttv5/client/vertx/test/automaticReconnect/AutomaticReconnectTest.java
@@ -4,10 +4,10 @@ import java.net.URI;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import org.eclipse.paho.common.test.categories.OnlineTest;
 import org.eclipse.paho.mqttv5.client.vertx.MqttConnectionOptions;
 import org.eclipse.paho.mqttv5.client.vertx.MqttClient;
 import org.eclipse.paho.mqttv5.client.vertx.persist.MemoryPersistence;
-import org.eclipse.paho.mqttv5.client.vertx.test.automaticReconnect.AutomaticReconnectTest;
 import org.eclipse.paho.mqttv5.client.vertx.test.logging.LoggingUtilities;
 import org.eclipse.paho.mqttv5.client.vertx.test.properties.TestProperties;
 import org.eclipse.paho.mqttv5.client.vertx.test.utilities.ConnectionManipulationProxyServer;
@@ -17,7 +17,10 @@ import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+
+@Category(OnlineTest.class)
 public class AutomaticReconnectTest {
 
 	static final Class<?> cclass = AutomaticReconnectTest.class;

--- a/org.eclipse.paho.mqttv5.client.vertx/src/test/java/org/eclipse/paho/mqttv5/client/vertx/test/automaticReconnect/OfflineBufferingTest.java
+++ b/org.eclipse.paho.mqttv5.client.vertx/src/test/java/org/eclipse/paho/mqttv5/client/vertx/test/automaticReconnect/OfflineBufferingTest.java
@@ -7,20 +7,19 @@ import java.util.UUID;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import org.eclipse.paho.common.test.categories.OnlineTest;
 import org.eclipse.paho.mqttv5.client.vertx.DisconnectedBufferOptions;
 import org.eclipse.paho.mqttv5.client.vertx.IMqttDeliveryToken;
 import org.eclipse.paho.mqttv5.client.vertx.IMqttToken;
 import org.eclipse.paho.mqttv5.client.vertx.MqttAsyncClient;
 import org.eclipse.paho.mqttv5.client.vertx.MqttConnectionOptions;
 import org.eclipse.paho.mqttv5.client.vertx.persist.MemoryPersistence;
-import org.eclipse.paho.mqttv5.client.vertx.test.automaticReconnect.OfflineBufferingTest;
 import org.eclipse.paho.mqttv5.client.vertx.test.logging.LoggingUtilities;
 import org.eclipse.paho.mqttv5.client.vertx.test.properties.TestProperties;
 import org.eclipse.paho.mqttv5.client.vertx.test.utilities.ConnectionManipulationProxyServer;
 import org.eclipse.paho.mqttv5.client.vertx.test.utilities.MqttV5Receiver;
 import org.eclipse.paho.mqttv5.client.vertx.test.utilities.TestMemoryPersistence;
 import org.eclipse.paho.mqttv5.client.vertx.test.utilities.Utility;
-import org.eclipse.paho.mqttv5.client.vertx.util.Debug;
 import org.eclipse.paho.mqttv5.common.MqttException;
 import org.eclipse.paho.mqttv5.common.MqttMessage;
 import org.eclipse.paho.mqttv5.common.packet.MqttProperties;
@@ -30,7 +29,10 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+
+@Category(OnlineTest.class)
 public class OfflineBufferingTest {
 
 	static final Class<?> cclass = OfflineBufferingTest.class;

--- a/org.eclipse.paho.mqttv5.client.vertx/src/test/java/org/eclipse/paho/mqttv5/client/vertx/test/automaticReconnect/OfflineBufferingTest.java
+++ b/org.eclipse.paho.mqttv5.client.vertx/src/test/java/org/eclipse/paho/mqttv5/client/vertx/test/automaticReconnect/OfflineBufferingTest.java
@@ -7,6 +7,7 @@ import java.util.UUID;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import org.eclipse.paho.common.test.categories.MQTTV5Test;
 import org.eclipse.paho.common.test.categories.OnlineTest;
 import org.eclipse.paho.mqttv5.client.vertx.DisconnectedBufferOptions;
 import org.eclipse.paho.mqttv5.client.vertx.IMqttDeliveryToken;
@@ -32,7 +33,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 
-@Category(OnlineTest.class)
+@Category({OnlineTest.class, MQTTV5Test.class})
 public class OfflineBufferingTest {
 
 	static final Class<?> cclass = OfflineBufferingTest.class;

--- a/org.eclipse.paho.mqttv5.client.vertx/src/test/java/org/eclipse/paho/mqttv5/client/vertx/test/automaticReconnect/TopicAliasReconnectTest.java
+++ b/org.eclipse.paho.mqttv5.client.vertx/src/test/java/org/eclipse/paho/mqttv5/client/vertx/test/automaticReconnect/TopicAliasReconnectTest.java
@@ -4,6 +4,7 @@ import java.net.URI;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import org.eclipse.paho.common.test.categories.OnlineTest;
 import org.eclipse.paho.mqttv5.client.vertx.IMqttDeliveryToken;
 import org.eclipse.paho.mqttv5.client.vertx.IMqttToken;
 import org.eclipse.paho.mqttv5.client.vertx.MqttAsyncClient;
@@ -22,7 +23,10 @@ import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+
+@Category(OnlineTest.class)
 public class TopicAliasReconnectTest {
 
 	static final Class<?> cclass = TopicAliasReconnectTest.class;

--- a/org.eclipse.paho.mqttv5.client.vertx/src/test/java/org/eclipse/paho/mqttv5/client/vertx/test/automaticReconnect/TopicAliasReconnectTest.java
+++ b/org.eclipse.paho.mqttv5.client.vertx/src/test/java/org/eclipse/paho/mqttv5/client/vertx/test/automaticReconnect/TopicAliasReconnectTest.java
@@ -4,6 +4,7 @@ import java.net.URI;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import org.eclipse.paho.common.test.categories.MQTTV5Test;
 import org.eclipse.paho.common.test.categories.OnlineTest;
 import org.eclipse.paho.mqttv5.client.vertx.IMqttDeliveryToken;
 import org.eclipse.paho.mqttv5.client.vertx.IMqttToken;
@@ -26,7 +27,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 
-@Category(OnlineTest.class)
+@Category({OnlineTest.class, MQTTV5Test.class})
 public class TopicAliasReconnectTest {
 
 	static final Class<?> cclass = TopicAliasReconnectTest.class;

--- a/org.eclipse.paho.mqttv5.client.vertx/src/test/java/org/eclipse/paho/mqttv5/client/vertx/test/connectionLoss/ConnectionLossTest.java
+++ b/org.eclipse.paho.mqttv5.client.vertx/src/test/java/org/eclipse/paho/mqttv5/client/vertx/test/connectionLoss/ConnectionLossTest.java
@@ -21,6 +21,7 @@ import java.util.TimerTask;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import org.eclipse.paho.common.test.categories.OnlineTest;
 import org.eclipse.paho.mqttv5.client.vertx.IMqttDeliveryToken;
 import org.eclipse.paho.mqttv5.client.vertx.MqttAsyncClient;
 import org.eclipse.paho.mqttv5.client.vertx.MqttCallback;
@@ -28,7 +29,6 @@ import org.eclipse.paho.mqttv5.client.vertx.MqttConnectionOptions;
 import org.eclipse.paho.mqttv5.client.vertx.MqttDisconnectResponse;
 import org.eclipse.paho.mqttv5.client.vertx.MqttClient;
 import org.eclipse.paho.mqttv5.client.vertx.persist.MemoryPersistence;
-import org.eclipse.paho.mqttv5.client.vertx.test.connectionLoss.ConnectionLossTest;
 import org.eclipse.paho.mqttv5.client.vertx.test.logging.LoggingUtilities;
 import org.eclipse.paho.mqttv5.client.vertx.test.properties.TestProperties;
 import org.eclipse.paho.mqttv5.client.vertx.test.utilities.ConnectionManipulationProxyServer;
@@ -41,6 +41,7 @@ import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 /**
  * These tests verify whether paho can successfully detect a loss of connection
@@ -56,6 +57,8 @@ import org.junit.Test;
  * @author mcarrer
  */
 
+
+@Category(OnlineTest.class)
 public class ConnectionLossTest implements MqttCallback {
 	static final Class<?> cclass = ConnectionLossTest.class;
 	private static final String className = cclass.getName();

--- a/org.eclipse.paho.mqttv5.client.vertx/src/test/java/org/eclipse/paho/mqttv5/client/vertx/test/connectionLoss/ConnectionLossTest.java
+++ b/org.eclipse.paho.mqttv5.client.vertx/src/test/java/org/eclipse/paho/mqttv5/client/vertx/test/connectionLoss/ConnectionLossTest.java
@@ -21,6 +21,7 @@ import java.util.TimerTask;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import org.eclipse.paho.common.test.categories.MQTTV5Test;
 import org.eclipse.paho.common.test.categories.OnlineTest;
 import org.eclipse.paho.mqttv5.client.vertx.IMqttDeliveryToken;
 import org.eclipse.paho.mqttv5.client.vertx.MqttAsyncClient;
@@ -58,7 +59,7 @@ import org.junit.experimental.categories.Category;
  */
 
 
-@Category(OnlineTest.class)
+@Category({OnlineTest.class, MQTTV5Test.class})
 public class ConnectionLossTest implements MqttCallback {
 	static final Class<?> cclass = ConnectionLossTest.class;
 	private static final String className = cclass.getName();

--- a/pom.xml
+++ b/pom.xml
@@ -301,6 +301,7 @@
 		</profile>
 	</profiles>
 	<modules>
+		<module>org.eclipse.paho.common</module>
 		<module>org.eclipse.paho.client.mqttv3</module>
 		<module>org.eclipse.paho.client.mqttv3.test</module>
 		<module>org.eclipse.paho.client.mqttv3.repository</module>

--- a/pom.xml
+++ b/pom.xml
@@ -299,6 +299,27 @@
 				</plugins>
 			</build>
 		</profile>
+		<profile>
+			<id>local</id>
+			<dependencies>
+				<dependency>
+					<groupId>junit</groupId>
+					<artifactId>junit</artifactId>
+				</dependency>
+			</dependencies>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-surefire-plugin</artifactId>
+						<version>3.0.0-M3</version>
+						<configuration>
+							<excludedGroups>org.eclipse.paho.common.test.categories.OnlineTest</excludedGroups>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
 	</profiles>
 	<modules>
 		<module>org.eclipse.paho.common</module>

--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,7 @@
 		<jacoco.version>0.8.2</jacoco.version>
 		<test.exclude>**/*ConformantTest.java</test.exclude>
 		<download.location>/home/data/httpd/download.eclipse.org/paho/releases/${project.version}/Java</download.location>
+		<exclude.groups></exclude.groups>
 	</properties>
 
 	<name>Eclipse Paho</name>
@@ -201,6 +202,13 @@
 		</plugins>
 	</build>
 
+	<dependencies>
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+		</dependency>
+	</dependencies>
+
 	<profiles>
 		<profile>
 			<id>eclipse-sign</id>
@@ -300,13 +308,10 @@
 			</build>
 		</profile>
 		<profile>
-			<id>local</id>
-			<dependencies>
-				<dependency>
-					<groupId>junit</groupId>
-					<artifactId>junit</artifactId>
-				</dependency>
-			</dependencies>
+			<id>exclude-tests</id>
+			<properties>
+				<exclude.groups>${exclude.groups}</exclude.groups>
+			</properties>
 			<build>
 				<plugins>
 					<plugin>
@@ -314,7 +319,7 @@
 						<artifactId>maven-surefire-plugin</artifactId>
 						<version>3.0.0-M3</version>
 						<configuration>
-							<excludedGroups>org.eclipse.paho.common.test.categories.OnlineTest</excludedGroups>
+							<excludedGroups>${exclude.groups}</excludedGroups>
 						</configuration>
 					</plugin>
 				</plugins>
@@ -328,7 +333,7 @@
 		<module>org.eclipse.paho.client.mqttv3.repository</module>
 		<module>org.eclipse.paho.sample.utility</module>
 		<module>org.eclipse.paho.mqttv5.common</module>
-    		<module>org.eclipse.paho.mqttv5.client.vertx</module>
-    		<module>org.eclipse.paho.mqttv5.client.vertx.test</module>
-	</modules>
+		<module>org.eclipse.paho.mqttv5.client.vertx</module>
+		<module>org.eclipse.paho.mqttv5.client.vertx.test</module>
+    </modules>
 </project>


### PR DESCRIPTION
Signed-off-by: Otavio R. Piske <angusyoung@gmail.com>

Please make sure that the following boxes are checked before submitting your Pull Request, thank you!

- [x] This change is against the develop branch, **not** master.
- [x] You have signed the [Eclipse ECA](https://wiki.eclipse.org/ECA)
- [x] All of your commits have been signed-off with the correct email address (The same one that you used to sign the CLA) _Hint: use the -s argument when committing_.
- [ ] If This PR fixes an issue, that you reference the issue below. OR if this is a new issue that you are fixing straight away that you add some Description about the bug and how this will fix it.
- [ ] If this is new functionality, You have added the appropriate Unit tests.

@icraggs 

This introduces the ability to disable the execution of tests requiring an internet connection. Although it may seem unnecessary, it can be useful for organizations that build the code in restricted environments where it's forbidden to access network resources. 

The way the code is implement still allows the execution of offline tests and retain the existing default behaviour.
