### PR TITLE
throw exception when no message ids available in persistBufferedMessage.

### DIFF
--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/ClientState.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/ClientState.java
@@ -582,8 +582,9 @@ public class ClientState {
 	 * Persists a buffered message to the persistence layer
 	 * 
 	 * @param message The {@link MqttWireMessage} to persist
+	 * @throws MqttException if an exception occurs when no message ids available.
 	 */
-	public void persistBufferedMessage(MqttWireMessage message) {
+	public void persistBufferedMessage(MqttWireMessage message) throws MqttException {
 		final String methodName = "persistBufferedMessage";
 		String key = getSendBufferedPersistenceKey(message);
 		
@@ -603,7 +604,8 @@ public class ClientState {
 			log.fine(CLASS_NAME,methodName, "513", new Object[]{key});
 		} catch (MqttException ex){
 			//@TRACE 514=Failed to persist buffered message key={0}
-			log.warning(CLASS_NAME,methodName, "513", new Object[]{key});
+			log.warning(CLASS_NAME,methodName, "514", new Object[]{key});
+			throw ex;
 		} 
 	}
 	


### PR DESCRIPTION

Signed-off-by: ogis-yamazaki <Yamazaki_Shoji@ogis-ri.co.jp>

Please make sure that the following boxes are checked before submitting your Pull Request, thank you!

- [x] This change is against the develop branch, **not** master.
- [x] You have signed the [Eclipse ECA](https://wiki.eclipse.org/ECA)
- [x] All of your commits have been signed-off with the correct email address (The same one that you used to sign the CLA) _Hint: use the -s argument when committing_.
- [ ] If This PR fixes an issue, that you reference the issue below. OR if this is a new issue that you are fixing straight away that you add some Description about the bug and how this will fix it.
- [ ] If this is new functionality, You have added the appropriate Unit tests.

Must throw exception when no message ids available in persistBufferedMessage, similer  to ClientState#send method.

Apart from that found typo warning message.
