### PR TITLE
Fix #640 Use same time units in time computations

### DIFF
--- a/org.eclipse.paho.client.mqttv3.test/src/test/java/org/eclipse/paho/client/mqttv3/test/MqttDataTypesTest.java
+++ b/org.eclipse.paho.client.mqttv3.test/src/test/java/org/eclipse/paho/client/mqttv3/test/MqttDataTypesTest.java
@@ -1,13 +1,8 @@
 package org.eclipse.paho.client.mqttv3.test;
 
-import java.io.BufferedReader;
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.DataInputStream;
-import java.io.DataOutputStream;
-import java.io.File;
-import java.io.FileReader;
-import java.io.IOException;
+import java.io.*;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 import org.eclipse.paho.client.mqttv3.MqttException;
 import org.eclipse.paho.client.mqttv3.internal.wire.MqttWireMessage;
@@ -127,7 +122,18 @@ public class MqttDataTypesTest {
 	@Test
 	public void testICanEatGlass() throws IOException, MqttException {
 		ClassLoader classLoader = getClass().getClassLoader();
-		File file = new File(classLoader.getResource("i_can_eat_glass.txt").getFile());
+		String encodedFileName = classLoader.getResource("i_can_eat_glass.txt").getFile();
+		String decodedFileName;
+		try {
+			decodedFileName = java.net.URLDecoder.decode( encodedFileName, StandardCharsets.UTF_8.name() );
+		}
+		catch ( UnsupportedEncodingException e ) {
+			// can't decode the URL, passing on the encoded name hoping that it
+			// actually contains something that exists in the filesystem with
+			// that name.
+			decodedFileName = encodedFileName;
+		}
+		File file = new File(decodedFileName);
 
 		try (BufferedReader br = new BufferedReader(new FileReader(file))) {
 			for (String line; (line = br.readLine()) != null;) {

--- a/org.eclipse.paho.client.mqttv3.test/src/test/java/org/eclipse/paho/client/mqttv3/test/SSLSessionResumptionTest.java
+++ b/org.eclipse.paho.client.mqttv3.test/src/test/java/org/eclipse/paho/client/mqttv3/test/SSLSessionResumptionTest.java
@@ -170,7 +170,7 @@ public class SSLSessionResumptionTest {
 		}
 	}
 
-	private static SSLSocketFactory getSocketFactory() throws Exception {
+	private static SSLSocketFactory    getSocketFactory() throws Exception {
 		InputStream keyStoreStream = new FileInputStream(TestProperties.getClientKeyStore());
 		SSLContext sslContext = SSLContext.getInstance("TLS");
 		TrustManagerFactory trustManagerFactory = TrustManagerFactory

--- a/org.eclipse.paho.client.mqttv3.test/src/test/java/org/eclipse/paho/client/mqttv3/test/SendReceiveAsyncTest.java
+++ b/org.eclipse.paho.client.mqttv3.test/src/test/java/org/eclipse/paho/client/mqttv3/test/SendReceiveAsyncTest.java
@@ -640,7 +640,7 @@ public class SendReceiveAsyncTest {
 		  Assert.fail("Should throw an timeout exception.");
 	  }
 	  catch (Exception exception) {
-		  log.log(Level.INFO, "Connect action failed at expected.");
+		  log.log(Level.INFO, "Connect action failed as expected.");
 		  Assert.assertTrue(exception instanceof MqttException);
 		  Assert.assertEquals(MqttException.REASON_CODE_CLIENT_TIMEOUT, ((MqttException) exception).getReasonCode());
 	  }
@@ -658,7 +658,7 @@ public class SendReceiveAsyncTest {
 		  connectToken.waitForCompletion(5000);
 	  }
 	  catch (Exception exception) {
-		  log.log(Level.INFO, "Connect action failed at expected.");
+		  log.log(Level.INFO, "Connect action failed as expected.");
 		  Assert.assertTrue(exception instanceof MqttException);
 		  Assert.assertEquals(
 				  (MqttException.REASON_CODE_CLIENT_TIMEOUT == ((MqttException) exception).getReasonCode() ||

--- a/org.eclipse.paho.client.mqttv3.test/src/test/java/org/eclipse/paho/client/mqttv3/test/properties/TestProperties.java
+++ b/org.eclipse.paho.client.mqttv3.test/src/test/java/org/eclipse/paho/client/mqttv3/test/properties/TestProperties.java
@@ -14,15 +14,13 @@
 
 package org.eclipse.paho.client.mqttv3.test.properties;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStream;
+import java.io.*;
 import java.net.InetAddress;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.UnknownHostException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -336,7 +334,15 @@ public class TestProperties {
 
   public static String getClientKeyStore() {
     URL keyStore = cclass.getClassLoader().getResource(getInstance().getProperty(KEY_CLIENT_KEY_STORE));
-    return keyStore.getPath();
+    String encodedPath=keyStore.getPath();
+    try {
+      return java.net.URLDecoder.decode( encodedPath, StandardCharsets.UTF_8.name());
+    }
+    catch (UnsupportedEncodingException e ) {
+      // likely the property value is malformed. Return it as is, hoping that
+      // the requester knows what to make of it.
+      return encodedPath;
+    }
   }
 
   /**

--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/security/SSLSocketFactoryFactory.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/security/SSLSocketFactoryFactory.java
@@ -18,6 +18,8 @@ package org.eclipse.paho.client.mqttv3.internal.security;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.security.KeyManagementException;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
@@ -1005,7 +1007,14 @@ public class SSLSocketFactoryFactory {
 	 * @return The name of the file that contains the truststore.
 	 */
 	public String getTrustStore(String configID) {
-		return getProperty(configID, TRUSTSTORE, SYSTRUSTSTORE);
+		String encodedPath = getProperty(configID, TRUSTSTORE, SYSTRUSTSTORE);
+		try {
+			String decodedPath = java.net.URLDecoder.decode( encodedPath, StandardCharsets.UTF_8.name());
+			return decodedPath;
+		}
+		catch( UnsupportedEncodingException e ) {
+			return encodedPath;
+		}
 	}
 
 	/**
@@ -1256,7 +1265,7 @@ public class SSLSocketFactoryFactory {
 			if (trustManager != null) {
 				trustMgrAlgo = trustManager;
 			}
-					
+
 			if(trustStoreName!=null && trustStoreType!=null && trustMgrAlgo!=null) {
 				try {
 					trustStore=KeyStore.getInstance(trustStoreType);

--- a/org.eclipse.paho.mqttv5.client/src/test/java/org/eclipse/paho/mqttv5/client/test/SendReceiveAsyncTest.java
+++ b/org.eclipse.paho.mqttv5.client/src/test/java/org/eclipse/paho/mqttv5/client/test/SendReceiveAsyncTest.java
@@ -624,7 +624,7 @@ public class SendReceiveAsyncTest {
 		  Assert.fail("Should throw a timeout exception.");
 	  }
 	  catch (Exception exception) {
-		  log.log(Level.INFO, "Connect action failed at expected.");
+		  log.log(Level.INFO, "Connect action failed as expected.");
 		  Assert.assertTrue(exception instanceof MqttException);
 		  Assert.assertEquals(MqttException.REASON_CODE_MALFORMED_PACKET, ((MqttException) exception).getReasonCode());
 	  }
@@ -646,7 +646,7 @@ public class SendReceiveAsyncTest {
 		  connectToken.waitForCompletion(5000);
 	  }
 	  catch (Exception exception) {
-		  log.log(Level.INFO, "Connect action failed at expected.");
+		  log.log(Level.INFO, "Connect action failed as expected.");
 		  //Assert.assertTrue(exception instanceof MqttException);
 		  Assert.assertEquals(
 				  (MqttClientException.REASON_CODE_CLIENT_CLOSED == ((MqttException) exception).getReasonCode() ||


### PR DESCRIPTION
Additional I slightly changed some variable names to include time unit
so to improve maintainability.

Signed-off-by: Massimiliano Pagani <maxpag@gmail.com>

Please make sure that the following boxes are checked before submitting your Pull Request, thank you!

- [x] This change is against the develop branch, **not** master.
- [x] You have signed the [Eclipse ECA](https://wiki.eclipse.org/ECA)
- [x] All of your commits have been signed-off with the correct email address (The same one that you used to sign the CLA) _Hint: use the -s argument when committing_.
- [x] If This PR fixes an issue, that you reference the issue below. OR if this is a new issue that you are fixing straight away that you add some Description about the bug and how this will fix it.
- [ ] If this is new functionality, You have added the appropriate Unit tests.

Fix for #738 and #640