### PR TITLE
Improve discoverability of MqttCallbackExtended

### DIFF
--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/IMqttClient.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/IMqttClient.java
@@ -847,6 +847,7 @@ public void subscribe(String topicFilter, int qos, IMqttMessageListener messageL
 	 * as connect and subscribe can be tracked using the {@link MqttToken} passed to the
 	 * operation<p>
 	 * @see MqttCallback
+	 * @see MqttCallbackExtended
 	 * @param callback the class to callback when for events related to the client
 	 */
 	public void setCallback(MqttCallback callback);

--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/MqttCallback.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/MqttCallback.java
@@ -22,6 +22,7 @@ package org.eclipse.paho.client.mqttv3;
  * Classes implementing this interface
  * can be registered on both types of client: {@link IMqttClient#setCallback(MqttCallback)}
  * and {@link IMqttAsyncClient#setCallback(MqttCallback)}
+ * @see MqttCallbackExtended
  */
 public interface MqttCallback {
 	/**


### PR DESCRIPTION
It's really hard to find the interface if you don't already know about it.
Nothing points to it, yet it's mandatory to subscribe to topics in the
method only available in this interface, otherwise the client will not
subscribe back to the topics after an automatic reconnection.

---
Please make sure that the following boxes are checked before submitting your Pull Request, thank you!

- [x] This change is against the develop branch, **not** master.
- [x] You have signed the [Eclipse ECA](https://wiki.eclipse.org/ECA)
- [x] All of your commits have been signed-off with the correct email address (The same one that you used to sign the CLA) _Hint: use the -s argument when committing_.
- [x] If This PR fixes an issue, that you reference the issue below. OR if this is a new issue that you are fixing straight away that you add some Description about the bug and how this will fix it.
- [ ] ~~If this is new functionality, You have added the appropriate Unit tests.~~
