### PR TITLE
Fix #640 Use same time units in time computations

### DIFF
--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/ClientState.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/ClientState.java
@@ -119,7 +119,7 @@ public class ClientState {
 	private CommsTokenStore tokenStore;
 	private ClientComms clientComms = null;
 	private CommsCallback callback = null;
-	private long keepAlive;
+	private long keepAliveNanos;					// nanoseconds time
 	private boolean cleanSession;
 	private MqttClientPersistence persistence;
 	
@@ -131,9 +131,9 @@ public class ClientState {
 	private final Object quiesceLock = new Object();
 	private boolean quiescing = false;
 	
-	private long lastOutboundActivity = 0;
-	private long lastInboundActivity = 0;
-	private long lastPing = 0;
+	private long lastOutboundActivity = 0;			// nanoseconds absolute time
+	private long lastInboundActivity = 0;			// nanoseconds absolute time
+	private long lastPing = 0;						// nanoseconds absolute time
 	private MqttWireMessage pingCommand;
 	private final Object pingOutstandingLock = new Object();
 	private int pingOutstanding = 0;
@@ -177,14 +177,14 @@ public class ClientState {
         pendingMessages = new Vector(this.maxInflight);
     }
     protected void setKeepAliveSecs(long keepAliveSecs) {
-		this.keepAlive = TimeUnit.SECONDS.toNanos(keepAliveSecs);
+		this.keepAliveNanos = TimeUnit.SECONDS.toNanos(keepAliveSecs);
 	}
     /**
      * Returns the keepAlive in Milliseconds
      * @return The KeepAlive value in Milliseconds
      */
 	protected long getKeepAlive() {
-		return TimeUnit.NANOSECONDS.toMillis(this.keepAlive);
+		return TimeUnit.NANOSECONDS.toMillis(this.keepAliveNanos);
 	}
 	protected void setCleanSession(boolean cleanSession) {
 		this.cleanSession = cleanSession;
@@ -715,9 +715,9 @@ public class ClientState {
         }
 
 		MqttToken token = null;
-		long nextPingTime = this.keepAlive;
+		long nextPingTime = TimeUnit.NANOSECONDS.toMillis(this.keepAliveNanos);		// milliseconds relative time
 		
-		if (connected && this.keepAlive > 0) {
+		if (connected && this.keepAliveNanos > 0) {
 			long time = System.nanoTime();
 			// Below might not be necessary since move to nanoTime (Issue #278)
 			//Reduce schedule frequency since System.currentTimeMillis is no accurate, add a buffer
@@ -728,13 +728,13 @@ public class ClientState {
             synchronized (pingOutstandingLock) {
 
                 // Is the broker connection lost because the broker did not reply to my ping?                                                                                                                                 
-                if (pingOutstanding > 0 && (time - lastInboundActivity >= keepAlive + delta)) {
+                if (pingOutstanding > 0 && (time - lastInboundActivity >= keepAliveNanos + delta)) {
                     // lastInboundActivity will be updated once receiving is done.                                                                                                                                        
                     // Add a delta, since the timer and System.currentTimeMillis() is not accurate.     
                 		// TODO - Remove Delta, maybe?
                 	// A ping is outstanding but no packet has been received in KA so connection is deemed broken                                                                                                         
                     //@TRACE 619=Timed out as no activity, keepAlive={0} lastOutboundActivity={1} lastInboundActivity={2} time={3} lastPing={4}                                                                           
-                    log.severe(CLASS_NAME,methodName,"619", new Object[]{ Long.valueOf(this.keepAlive), Long.valueOf(lastOutboundActivity), Long.valueOf(lastInboundActivity),  Long.valueOf(time),  Long.valueOf(lastPing)});
+                    log.severe(CLASS_NAME,methodName,"619", new Object[]{ Long.valueOf(this.keepAliveNanos), Long.valueOf(lastOutboundActivity), Long.valueOf(lastInboundActivity),  Long.valueOf(time),  Long.valueOf(lastPing)});
 
                     // A ping has already been sent. At this point, assume that the                                                                                                                                       
                     // broker has hung and the TCP layer hasn't noticed.                                                                                                                                                  
@@ -742,10 +742,10 @@ public class ClientState {
                 }
 
                 // Is the broker connection lost because I could not get any successful write for 2 keepAlive intervals?                                                                                                      
-                if (pingOutstanding == 0 && (time - lastOutboundActivity >= 2*keepAlive)) {
+                if (pingOutstanding == 0 && (time - lastOutboundActivity >= 2* keepAliveNanos)) {
                     
                     // I am probably blocked on a write operations as I should have been able to write at least a ping message                                                                                                    
-                	log.severe(CLASS_NAME,methodName,"642", new Object[]{ Long.valueOf(this.keepAlive), Long.valueOf(lastOutboundActivity), Long.valueOf(lastInboundActivity),  Long.valueOf(time),  Long.valueOf(lastPing)});
+                	log.severe(CLASS_NAME,methodName,"642", new Object[]{ Long.valueOf(this.keepAliveNanos), Long.valueOf(lastOutboundActivity), Long.valueOf(lastInboundActivity),  Long.valueOf(time),  Long.valueOf(lastPing)});
 
                     // A ping has not been sent but I am not progressing on the current write operation. 
                 	// At this point, assume that the broker has hung and the TCP layer hasn't noticed.                                                                                                                                                  
@@ -761,11 +761,11 @@ public class ClientState {
                 //    This would be the case when receiving a large message;                                                                                                                                                  
                 //    the broker needs to keep receiving a regular ping even if the ping response are queued after the long message                                                                                           
                 //    If lacking to do so, the broker will consider my connection lost and cut my socket.                                                                                                                     
-                if ((pingOutstanding == 0 && (time - lastInboundActivity >= keepAlive - delta)) ||
-                    (time - lastOutboundActivity >= keepAlive - delta)) {
+                if ((pingOutstanding == 0 && (time - lastInboundActivity >= keepAliveNanos - delta)) ||
+                    (time - lastOutboundActivity >= keepAliveNanos - delta)) {
 
                     //@TRACE 620=ping needed. keepAlive={0} lastOutboundActivity={1} lastInboundActivity={2}                                                                                                              
-                    log.fine(CLASS_NAME,methodName,"620", new Object[]{ Long.valueOf(this.keepAlive), Long.valueOf(lastOutboundActivity), Long.valueOf(lastInboundActivity)});
+                    log.fine(CLASS_NAME,methodName,"620", new Object[]{ Long.valueOf(this.keepAliveNanos), Long.valueOf(lastOutboundActivity), Long.valueOf(lastInboundActivity)});
 
                     // pingOutstanding++;  // it will be set after the ping has been written on the wire                                                                                                             
                     // lastPing = time;    // it will be set after the ping has been written on the wire                                                                                                             
@@ -784,7 +784,9 @@ public class ClientState {
                 else {
                 		//@TRACE 634=ping not needed yet. Schedule next ping.
                     log.fine(CLASS_NAME, methodName, "634", null);
-                    nextPingTime = Math.max(1,  getKeepAlive() - (time - lastOutboundActivity));
+                    long elapsedSinceLastActivityNanos = time - lastOutboundActivity;
+                    long elapsedSinceLastActivityMillis = TimeUnit.NANOSECONDS.toMillis( elapsedSinceLastActivityNanos );
+                    nextPingTime = Math.max(1,  getKeepAlive() - elapsedSinceLastActivityMillis);
                 }
             }
             //@TRACE 624=Schedule next ping at {0}                                                                                                                                                                                
@@ -882,8 +884,13 @@ public class ClientState {
 		return result;
 	}
 	
+	/**
+	 * Sets the keep alive interval.
+	 *
+	 * @param interval keep alive interval in milliseconds.
+	 */
 	public void setKeepAliveInterval(long interval) {
-		this.keepAlive = interval;
+		this.keepAliveNanos = TimeUnit.MILLISECONDS.toNanos(interval);
 	}
 	
     public void notifySentBytes(int sentBytesCount) {


### PR DESCRIPTION
Additional I slightly changed some variable names to include time unit
so to improve maintainability.

Signed-off-by: maxp <maxpag@gmail.com>

Please make sure that the following boxes are checked before submitting your Pull Request, thank you!

- [x] This change is against the develop branch, **not** master.
- [x] You have signed the [Eclipse ECA](https://wiki.eclipse.org/ECA)
- [x] All of your commits have been signed-off with the correct email address (The same one that you used to sign the CLA) _Hint: use the -s argument when committing_.
- [x] If This PR fixes an issue, that you reference the issue below. OR if this is a new issue that you are fixing straight away that you add some Description about the bug and how this will fix it.
- [ ] If this is new functionality, You have added the appropriate Unit tests.
