### PR TITLE
Fix MQTT client hangs after publishing with QoS 0 #314

### DIFF
--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/ClientState.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/ClientState.java
@@ -930,6 +930,7 @@ public class ClientState {
 				// once a QoS 0 message is sent we can clean up its records straight away as
 				// we won't be hearing about it again
 				token.internalTok.markComplete(null, null);
+				token.internalTok.notifyComplete();
 				callback.asyncOperationComplete(token);
 				decrementInFlight();
 				releaseMessageId(message.getMessageId());


### PR DESCRIPTION
Call the notifyComplete method on the internal token to allow the MQTT client thread, that is waiting for completion, to continue

Signed-off-by: Fco. Javier de Arcos Velilla <fj.dearcos@gmail.com>

Please make sure that the following boxes are checked before submitting your Pull Request, thank you!

- [x] This change is against the develop branch, **not** master.
- [x] You have signed the [Eclipse ECA](https://wiki.eclipse.org/ECA)
- [x] All of your commits have been signed-off with the correct email address (The same one that you used to sign the CLA) _Hint: use the -s argument when committing_.
- [x] If This PR fixes an issue, that you reference the issue below. OR if this is a new issue that you are fixing straight away that you add some Description about the bug and how this will fix it.
- [ ] If this is new functionality, You have added the appropriate Unit tests.
