### PR TITLE
Fix for #719

### DIFF
--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/CommsReceiver.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/CommsReceiver.java
@@ -165,7 +165,11 @@ public class CommsReceiver implements Runnable {
 						if (message != null) {
 							// A new message has arrived
 							clientState.notifyReceivedMsg(message);
-						}
+						} else {
+                                                    if (!clientComms.isConnected()) {
+                                                        throw new MqttException(MqttException.REASON_CODE_CONNECTION_LOST);
+                                                    }
+                                                }
 					}
 				}
 				catch (MqttException ex) {

--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/CommsReceiver.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/CommsReceiver.java
@@ -166,6 +166,7 @@ public class CommsReceiver implements Runnable {
 							// A new message has arrived
 							clientState.notifyReceivedMsg(message);
 						} else {
+                                                    // fix for bug 719
                                                     if (!clientComms.isConnected()) {
                                                         throw new MqttException(MqttException.REASON_CODE_CONNECTION_LOST);
                                                     }


### PR DESCRIPTION
If for any intermittent networking problem, client fails to receive connection ACK, client may go in hung state.

When this happens, CommsReceiver() receives a null message from readMqttWireMessage(). The method readMqttWireMessage() doesn't catch socket exception "connection reset" but returns a null message to the caller. Though this behavior in readMqttWireMessage() is needed to handle different cases, but  this can cause problem during connection, when client is in connecting state. The null message case when client is not connected, is not handled in CommsReceiver(). Client just waits for ever to receive connection ACK. The CommsReceiver() should throw an exception when it receives a null message and client is not connected.

This problem can be recreated using "tcpkill" to block source port during connection. Steps are as follows:
- Configure client with automatic reconnect option
- Let client connect successfully and publish messages
- Block source port:
  $ tcpkill -9 src port 1883
- Client will be disconnected and start a connection cycle
- After about 60 seconds, stop tcpkill




Please make sure that the following boxes are checked before submitting your Pull Request, thank you!

- [x] This change is against the develop branch, **not** master.
- [x] You have signed the [Eclipse ECA](https://wiki.eclipse.org/ECA)
- [x] All of your commits have been signed-off with the correct email address (The same one that you used to sign the CLA) _Hint: use the -s argument when committing_.
- [x] If This PR fixes an issue, that you reference the issue below. OR if this is a new issue that you are fixing straight away that you add some Description about the bug and how this will fix it.
- [ ] If this is new functionality, You have added the appropriate Unit tests.

The fix is for issue #719 
