### PR TITLE
Implementation specific timer for ClientState

### DIFF
--- a/org.eclipse.paho.client.mqttv3/src/main/java-templates/org/eclipse/paho/client/mqttv3/internal/ClientComms.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java-templates/org/eclipse/paho/client/mqttv3/internal/ClientComms.java
@@ -95,7 +95,8 @@ public class ClientComms {
 	 * @param executorService the {@link ExecutorService}
 	 * @throws MqttException if an exception occurs whilst communicating with the server
 	 */
-	public ClientComms(IMqttAsyncClient client, MqttClientPersistence persistence, MqttPingSender pingSender, ExecutorService executorService) throws MqttException {
+	public ClientComms(IMqttAsyncClient client, MqttClientPersistence persistence, MqttPingSender pingSender,
+					   ExecutorService executorService, HighResolutionTimer highResolutionTimer) throws MqttException {
 		this.conState = DISCONNECTED;
 		this.client 	= client;
 		this.persistence = persistence;
@@ -105,7 +106,7 @@ public class ClientComms {
 
 		this.tokenStore = new CommsTokenStore(getClient().getClientId());
 		this.callback 	= new CommsCallback(this);
-		this.clientState = new ClientState(persistence, tokenStore, this.callback, this, pingSender);
+		this.clientState = new ClientState(persistence, tokenStore, this.callback, this, pingSender, highResolutionTimer);
 
 		callback.setClientState(clientState);
 		log.setResourceName(getClient().getClientId());

--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/ClientState.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/ClientState.java
@@ -122,6 +122,7 @@ public class ClientState {
 	private long keepAliveNanos;					// nanoseconds time
 	private boolean cleanSession;
 	private MqttClientPersistence persistence;
+	private HighResolutionTimer highResolutionTimer;
 	
 	private int maxInflight = 0;	
 	private int actualInFlight = 0;
@@ -148,7 +149,8 @@ public class ClientState {
 	private MqttPingSender pingSender = null;
 
 	protected ClientState(MqttClientPersistence persistence, CommsTokenStore tokenStore, 
-			CommsCallback callback, ClientComms clientComms, MqttPingSender pingSender) throws MqttException {
+			CommsCallback callback, ClientComms clientComms, MqttPingSender pingSender,
+		    HighResolutionTimer highResolutionTimer) throws MqttException {
 		
 		log.setResourceName(clientComms.getClient().getClientId());
 		log.finer(CLASS_NAME, "<Init>", "" );
@@ -168,6 +170,7 @@ public class ClientState {
 		this.tokenStore = tokenStore;
 		this.clientComms = clientComms;
 		this.pingSender = pingSender;
+		this.highResolutionTimer = highResolutionTimer;
 		
 		restoreState();
 	}
@@ -719,7 +722,7 @@ public class ClientState {
 		long nextPingTime = TimeUnit.NANOSECONDS.toMillis(this.keepAliveNanos);		// milliseconds relative time
 		
 		if (connected && this.keepAliveNanos > 0) {
-			long time = System.nanoTime();
+			long time = highResolutionTimer.nanoTime();
 			// Below might not be necessary since move to nanoTime (Issue #278)
 			//Reduce schedule frequency since System.currentTimeMillis is no accurate, add a buffer
 			//It is 1/10 in minimum keepalive unit.
@@ -897,7 +900,7 @@ public class ClientState {
     public void notifySentBytes(int sentBytesCount) {
         final String methodName = "notifySentBytes";
         if (sentBytesCount > 0) {
-        	this.lastOutboundActivity = System.nanoTime();
+        	this.lastOutboundActivity = highResolutionTimer.nanoTime();
         }
         // @TRACE 643=sent bytes count={0}                                                                                                                                                                                            
         log.fine(CLASS_NAME, methodName, "643", new Object[] {
@@ -912,7 +915,7 @@ public class ClientState {
 	protected void notifySent(MqttWireMessage message) {
 		final String methodName = "notifySent";
 		
-		this.lastOutboundActivity = System.nanoTime();
+		this.lastOutboundActivity = highResolutionTimer.nanoTime();
 		//@TRACE 625=key={0}
 		log.fine(CLASS_NAME,methodName,"625",new Object[]{message.getKey()});
 		
@@ -924,7 +927,7 @@ public class ClientState {
 		token.internalTok.notifySent();
         if (message instanceof MqttPingReq) {
             synchronized (pingOutstandingLock) {
-            	long time = System.nanoTime();
+            	long time = highResolutionTimer.nanoTime();
                 synchronized (pingOutstandingLock) {
                 	lastPing = time;
                 	pingOutstanding++;
@@ -978,7 +981,7 @@ public class ClientState {
     public void notifyReceivedBytes(int receivedBytesCount) {
         final String methodName = "notifyReceivedBytes";
         if (receivedBytesCount > 0) {
-            this.lastInboundActivity = System.nanoTime();
+            this.lastInboundActivity = highResolutionTimer.nanoTime();
         }
         // @TRACE 630=received bytes count={0}                                                                                                                                                                                        
         log.fine(CLASS_NAME, methodName, "630", new Object[] {
@@ -993,7 +996,7 @@ public class ClientState {
 	 */
 	protected void notifyReceivedAck(MqttAck ack) throws MqttException {
 		final String methodName = "notifyReceivedAck";
-		this.lastInboundActivity = System.nanoTime();
+		this.lastInboundActivity = highResolutionTimer.nanoTime();
 
 		// @TRACE 627=received key={0} message={1}
 		log.fine(CLASS_NAME, methodName, "627", new Object[] {
@@ -1075,7 +1078,7 @@ public class ClientState {
 	 */
 	protected void notifyReceivedMsg(MqttWireMessage message) throws MqttException {
 		final String methodName = "notifyReceivedMsg";
-		this.lastInboundActivity = System.nanoTime();
+		this.lastInboundActivity = highResolutionTimer.nanoTime();
 
 		// @TRACE 651=received key={0} message={1}
 		log.fine(CLASS_NAME, methodName, "651", new Object[] {
@@ -1435,7 +1438,8 @@ public class ClientState {
 		callback = null;
 		clientComms = null;
 		persistence = null;
-		pingCommand = null;	
+		pingCommand = null;
+		highResolutionTimer = null;
 	}
 	
 	public Properties getDebug() {

--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/HighResolutionTimer.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/HighResolutionTimer.java
@@ -1,0 +1,35 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2018 IBM Corp.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    https://www.eclipse.org/legal/epl-2.0
+ * and the Eclipse Distribution License is available at
+ *   https://www.eclipse.org/org/documents/edl-v10.php
+ *
+ * Contributors:
+ *    Dustin Thomson - initial API and implementation and/or initial documentation
+ */
+
+package org.eclipse.paho.client.mqttv3.internal;
+
+/**
+ * A high-resolution timer source.
+ *
+ * Implementations must use clocks that are guaranteed to be monotonic and continue to run
+ * even if the CPU enters a low-power state.
+ */
+public interface HighResolutionTimer {
+
+    /**
+     * Returns the current value of a high-resolution time source, in nanoseconds.
+     *
+     * This method can only be used to measure elapsed time and may return negative values.
+     *
+     * @return the current value of a high-resolution time source, in nanoseconds.
+     */
+    public long nanoTime();
+}

--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/SystemHighResolutionTimer.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/SystemHighResolutionTimer.java
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2018 IBM Corp.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    https://www.eclipse.org/legal/epl-2.0
+ * and the Eclipse Distribution License is available at
+ *   https://www.eclipse.org/org/documents/edl-v10.php
+ *
+ * Contributors:
+ *    Dustin Thomson - initial API and implementation and/or initial documentation
+ */
+
+package org.eclipse.paho.client.mqttv3.internal;
+
+/**
+ * A high resolution timer appropriate for use by most JVMs.
+ *
+ * This implementation delegates {@link #nanoTime()} to {@link System#nanoTime()}.
+ *
+ * Note: This implementation is not appropriate for use on Android, as the clock backing {@link System#nanoTime()} stops
+ *       when the system enters deep sleep.
+ */
+public class SystemHighResolutionTimer implements HighResolutionTimer {
+    @Override
+    public long nanoTime() {
+        return System.nanoTime();
+    }
+}


### PR DESCRIPTION
On some platforms (eg: android) the clock backing System.nanoTime stops
running when the device enters a low power state. By allowing users of
the library to supply a custom HighResolutionTimer implementation, an
appropriate time source can be used.

Fixes #774

Signed-off-by: Dustin Thomson <dthomson@51systems.com>

Please make sure that the following boxes are checked before submitting your Pull Request, thank you!

- [x] This change is against the develop branch, **not** master.
- [x] You have signed the [Eclipse ECA](https://wiki.eclipse.org/ECA)
- [x] All of your commits have been signed-off with the correct email address (the same one that you 
      used to sign the CLA) _Hint: use the -s argument when committing_.
- [x] If This PR fixes an issue, that you reference the issue below. OR if this is a new issue that 
      you are fixing straight away that you add some Description about the bug and how this will fix it.
- [x] If this is new functionality, You have added the appropriate Unit tests.
