### PR TITLE
Fix for #719

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,7 +1,7 @@
 Please fill out the form below before submitting, thank you!
 
-- [ ] Bug exists Release Version 1.2.0 ( Master Branch)
-- [ ] Bug exists in MQTTv3 Client on Snapshot Version 1.2.1-SNAPSHOT (Develop Branch)
-- [ ] Bug exists in MQTTv5 Client on Snapshot Version 1.2.1-SNAPSHOT (Develop Branch)
+- [ ] Bug exists Release Version 1.2.2 ( Master Branch)
+- [ ] Bug exists in MQTTv3 Client on Snapshot Version 1.2.3-SNAPSHOT (Develop Branch)
+- [ ] Bug exists in MQTTv5 Client on Snapshot Version 1.2.3-SNAPSHOT (Develop Branch)
 
 If this is a bug regarding the Android Service, please raise the bug here instead: https://github.com/eclipse/paho.mqtt.android/issues/new

--- a/MQTTv3.md
+++ b/MQTTv3.md
@@ -11,7 +11,7 @@ Eclipse hosts a Nexus repository for those who want to use Maven to manage their
 Add the repository definition and the dependency definition shown below to your pom.xml.
 
 Replace %REPOURL% with either ``` https://repo.eclipse.org/content/repositories/paho-releases/ ``` for the official releases, or ``` https://repo.eclipse.org/content/repositories/paho-snapshots/  ``` for the nightly snapshots. Replace %VERSION% with the level required .
-The latest release version is ```1.2.1``` and the current snapshot version is ```1.2.2-SNAPSHOT```.
+The latest release version is ```1.2.2``` and the current snapshot version is ```1.2.3-SNAPSHOT```.
 
 ```
 <project ...>

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Add the repository definition and the dependency definition shown below to your 
 
 Replace %REPOURL% with either ``` https://repo.eclipse.org/content/repositories/paho-releases/ ``` for the official releases, or ``` https://repo.eclipse.org/content/repositories/paho-snapshots/  ``` for the nightly snapshots. Replace %VERSION% with the level required .
 
-The latest release version is ```1.2.1``` and the current snapshot version is ```1.2.2-SNAPSHOT```.
+The latest release version is ```1.2.2``` and the current snapshot version is ```1.2.3-SNAPSHOT```.
 
 
 ```

--- a/org.eclipse.paho.client.mqttv3.internal.traceformat/build.xml
+++ b/org.eclipse.paho.client.mqttv3.internal.traceformat/build.xml
@@ -8,8 +8,8 @@
 	<!-- classpath.folder = ship.folder of org.eclipse.paho.client.mqttv3 build.xml -->
 	<property name="classpath.folder" value="../org.eclipse.paho.client.mqttv3/target/ship" />
 	
-	<property name="client.release.version" value="1.2.2.qualifier" />
-	<property name="bundleVersion" value="1.2.2.qualifier" />
+	<property name="client.release.version" value="1.2.2" />
+	<property name="bundleVersion" value="1.2.2" />
 
 	<property name="bundleVendor" value="Eclipse.org" />
 	<property name="build.level" value="LYYMMDD" />

--- a/org.eclipse.paho.client.mqttv3.repository/category.xml
+++ b/org.eclipse.paho.client.mqttv3.repository/category.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <site>
-	<bundle id="org.eclipse.paho.client.mqttv3" version="1.2.2.qualifier">
+	<bundle id="org.eclipse.paho.client.mqttv3" version="1.2.2">
 		<category name="Paho MQTT Java"/>
 	</bundle>
 	<category-def name="Paho MQTT Java" label="Paho MQTT Java">

--- a/org.eclipse.paho.client.mqttv3.repository/pom.xml
+++ b/org.eclipse.paho.client.mqttv3.repository/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.eclipse.paho</groupId>
 		<artifactId>java-parent</artifactId>
-		<version>1.2.2-SNAPSHOT</version>
+		<version>1.2.2</version>
 	</parent>
 
 	<artifactId>org.eclipse.paho.client.mqttv3.repository</artifactId>

--- a/org.eclipse.paho.client.mqttv3.test/pom.xml
+++ b/org.eclipse.paho.client.mqttv3.test/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.paho</groupId>
 		<artifactId>java-parent</artifactId>
-		<version>1.2.2-SNAPSHOT</version>
+		<version>1.2.2</version>
 	</parent>
 
 	<artifactId>org.eclipse.paho.client.mqttv3.test</artifactId>
@@ -86,7 +86,7 @@
 		<dependency>
 			<groupId>org.eclipse.paho</groupId>
 			<artifactId>org.eclipse.paho.client.mqttv3</artifactId>
-			<version>1.2.2-SNAPSHOT</version>
+			<version>1.2.2</version>
 		</dependency>
 
 		<dependency>

--- a/org.eclipse.paho.client.mqttv3.test/src/test/java/org/eclipse/paho/client/mqttv3/test/SSLSessionResumptionTest.java
+++ b/org.eclipse.paho.client.mqttv3.test/src/test/java/org/eclipse/paho/client/mqttv3/test/SSLSessionResumptionTest.java
@@ -82,7 +82,7 @@ public class SSLSessionResumptionTest {
 	 * 
 	 * @throws Exception
 	 */
-	@Test(timeout=30000)
+	@Test(timeout=60000)
 	public void testSSLSessionInvalidated() throws Exception {
 		 //System.setProperty("javax.net.debug", "all");
 

--- a/org.eclipse.paho.client.mqttv3/META-INF/MANIFEST.MF
+++ b/org.eclipse.paho.client.mqttv3/META-INF/MANIFEST.MF
@@ -2,12 +2,12 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %bundle.name
 Bundle-SymbolicName: org.eclipse.paho.client.mqttv3
-Bundle-Version: 1.2.2.qualifier
+Bundle-Version: 1.2.2
 Bundle-Localization: bundle
-Export-Package: org.eclipse.paho.client.mqttv3;version="1.2.2.qualifier",
- org.eclipse.paho.client.mqttv3.logging;version="1.2.2.qualifier",
- org.eclipse.paho.client.mqttv3.persist;version="1.2.2.qualifier",
- org.eclipse.paho.client.mqttv3.util;version="1.2.2.qualifier"
+Export-Package: org.eclipse.paho.client.mqttv3;version="1.2.2",
+ org.eclipse.paho.client.mqttv3.logging;version="1.2.2",
+ org.eclipse.paho.client.mqttv3.persist;version="1.2.2",
+ org.eclipse.paho.client.mqttv3.util;version="1.2.2"
 Bundle-Vendor: %bundle.provider
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7

--- a/org.eclipse.paho.client.mqttv3/pom.xml
+++ b/org.eclipse.paho.client.mqttv3/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.paho</groupId>
 		<artifactId>java-parent</artifactId>
-		<version>1.2.2-SNAPSHOT</version>
+		<version>1.2.2</version>
 	</parent>
 
 	<artifactId>org.eclipse.paho.client.mqttv3</artifactId>
@@ -133,5 +133,5 @@
 			</plugins>
 		</pluginManagement>
 	</build>
-<version>1.2.2-SNAPSHOT</version>
+<version>1.2.2</version>
 </project>

--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/CommsReceiver.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/CommsReceiver.java
@@ -165,7 +165,12 @@ public class CommsReceiver implements Runnable {
 						if (message != null) {
 							// A new message has arrived
 							clientState.notifyReceivedMsg(message);
-						}
+						}  else {
+                                                    // fix for bug 719
+                                                    if (!clientComms.isConnected()) {
+                                                        throw new MqttException(MqttException.REASON_CODE_CONNECTION_LOST);
+                                                    }
+                                                }
 					}
 				}
 				catch (MqttException ex) {

--- a/org.eclipse.paho.mqttv5.client.test/pom.xml
+++ b/org.eclipse.paho.mqttv5.client.test/pom.xml
@@ -5,11 +5,11 @@
   <parent>
     <groupId>org.eclipse.paho</groupId>
     <artifactId>java-parent</artifactId>
-    <version>1.2.2-SNAPSHOT</version>
+    <version>1.2.2</version>
   </parent>
   <groupId>org.eclipse.paho.mqttv5.client.test</groupId>
   <artifactId>org.eclipse.paho.mqttv5.client.test</artifactId>
-  <version>1.2.2-SNAPSHOT</version>
+  <version>1.2.2</version>
   <name>org.eclipse.paho.mqttv5.client.test</name>
   <url>http://maven.apache.org</url>
   <properties>
@@ -50,12 +50,12 @@
     <dependency>
     	<groupId>org.eclipse.paho</groupId>
     	<artifactId>org.eclipse.paho.mqttv5.common</artifactId>
-    	<version>1.2.2-SNAPSHOT</version>
+    	<version>1.2.2</version>
     </dependency>
     <dependency>
     	<groupId>org.eclipse.paho</groupId>
     	<artifactId>org.eclipse.paho.mqttv5.client</artifactId>
-    	<version>1.2.2-SNAPSHOT</version>
+    	<version>1.2.2</version>
     </dependency>
   </dependencies>
   

--- a/org.eclipse.paho.mqttv5.client/pom.xml
+++ b/org.eclipse.paho.mqttv5.client/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.eclipse.paho</groupId>
 		<artifactId>java-parent</artifactId>
-		<version>1.2.2-SNAPSHOT</version>
+		<version>1.2.2</version>
 	</parent>
 	<artifactId>org.eclipse.paho.mqttv5.client</artifactId>
 	<name>org.eclipse.paho.mqttv5.client</name>
@@ -41,7 +41,7 @@
 		<dependency>
 			<groupId>org.eclipse.paho</groupId>
 			<artifactId>org.eclipse.paho.mqttv5.common</artifactId>
-			<version>1.2.2-SNAPSHOT</version>
+			<version>1.2.2</version>
 		</dependency>
 		<dependency>
 			<groupId>junit</groupId>

--- a/org.eclipse.paho.mqttv5.common/pom.xml
+++ b/org.eclipse.paho.mqttv5.common/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.eclipse.paho</groupId>
 		<artifactId>java-parent</artifactId>
-		<version>1.2.2-SNAPSHOT</version>
+		<version>1.2.2</version>
 	</parent>
 
 	<artifactId>org.eclipse.paho.mqttv5.common</artifactId>

--- a/org.eclipse.paho.sample.mqttclient/pom.xml
+++ b/org.eclipse.paho.sample.mqttclient/pom.xml
@@ -7,11 +7,11 @@
 	<parent>
 		<groupId>org.eclipse.paho</groupId>
 		<artifactId>java-parent</artifactId>
-		<version>1.2.2-SNAPSHOT</version>
+		<version>1.2.2</version>
 	</parent>
 	<groupId>org.eclipse.paho</groupId>
 	<artifactId>org.eclipse.paho.sample.mqttclient</artifactId>
-	<version>1.0-SNAPSHOT</version>
+	<version>1.2.2</version>
 	<name>org.eclipse.paho.sample.mqttclient</name>
 	<url>http://maven.apache.org</url>
 	    <properties>
@@ -34,12 +34,12 @@
 		<dependency>
 			<groupId>org.eclipse.paho</groupId>
 			<artifactId>org.eclipse.paho.client.mqttv3</artifactId>
-			<version>1.2.2-SNAPSHOT</version>
+			<version>1.2.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.paho</groupId>
 			<artifactId>org.eclipse.paho.mqttv5.client</artifactId>
-			<version>1.2.2-SNAPSHOT</version>
+			<version>1.2.2</version>
 		</dependency>
 	</dependencies>
 	<build>

--- a/org.eclipse.paho.sample.mqttclient/src/main/scripts/mqtt-client
+++ b/org.eclipse.paho.sample.mqttclient/src/main/scripts/mqtt-client
@@ -1,4 +1,4 @@
 #!/bin/bash
 currentDir=`dirname "$0"`
 trace="-Djava.util.logging.config.file=/Users/jsutton/ibm/paho/trace/mqttv5trace.properties"
-java "$trace" -jar "$currentDir/"org.eclipse.paho.sample.mqttclient-1.0-SNAPSHOT-jar-with-dependencies.jar "$@"
+java "$trace" -jar "$currentDir/"org.eclipse.paho.sample.mqttclient-1.2.3-SNAPSHOT-jar-with-dependencies.jar "$@"

--- a/org.eclipse.paho.sample.utility/pom.xml
+++ b/org.eclipse.paho.sample.utility/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
         <groupId>org.eclipse.paho</groupId>
         <artifactId>java-parent</artifactId>
-        <version>1.2.2-SNAPSHOT</version>
+        <version>1.2.2</version>
     </parent>
 
     <artifactId>org.eclipse.paho.mqtt.utility</artifactId>
@@ -71,7 +71,7 @@
         <dependency>
             <groupId>org.eclipse.paho</groupId>
             <artifactId>org.eclipse.paho.client.mqttv3</artifactId>
-            <version>1.2.2-SNAPSHOT</version>
+            <version>1.2.2</version>
         </dependency>
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<groupId>org.eclipse.paho</groupId>
 	<artifactId>java-parent</artifactId>
 	<packaging>pom</packaging>
-	<version>1.2.2-SNAPSHOT</version>
+	<version>1.2.2</version>
 
 	<properties>
 		<!-- source & target java version for MQTT Client -->
@@ -55,7 +55,7 @@
 	<scm>
 		<url>http://git.eclipse.org/c/paho/org.eclipse.paho.mqtt.java.git</url>
 		<connection>scm:git://git.eclipse.org/gitroot/paho/org.eclipse.paho.mqtt.java.git</connection>
-	  <tag>java-parent-1.2.1</tag>
+	  <tag>java-parent-1.2.2</tag>
   </scm>
 
 	<distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -117,6 +117,9 @@
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-javadoc-plugin</artifactId>
 					<version>3.0.0</version>
+					<configuration>
+						<source>8</source>
+					</configuration>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Fix for issue 719

	modified:   org.eclipse.paho.client.mqttv3.test/src/test/java/org/eclipse/paho/client/mqttv3/test/SSLSessionResumptionTest.java
	modified:   org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/CommsReceiver.java

Please make sure that the following boxes are checked before submitting your Pull Request, thank you!

- [ ] This change is against the develop branch, **not** master.
- [X] You have signed the [Eclipse ECA](https://wiki.eclipse.org/ECA)
- [X] All of your commits have been signed-off with the correct email address (The same one that you used to sign the CLA) _Hint: use the -s argument when committing_.
- [X] If This PR fixes an issue, that you reference the issue below. OR if this is a new issue that you are fixing straight away that you add some Description about the bug and how this will fix it.
- [ ] If this is new functionality, You have added the appropriate Unit tests.

-----------------------

Fix for issue #719

How to recreate the problem?
This problem can be recreated using "tcpkill" to block source port during connection. Steps are as follows:

    Configure client with automatic reconnect option
    Let client connect successfully and publish messages
    Block source port:
    $ tcpkill -9 src port 1883
    Client will be disconnected and start a connection cycle
    After about 60 seconds, stop tcpkill

Analysis:
If for any intermittent networking problem, client fails to receive connection ACK, client may go in hung state.

When client is trying to connect, client state is set to connecting. After sending connect packet, client waits for conack. The receiver thread processes conack. This thread invokes readMqttWireMessage() method to get incoming messages. The readMqttWireMessage() method processes incoming packets and send messages to receiver thread. If connection is reset for any reason, method readMqttWireMessage() gets Socket exception "connection reset" but is not handled. This method returns a null message to the caller. The receiver thread silently drops this packet. 

Though this behavior in readMqttWireMessage() is needed to handle different cases, but this can cause problem during connection, when client is in connecting state. The pinger thread (responsible for keepalive) is not active when client is not in connected state. Since the "connection reset" case is not handled, client can not go in reconnect mode even if auto reconnect is enabled. And client goes in hung state. 

The receiver should throw an exception when it receives a null message and client is not connected.

I am also fixing one unit test that fails with timeout error. This got exposed due to fix made to fix issue 719.

