### PR TITLE
Add network interface in MqttConnectOptions

### DIFF
--- a/org.eclipse.paho.client.mqttv3.test/src/test/java/org/eclipse/paho/client/mqttv3/test/TestNetworkInterface.java
+++ b/org.eclipse.paho.client.mqttv3.test/src/test/java/org/eclipse/paho/client/mqttv3/test/TestNetworkInterface.java
@@ -1,0 +1,29 @@
+package org.eclipse.paho.client.mqttv3.test;
+
+import org.eclipse.paho.client.mqttv3.MqttConnectOptions;
+
+import static org.junit.Assert.*;
+import org.junit.Test;
+
+public class TestNetworkInterface { 
+	private String WLAN_NETWORK_INTERFACE = "wlan0";
+
+	@Test
+	public void testValidateSetNetworkInterface() {
+		MqttConnectOptions connectOptions = new MqttConnectOptions();
+
+		connectOptions.setNetworkInterface(WLAN_NETWORK_INTERFACE);
+	}
+
+	@Test
+	public void testInvalidSetNetworkInterface() {
+		MqttConnectOptions connectOptions = new MqttConnectOptions();
+
+		try {
+			connectOptions.setNetworkInterface("");
+			fail("MQTT Network Interface is not valid");
+		} catch (IllegalArgumentException e) {
+			assertEquals("Set network interface options must be valid strings. Null and empty strings are not acceptable.", e.getMessage());
+		}
+	}
+}

--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/MqttConnectOptions.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/MqttConnectOptions.java
@@ -74,6 +74,7 @@ public class MqttConnectOptions {
 	private boolean automaticReconnect = false;
 	private int maxReconnectDelay = 128000;
 	private Properties customWebSocketHeaders = null;
+	private String networkInterface;
 
 	// Client Operation Parameters
 	private int executorServiceTimeout = 1; // How long to wait in seconds when terminating the executor service.
@@ -696,6 +697,23 @@ public class MqttConnectOptions {
 	public Properties getCustomWebSocketHeaders() {
 		return customWebSocketHeaders;
 	}
+
+	/**
+	 * Returns the network interface to bind for the connection.
+	 *
+	 * @return the network interface to bind for the connection.
+	 */
+	public String getNetworkInterface() {
+		return networkInterface;
+	}
+
+	/**
+	 * Sets the network interface to bind for the connection.
+	 *
+	 * @param networkInterface
+	 *            The networkInterface as a String
+	 */
+	public void setNetworkInterface(String networkInterface) { this.networkInterface = networkInterface; }
 
 	public String toString() {
 		return Debug.dumpProperties(getDebug(), "Connection options");

--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/MqttConnectOptions.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/MqttConnectOptions.java
@@ -74,7 +74,7 @@ public class MqttConnectOptions {
 	private boolean automaticReconnect = false;
 	private int maxReconnectDelay = 128000;
 	private Properties customWebSocketHeaders = null;
-	private String networkInterface;
+	private String networkInterface = null;
 
 	// Client Operation Parameters
 	private int executorServiceTimeout = 1; // How long to wait in seconds when terminating the executor service.
@@ -713,7 +713,12 @@ public class MqttConnectOptions {
 	 * @param networkInterface
 	 *            The networkInterface as a String
 	 */
-	public void setNetworkInterface(String networkInterface) { this.networkInterface = networkInterface; }
+	public void setNetworkInterface(String networkInterface) {
+	 	if ((networkInterface == null) || networkInterface.isEmpty()) {
+                        throw new IllegalArgumentException();
+                }
+		this.networkInterface = networkInterface;
+	}
 
 	public String toString() {
 		return Debug.dumpProperties(getDebug(), "Connection options");

--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/MqttConnectOptions.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/MqttConnectOptions.java
@@ -715,7 +715,7 @@ public class MqttConnectOptions {
 	 */
 	public void setNetworkInterface(String networkInterface) {
 	 	if ((networkInterface == null) || networkInterface.isEmpty()) {
-                        throw new IllegalArgumentException();
+                        throw new IllegalArgumentException("Set network interface options must be valid strings. Null and empty strings are not acceptable.");
                 }
 		this.networkInterface = networkInterface;
 	}

--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/TCPNetworkModule.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/TCPNetworkModule.java
@@ -78,7 +78,7 @@ public class TCPNetworkModule implements NetworkModule {
 			socket = factory.createSocket();
 
 			/* Bind to the network interface */
-			if (networkInterface != null && !networkInterface.isEmpty()) {
+			if (networkInterface != null) {
 				NetworkInterface nif = NetworkInterface.getByName(networkInterface);
 				Enumeration<InetAddress> nifAddresses = nif.getInetAddresses();
 				socket.bind(new InetSocketAddress(nifAddresses.nextElement(), 0));

--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/TCPNetworkModule.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/TCPNetworkModule.java
@@ -22,6 +22,10 @@ import java.net.ConnectException;
 import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.net.SocketAddress;
+import java.net.NetworkInterface;
+import java.net.InetAddress;
+
+import java.util.Enumeration;
 
 import javax.net.SocketFactory;
 
@@ -41,6 +45,7 @@ public class TCPNetworkModule implements NetworkModule {
 	private String host;
 	private int port;
 	private int conTimeout;
+	private String networkInterface;
 
 	/**
 	 * Constructs a new TCPNetworkModule using the specified host and
@@ -71,6 +76,14 @@ public class TCPNetworkModule implements NetworkModule {
 			log.fine(CLASS_NAME,methodName, "252", new Object[] {host, Integer.valueOf(port), Long.valueOf(conTimeout*1000)});
 			SocketAddress sockaddr = new InetSocketAddress(host, port);
 			socket = factory.createSocket();
+
+			/* Bind to the network interface */
+			if (networkInterface != null && !networkInterface.isEmpty()) {
+				NetworkInterface nif = NetworkInterface.getByName(networkInterface);
+				Enumeration<InetAddress> nifAddresses = nif.getInetAddresses();
+				socket.bind(new InetSocketAddress(nifAddresses.nextElement(), 0));
+			}
+
 			socket.connect(sockaddr, conTimeout*1000);
 			socket.setSoTimeout(1000);
 		}
@@ -105,6 +118,14 @@ public class TCPNetworkModule implements NetworkModule {
 	 */
 	public void setConnectTimeout(int timeout) {
 		this.conTimeout = timeout;
+	}
+
+	/**
+	 * Set the Network Interface for Socket bind
+	 * @param timeout  The connection timeout
+	 */
+	public void setNetworkInterface(String networkInterface) {
+		this.networkInterface = networkInterface;
 	}
 
 	public String getServerURI() {

--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/TCPNetworkModuleFactory.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/TCPNetworkModuleFactory.java
@@ -57,7 +57,8 @@ public class TCPNetworkModuleFactory implements NetworkModuleFactory {
 			throw ExceptionHelper.createMqttException(MqttException.REASON_CODE_SOCKET_FACTORY_MISMATCH);
 		}
 		TCPNetworkModule networkModule = new TCPNetworkModule(factory, host, port, clientId);
-		networkModule.setNetworkInterface(options.getNetworkInterface());
+		if (options.getNetworkInterface() != null)
+			networkModule.setNetworkInterface(options.getNetworkInterface());
 		networkModule.setConnectTimeout(options.getConnectionTimeout());
 		return networkModule;
 	}

--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/TCPNetworkModuleFactory.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/TCPNetworkModuleFactory.java
@@ -57,6 +57,7 @@ public class TCPNetworkModuleFactory implements NetworkModuleFactory {
 			throw ExceptionHelper.createMqttException(MqttException.REASON_CODE_SOCKET_FACTORY_MISMATCH);
 		}
 		TCPNetworkModule networkModule = new TCPNetworkModule(factory, host, port, clientId);
+		networkModule.setNetworkInterface(options.getNetworkInterface());
 		networkModule.setConnectTimeout(options.getConnectionTimeout());
 		return networkModule;
 	}


### PR DESCRIPTION
Issue : Failed MQTT connection to IPv6 link local hostname with scope id containing
illegal characters like '_'.

Error log:
W/System.err: java.net.URISyntaxException: Illegal character in scope id at
index 37: tcp://[fe80::xxxx:xxxx:xxxx:xxxx%aware_data0]:1883

Solution: Add network interface in MqttConnectOptions, so that the
URI excludes the network scope id.
For Eg:  tcp://[fe80::xxxx:xxxx:xxxx:xxxx]:1883

Signed-off-by: Shyamakshi Ghosh <g.shyamakshi@samsung.com>

Please make sure that the following boxes are checked before submitting your Pull Request, thank you!

- [x] This change is against the develop branch, **not** master.
- [x] You have signed the [Eclipse ECA](https://wiki.eclipse.org/ECA)
- [x] All of your commits have been signed-off with the correct email address (the same one that you 
      used to sign the CLA) _Hint: use the -s argument when committing_.
- [ ] If This PR fixes an issue, that you reference the issue below. OR if this is a new issue that 
      you are fixing straight away that you add some Description about the bug and how this will fix it.
- [ ] If this is new functionality, You have added the appropriate Unit tests.
