### PR TITLE
Refactored thread stopping and starting, to not introduce 100ms delays per client

### DIFF
--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/CommsSender.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/CommsSender.java
@@ -17,6 +17,7 @@ package org.eclipse.paho.client.mqttv3.internal;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 
@@ -42,7 +43,7 @@ public class CommsSender implements Runnable {
 	private Thread 	sendThread		= null;
 	private String threadName;
 	private Future<?> senderFuture;
-	
+
 	private ClientState clientState = null;
 	private MqttOutputStream out;
 	private ClientComms clientComms = null;
@@ -67,15 +68,16 @@ public class CommsSender implements Runnable {
 		synchronized (lifecycle) {
 			if (current_state == State.STOPPED && target_state == State.STOPPED) {
 				target_state = State.RUNNING;
+				current_state = State.RUNNING;
 				if (executorService == null) {
-					new Thread(this).start();
+					senderFuture = null;
+					sendThread = new Thread(this);
+					sendThread.start();
 				} else {
+					sendThread = null;
 					senderFuture = executorService.submit(this);
 				}
 			}
-		}
-		while (!isRunning()) {
-			try { Thread.sleep(100); } catch (Exception e) { }
 		}
 	}
 
@@ -84,39 +86,44 @@ public class CommsSender implements Runnable {
 	 */
 	public void stop() {
 		final String methodName = "stop";
-		
+		boolean isRunning;
+
 		if (!isRunning()) {
 			return;
 		}
-			
+
 		synchronized (lifecycle) {
-			if (senderFuture != null) {
-				senderFuture.cancel(true);
-			}
 			//@TRACE 800=stopping sender
 			log.fine(CLASS_NAME,methodName,"800");
-			if (isRunning()) {
+			isRunning = isRunning();
+			if (isRunning) {
 				target_state = State.STOPPED;
 				clientState.notifyQueueLock();
 			}
 		}
-		while (isRunning()) {
-			try { Thread.sleep(100); } catch (Exception e) { }
-			clientState.notifyQueueLock();
+		// This and the clause above will prevent a thread from waiting for itself.
+		if (isRunning) {
+			if (senderFuture != null) {
+				try {
+					senderFuture.get();
+				} catch (ExecutionException | InterruptedException e) {
+				}
+			} else {
+				try {
+					sendThread.join();
+				} catch (InterruptedException e) {
+					e.printStackTrace();
+				}
+			}
 		}
 		//@TRACE 801=stopped
 		log.fine(CLASS_NAME,methodName,"801");
 	}
 
 	public void run() {
-		sendThread = Thread.currentThread();
-		sendThread.setName(threadName);
+		Thread.currentThread().setName(threadName);
 		final String methodName = "run";
 		MqttWireMessage message = null;
-		
-		synchronized (lifecycle) {
-			current_state = State.RUNNING;
-		}
 
 		try {
 			State my_target;
@@ -176,7 +183,6 @@ public class CommsSender implements Runnable {
 		} finally {
 			synchronized (lifecycle) {
 				current_state = State.STOPPED;
-				sendThread = null;
 			}
 		}
 


### PR DESCRIPTION
Please make sure that the following boxes are checked before submitting your Pull Request, thank you!

- [X] This change is against the develop branch, **not** master.
- [X] You have signed the [Eclipse ECA](https://wiki.eclipse.org/ECA)
- [X] All of your commits have been signed-off with the correct email address (The same one that you used to sign the CLA) _Hint: use the -s argument when committing_.
- [X] If This PR fixes an issue, that you reference the issue below. OR if this is a new issue that you are fixing straight away that you add some Description about the bug and how this will fix it.
- [ ] If this is new functionality, You have added the appropriate Unit tests.

Please make sure that the following boxes are checked before submitting your Pull Request, thank you!

Related to: #651.

Related commits: a6faf77, 4b23f12

Do not wait for threads to start & stop with Thread.sleep(), as this causes the amount of time taken for a project that initiates many connections to start up, to grow exponentially. To initiate 400 connections, Paho currently needs over 2 minutes.

Threads will enter the running state immediately when start() is called, to avoid the need to synchronize with the thread.
If the ExecutorService is used, gracefully terminate threads by waiting for their completion, rather than interupting. This will keep the behaviour of Paho uniform, regardless of whether an ExecutorService is used or not.

The difference between this PR and the previous one, is that I removed some leftover test code that was preventing threads from getting shutdown properly. I did not really test support for ThreadExecutor, but it should be okay.

Signed-off-by: Liu Woon Yung pirorin187@gmail.com