### PR TITLE
fix the problem#680: connectComplete be triggered when connectionLost

### DIFF
--- a/org.eclipse.paho.client.mqttv3/src/main/java-templates/org/eclipse/paho/client/mqttv3/internal/ClientComms.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java-templates/org/eclipse/paho/client/mqttv3/internal/ClientComms.java
@@ -465,7 +465,7 @@ public class ClientComms {
 			// First the token that was related to the disconnect / shutdown may
 			// not be in the token table - temporarily add it if not
 			if (token != null) {
-				if (tokenStore.getToken(token.internalTok.getKey())==null) {
+				if (!token.isComplete() && tokenStore.getToken(token.internalTok.getKey())==null) {
 					tokenStore.saveToken(token, token.internalTok.getKey());
 				}
 			}


### PR DESCRIPTION
Please make sure that the following boxes are checked before submitting your Pull Request, thank you!

- [√ ] This change is against the develop branch, **not** master.
- [√ ] You have signed the [Eclipse ECA](https://wiki.eclipse.org/ECA)
- [√ ] All of your commits have been signed-off with the correct email address (The same one that you used to sign the CLA) _Hint: use the -s argument when committing_.
- [√] If This PR fixes an issue, that you reference the issue below. OR if this is a new issue that you are fixing straight away that you add some Description about the bug and how this will fix it.
- [√ ] If this is new functionality, You have added the appropriate Unit tests.

fix #680 
When a token has been already completed(connect by this case), do not put it to token store.