### PR TITLE
Makes port additions during the handshake are configurable

### DIFF
--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/MqttConnectOptions.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/MqttConnectOptions.java
@@ -74,6 +74,7 @@ public class MqttConnectOptions {
 	private boolean automaticReconnect = false;
 	private int maxReconnectDelay = 128000;
 	private Properties customWebSocketHeaders = null;
+	private boolean skipPortDuringHandshake = false;
 
 	// Client Operation Parameters
 	private int executorServiceTimeout = 1; // How long to wait in seconds when terminating the executor service.
@@ -99,7 +100,7 @@ public class MqttConnectOptions {
 
 	/**
 	 * Returns the password to use for the connection.
-	 * 
+	 *
 	 * @return the password to use for the connection.
 	 */
 	public char[] getPassword() {
@@ -108,7 +109,7 @@ public class MqttConnectOptions {
 
 	/**
 	 * Sets the password to use for the connection.
-	 * 
+	 *
 	 * @param password
 	 *            A Char Array of the password
 	 */
@@ -118,7 +119,7 @@ public class MqttConnectOptions {
 
 	/**
 	 * Returns the user name to use for the connection.
-	 * 
+	 *
 	 * @return the user name to use for the connection.
 	 */
 	public String getUserName() {
@@ -127,7 +128,7 @@ public class MqttConnectOptions {
 
 	/**
 	 * Sets the user name to use for the connection.
-	 * 
+	 *
 	 * @param userName
 	 *            The Username as a String
 	 */
@@ -137,7 +138,7 @@ public class MqttConnectOptions {
 
 	/**
 	 * Get the maximum time (in millis) to wait between reconnects
-	 * 
+	 *
 	 * @return Get the maximum time (in millis) to wait between reconnects
 	 */
 	public int getMaxReconnectDelay() {
@@ -146,7 +147,7 @@ public class MqttConnectOptions {
 
 	/**
 	 * Set the maximum time to wait between reconnects
-	 * 
+	 *
 	 * @param maxReconnectDelay
 	 *            the duration (in millis)
 	 */
@@ -206,7 +207,7 @@ public class MqttConnectOptions {
 
 	/**
 	 * Sets up the will information, based on the supplied parameters.
-	 * 
+	 *
 	 * @param topic
 	 *            the topic to send the LWT message to
 	 * @param msg
@@ -227,7 +228,7 @@ public class MqttConnectOptions {
 
 	/**
 	 * Returns the "keep alive" interval.
-	 * 
+	 *
 	 * @see #setKeepAliveInterval(int)
 	 * @return the keep alive interval.
 	 */
@@ -237,7 +238,7 @@ public class MqttConnectOptions {
 
 	/**
 	 * Returns the MQTT version.
-	 * 
+	 *
 	 * @see #setMqttVersion(int)
 	 * @return the MQTT version.
 	 */
@@ -273,7 +274,7 @@ public class MqttConnectOptions {
 	/**
 	 * Returns the "max inflight". The max inflight limits to how many messages we
 	 * can send without receiving acknowledgments.
-	 * 
+	 *
 	 * @see #setMaxInflight(int)
 	 * @return the max inflight
 	 */
@@ -287,7 +288,7 @@ public class MqttConnectOptions {
 	 * <p>
 	 * The default value is 10
 	 * </p>
-	 * 
+	 *
 	 * @param maxInflight
 	 *            the number of maxInfligt messages
 	 */
@@ -300,7 +301,7 @@ public class MqttConnectOptions {
 
 	/**
 	 * Returns the connection timeout value.
-	 * 
+	 *
 	 * @see #setConnectionTimeout(int)
 	 * @return the connection timeout value.
 	 */
@@ -314,7 +315,7 @@ public class MqttConnectOptions {
 	 * the MQTT server to be established. The default timeout is 30 seconds. A value
 	 * of 0 disables timeout processing meaning the client will wait until the
 	 * network connection is made successfully or fails.
-	 * 
+	 *
 	 * @param connectionTimeout
 	 *            the timeout value, measured in seconds. It must be &gt;0;
 	 */
@@ -328,7 +329,7 @@ public class MqttConnectOptions {
 	/**
 	 * Returns the socket factory that will be used when connecting, or
 	 * <code>null</code> if one has not been set.
-	 * 
+	 *
 	 * @return The Socket Factory
 	 */
 	public SocketFactory getSocketFactory() {
@@ -340,7 +341,7 @@ public class MqttConnectOptions {
 	 * apply its own policies around the creation of network sockets. If using an
 	 * SSL connection, an <code>SSLSocketFactory</code> can be used to supply
 	 * application-specific security settings.
-	 * 
+	 *
 	 * @param socketFactory
 	 *            the factory to use.
 	 */
@@ -350,7 +351,7 @@ public class MqttConnectOptions {
 
 	/**
 	 * Returns the topic to be used for last will and testament (LWT).
-	 * 
+	 *
 	 * @return the MqttTopic to use, or <code>null</code> if LWT is not set.
 	 * @see #setWill(MqttTopic, byte[], int, boolean)
 	 */
@@ -362,7 +363,7 @@ public class MqttConnectOptions {
 	 * Returns the message to be sent as last will and testament (LWT). The returned
 	 * object is "read only". Calling any "setter" methods on the returned object
 	 * will result in an <code>IllegalStateException</code> being thrown.
-	 * 
+	 *
 	 * @return the message to use, or <code>null</code> if LWT is not set.
 	 */
 	public MqttMessage getWillMessage() {
@@ -371,7 +372,7 @@ public class MqttConnectOptions {
 
 	/**
 	 * Returns the SSL properties for the connection.
-	 * 
+	 *
 	 * @return the properties for the SSL connection
 	 */
 	public Properties getSSLProperties() {
@@ -658,6 +659,24 @@ public class MqttConnectOptions {
 	}
 
 	/**
+	 * Returns whether to skip a port during a handshake
+	 *
+	 * @return skipPortDuringHandshake
+	 */
+    public boolean isSkipPortDuringHandshake() {
+        return skipPortDuringHandshake;
+    }
+
+    /**
+     * Sets a flag that indicates whether to add a port to the host during a handshake
+     *
+     * @param skip if set to True, the port will not be added
+     */
+    public void setSkipPortDuringHandshake(boolean skip) {
+        this.skipPortDuringHandshake = skip;
+    }
+
+	/**
 	 * @return The Debug Properties
 	 */
 	public Properties getDebug() {
@@ -679,6 +698,7 @@ public class MqttConnectOptions {
 		} else {
 			p.put("SSLProperties", getSSLProperties());
 		}
+		p.put("SkipPortDuringHandshake", isSkipPortDuringHandshake());
 		return p;
 	}
 

--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/websocket/WebSocketHandshake.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/websocket/WebSocketHandshake.java
@@ -50,6 +50,8 @@ public class WebSocketHandshake {
 	private static final String HTTP_HEADER_CONNECTION_VALUE = "upgrade";
 	private static final String HTTP_HEADER_SEC_WEBSOCKET_PROTOCOL = "sec-websocket-protocol";
 
+	private final boolean skipPortDuringHandshake;
+
 	InputStream input;
 	OutputStream output;
 	String uri;
@@ -57,13 +59,14 @@ public class WebSocketHandshake {
 	int port;
 	Properties customWebSocketHeaders;
 
-	public WebSocketHandshake(InputStream input, OutputStream output, String uri, String host, int port, Properties customWebSocketHeaders){
+	public WebSocketHandshake(InputStream input, OutputStream output, String uri, String host, int port, Properties customWebSocketHeaders, boolean skipPortDuringHandshake){
 		this.input = input;
 		this.output = output;
 		this.uri = uri;
 		this.host = host;
 		this.port = port;
 		this.customWebSocketHeaders = customWebSocketHeaders;
+		this.skipPortDuringHandshake = skipPortDuringHandshake;
 	}
 
 
@@ -99,7 +102,7 @@ public class WebSocketHandshake {
 
 			PrintWriter pw = new PrintWriter(output);
 			pw.print("GET " + path + " HTTP/1.1" + LINE_SEPARATOR);
-			if (port != 80) {
+			if (port != 80 && !skipPortDuringHandshake) {
 				pw.print("Host: " + host + ":" + port + LINE_SEPARATOR);
 			}
 			else {

--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/websocket/WebSocketNetworkModule.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/websocket/WebSocketNetworkModule.java
@@ -41,6 +41,7 @@ public class WebSocketNetworkModule extends TCPNetworkModule {
 	private Properties customWebsocketHeaders;
 	private PipedInputStream pipedInputStream;
 	private WebSocketReceiver webSocketReceiver;
+	private final boolean skipPortDuringHandshake;
 	ByteBuffer recievedPayload;
 	
 	/**
@@ -50,20 +51,20 @@ public class WebSocketNetworkModule extends TCPNetworkModule {
 	 */
 	private ByteArrayOutputStream outputStream = new ExtendedByteArrayOutputStream(this);
 
-	public WebSocketNetworkModule(SocketFactory factory, String uri, String host, int port, String resourceContext, Properties customWebsocketHeaders){
+	public WebSocketNetworkModule(SocketFactory factory, String uri, String host, int port, String resourceContext, Properties customWebsocketHeaders, boolean skipPortDuringHandshake){
 		super(factory, host, port, resourceContext);
 		this.uri = uri;
 		this.host = host;
 		this.port = port;
 		this.customWebsocketHeaders = customWebsocketHeaders;
 		this.pipedInputStream = new PipedInputStream();
-		
+		this.skipPortDuringHandshake = skipPortDuringHandshake;
 		log.setResourceName(resourceContext);
 	}
 	
 	public void start() throws IOException, MqttException {
 		super.start();
-		WebSocketHandshake handshake = new WebSocketHandshake(getSocketInputStream(), getSocketOutputStream(), uri, host, port, customWebsocketHeaders);
+		WebSocketHandshake handshake = new WebSocketHandshake(getSocketInputStream(), getSocketOutputStream(), uri, host, port, customWebsocketHeaders, skipPortDuringHandshake);
 		handshake.execute();
 		this.webSocketReceiver = new WebSocketReceiver(getSocketInputStream(), pipedInputStream);
 		webSocketReceiver.start("webSocketReceiver");

--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/websocket/WebSocketNetworkModuleFactory.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/websocket/WebSocketNetworkModuleFactory.java
@@ -52,7 +52,7 @@ public class WebSocketNetworkModuleFactory implements NetworkModuleFactory {
 			throw ExceptionHelper.createMqttException(MqttException.REASON_CODE_SOCKET_FACTORY_MISMATCH);
 		}
 		WebSocketNetworkModule netModule = new WebSocketNetworkModule(factory, brokerUri.toString(), host, port,
-				clientId, options.getCustomWebSocketHeaders());
+				clientId, options.getCustomWebSocketHeaders(), options.isSkipPortDuringHandshake());
 		netModule.setConnectTimeout(options.getConnectionTimeout());
 		return netModule;
 	}

--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/websocket/WebSocketSecureNetworkModule.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/websocket/WebSocketSecureNetworkModule.java
@@ -40,6 +40,7 @@ public class WebSocketSecureNetworkModule extends SSLNetworkModule{
 	private String host;
 	private int port;
 	private Properties customWebSocketHeaders;
+	private final boolean skipPortDuringHandshake;
 	ByteBuffer recievedPayload;
 	
 	/**
@@ -49,19 +50,20 @@ public class WebSocketSecureNetworkModule extends SSLNetworkModule{
 	 */
 	private ByteArrayOutputStream outputStream = new ExtendedByteArrayOutputStream(this);
 
-	public WebSocketSecureNetworkModule(SSLSocketFactory factory, String uri, String host, int port, String clientId, Properties customWebSocketHeaders) {
+	public WebSocketSecureNetworkModule(SSLSocketFactory factory, String uri, String host, int port, String clientId, Properties customWebSocketHeaders, boolean skipPortDuringHandshake) {
 		super(factory, host, port, clientId);
 		this.uri = uri;
 		this.host = host;
 		this.port = port;
 		this.customWebSocketHeaders = customWebSocketHeaders;
 		this.pipedInputStream = new PipedInputStream();
+		this.skipPortDuringHandshake = skipPortDuringHandshake;
 		log.setResourceName(clientId);
 	}
 
 	public void start() throws IOException, MqttException {
 		super.start();
-		WebSocketHandshake handshake = new WebSocketHandshake(super.getInputStream(), super.getOutputStream(), uri, host, port, customWebSocketHeaders);
+		WebSocketHandshake handshake = new WebSocketHandshake(super.getInputStream(), super.getOutputStream(), uri, host, port, customWebSocketHeaders, skipPortDuringHandshake);
 		handshake.execute();
 		this.webSocketReceiver = new WebSocketReceiver(getSocketInputStream(), pipedInputStream);
 		webSocketReceiver.start("WssSocketReceiver");

--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/websocket/WebSocketSecureNetworkModuleFactory.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/websocket/WebSocketSecureNetworkModuleFactory.java
@@ -64,7 +64,7 @@ public class WebSocketSecureNetworkModuleFactory implements NetworkModuleFactory
 
 		// Create the network module...
 		WebSocketSecureNetworkModule netModule = new WebSocketSecureNetworkModule((SSLSocketFactory) factory,
-				brokerUri.toString(), host, port, clientId, options.getCustomWebSocketHeaders());
+				brokerUri.toString(), host, port, clientId, options.getCustomWebSocketHeaders(), options.isSkipPortDuringHandshake());
 		netModule.setSSLhandshakeTimeout(options.getConnectionTimeout());
 		netModule.setSSLHostnameVerifier(options.getSSLHostnameVerifier());
 		netModule.setHttpsHostnameVerificationEnabled(options.isHttpsHostnameVerificationEnabled());


### PR DESCRIPTION
Added the ability to not specify the host port during a web socket handshake

- [x] This change is against the develop branch, **not** master.
- [x] You have signed the [Eclipse ECA](https://wiki.eclipse.org/ECA)
- [x] All of your commits have been signed-off with the correct email address (the same one that you used to sign the CLA) _Hint: use the -s argument when committing_.
- [x] If This PR fixes an issue, that you reference the issue below. OR if this is a new issue that you are fixing straight away that you add some Description about the bug and how this will fix it.
- [x] If this is new functionality, You have added the appropriate Unit tests.

Signed-off-by: Yehor Beskhmelnytsyn egor.besik@gmail.com