### PR TITLE
Fixing the error Caused by: java.io.IOException: Already connected.

### DIFF
--- a/org.eclipse.paho.client.mqttv3/src/main/java-templates/org/eclipse/paho/client/mqttv3/internal/ClientComms.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java-templates/org/eclipse/paho/client/mqttv3/internal/ClientComms.java
@@ -383,7 +383,8 @@ public class ClientComms {
 				}
 			}
 		} catch (Exception ioe) {
-			// Ignore as we are shutting down
+			// @TRACE 227=Error while stopping at least one of the network modules (protocol handlers), during connection shutdown - {0} : {1}. Ignoring.
+			log.fine(CLASS_NAME, methodName, "227", new String[] {ioe.getClass().getName(), ioe.getLocalizedMessage()});
 		}
 
 		// Stop any new tokens being saved by app and throwing an exception if they do
@@ -400,7 +401,8 @@ public class ClientComms {
 			if (clientState.getCleanSession())
 				callback.removeMessageListeners();
 		}catch(Exception ex) {
-			// Ignore as we are shutting down
+			// @TRACE 228=Error while cleaning sessions, during connection shutdown - {0} : {1}. Ignoring.
+			log.fine(CLASS_NAME, methodName, "228", new String[] {ex.getClass().getName(), ex.getLocalizedMessage()});
 		}
 
 		if (sender != null) { sender.stop(); }
@@ -415,7 +417,8 @@ public class ClientComms {
 			}
 			
 		}catch(Exception ex) {
-			// Ignore as we are shutting down
+			// @TRACE 229=Error while closing persistance objects, during connection shutdown - {0} : {1}. Ignoring.
+			log.fine(CLASS_NAME, methodName, "229", new String[] {ex.getClass().getName(), ex.getLocalizedMessage()});
 		}
 		// All disconnect logic has been completed allowing the
 		// client to be marked as disconnected.
@@ -447,6 +450,8 @@ public class ClientComms {
 				try {
 					close(true);
 				} catch (Exception e) { // ignore any errors as closing
+					// @TRACE 230=Error while closing pending, during connection shutdown - {0} : {1}. Ignoring.
+					log.fine(CLASS_NAME, methodName, "230", new String[] {e.getClass().getName(), e.getLocalizedMessage()});
 				}
 			}
 		}
@@ -490,6 +495,8 @@ public class ClientComms {
 			}
 		}catch(Exception ex) {
 			// Ignore as we are shutting down
+			// @TRACE 231=Error while cleanup, during connection shutdown - {0} : {1}. Ignoring.
+			log.fine(CLASS_NAME, methodName, "231", new String[] {ex.getClass().getName(), ex.getLocalizedMessage()});
 		}
 		return tokToNotifyLater;
 	}
@@ -536,6 +543,7 @@ public class ClientComms {
 	 * @throws MqttException if an error occurs whilst disconnecting
 	 */
 	public void disconnectForcibly(long quiesceTimeout, long disconnectTimeout, boolean sendDisconnectPacket) throws MqttException {
+		final String methodName = "disconnectForcibly";
 		conState = DISCONNECTING;
 		// Allow current inbound and outbound work to complete
 		if (clientState != null) {
@@ -553,6 +561,8 @@ public class ClientComms {
 		}
 		catch (Exception ex) {
 			// ignore, probably means we failed to send the disconnect packet.
+			// @TRACE 232=Error while forcibly disconnecting. Probable failure to send the disconnect packet. - {0} : {1}.
+			log.fine(CLASS_NAME, methodName, "232", new String[] {ex.getClass().getName(), ex.getLocalizedMessage()});
 		}
 		finally {
 			token.internalTok.markComplete(null, null);
@@ -722,7 +732,7 @@ public class ClientComms {
 				// packet.
 				NetworkModule networkModule = networkModules[networkModuleIndex];
 				networkModule.start();
-				receiver = new CommsReceiver(clientComms, clientState, tokenStore, networkModule.getInputStream());
+				receiver = new CommsReceiver(clientComms, clientState, tokenStore, networkModule);
 				receiver.start("MQTT Rec: "+getClient().getClientId(), executorService);
 				sender = new CommsSender(clientComms, clientState, tokenStore, networkModule.getOutputStream());
 				sender.start("MQTT Snd: "+getClient().getClientId(), executorService);
@@ -783,6 +793,8 @@ public class ClientComms {
 				}
 			}
 			catch (MqttException ex) {
+				//@TRACE 226=connect failed: unexpected exception
+				log.fine(CLASS_NAME, methodName, "226", null, ex);
 			}
 			finally {
 				token.internalTok.markComplete(null, null);

--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/CommsReceiver.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/CommsReceiver.java
@@ -48,12 +48,12 @@ public class CommsReceiver implements Runnable {
 	
 	private ClientState clientState = null;
 	private ClientComms clientComms = null;
-	private MqttInputStream in;
+	private NetworkModule networkModule = null;
 	private CommsTokenStore tokenStore = null;
 	private Thread recThread	= null;
 
-	public CommsReceiver(ClientComms clientComms, ClientState clientState,CommsTokenStore tokenStore, InputStream in) {
-		this.in = new MqttInputStream(clientState, in);
+	public CommsReceiver(ClientComms clientComms, ClientState clientState,CommsTokenStore tokenStore, NetworkModule networkModule) {
+		this.networkModule = networkModule;
 		this.clientComms = clientComms;
 		this.clientState = clientState;
 		this.tokenStore = tokenStore;
@@ -111,6 +111,7 @@ public class CommsReceiver implements Runnable {
 	 * Run loop to receive messages from the server.
 	 */
 	public void run() {
+
 		recThread = Thread.currentThread();
 		recThread.setName(threadName);
 		final String methodName = "run";
@@ -125,8 +126,9 @@ public class CommsReceiver implements Runnable {
 			synchronized (lifecycle) {
 				my_target = target_state;
 			}
-			while (my_target == State.RUNNING && (in != null)) {
+			while (my_target == State.RUNNING) {
 				try {
+					MqttInputStream in = new MqttInputStream(this.clientState, this.networkModule.getInputStream());
 					//@TRACE 852=network read message
 					log.fine(CLASS_NAME,methodName,"852");
 					if (in.available() > 0) {

--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/websocket/WebSocketHandshake.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/websocket/WebSocketHandshake.java
@@ -88,7 +88,7 @@ public class WebSocketHandshake {
 	 */
 	private void sendHandshakeRequest(String key) throws IOException{
 		try {
-			String path = "/mqtt";
+			String path = "/messaging/mqtt";
 			URI srvUri = new URI(uri);
 			if (srvUri.getRawPath() != null && !srvUri.getRawPath().isEmpty()) { 
 				path = srvUri.getRawPath();

--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/websocket/WebSocketReceiver.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/websocket/WebSocketReceiver.java
@@ -85,7 +85,8 @@ public class WebSocketReceiver implements Runnable{
 		        //This must not happen in the synchronized block, otherwise we can deadlock ourselves!
 				receiverThread.join();
 			} catch (InterruptedException ex) {
-				// Interrupted Exception
+				// @TRACE 860=Interrupted while waiting to stop reading from web socket {0}. Continuing without waiting any longer.
+				log.fine(CLASS_NAME, methodName, "860", new String[] {ex.getLocalizedMessage()});
 			}
 		}
 		receiverThread = null;
@@ -116,18 +117,23 @@ public class WebSocketReceiver implements Runnable{
 
 				receiving = false;
 			} catch (SocketTimeoutException ex) {
-				// Ignore SocketTimeoutException 
+				// @TRACE 861=Socket timed out while reading from websocket  - {0} : {1}
+				log.fine(CLASS_NAME, methodName, "861", new String[] {ex.getClass().getName(), ex.getLocalizedMessage()});
 			} catch (IOException ex) {
-				// Exception occurred whilst reading the stream.
+				// @TRACE 862=Error while reading from websocket - {0} : {1}. Stopping the websocket communication.
+				log.severe(CLASS_NAME, methodName, "862", new String[] {ex.getClass().getName(), ex.getLocalizedMessage()});
 				this.stop();
 			}
 		}
 	}
 
 	private void closeOutputStream(){
+		final String methodName = "closeOutputStream";
 		try {
 			pipedOutputStream.close();
 		} catch (IOException e) {
+			// @TRACE 863=Input/Output error while closing network connection stream - {0} : {1}. Ignoring and continuing.
+			log.fine(CLASS_NAME, methodName, "863", new String[] {e.getClass().getName(), e.getLocalizedMessage()});
 		}
 	}
 

--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/websocket/WebSocketSecureNetworkModule.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/websocket/WebSocketSecureNetworkModule.java
@@ -55,7 +55,6 @@ public class WebSocketSecureNetworkModule extends SSLNetworkModule{
 		this.host = host;
 		this.port = port;
 		this.customWebSocketHeaders = customWebSocketHeaders;
-		this.pipedInputStream = new PipedInputStream();
 		log.setResourceName(clientId);
 	}
 
@@ -63,6 +62,7 @@ public class WebSocketSecureNetworkModule extends SSLNetworkModule{
 		super.start();
 		WebSocketHandshake handshake = new WebSocketHandshake(super.getInputStream(), super.getOutputStream(), uri, host, port, customWebSocketHeaders);
 		handshake.execute();
+		this.pipedInputStream = new PipedInputStream();
 		this.webSocketReceiver = new WebSocketReceiver(getSocketInputStream(), pipedInputStream);
 		webSocketReceiver.start("WssSocketReceiver");
 

--- a/org.eclipse.paho.client.mqttv3/src/main/resources/org/eclipse/paho/client/mqttv3/internal/nls/logcat.properties
+++ b/org.eclipse.paho.client.mqttv3/src/main/resources/org/eclipse/paho/client/mqttv3/internal/nls/logcat.properties
@@ -36,6 +36,11 @@
 222=>
 223=failed: in closed state
 224=failed: not disconnected
+227=Error while stopping at least one of the network modules (protocol handlers), during connection shutdown - {0} : {1}. Ignoring.
+228=Error while cleaning sessions, during connection shutdown - {0} : {1}. Ignoring.
+229=Error while closing persistance objects, during connection shutdown - {0} : {1}. Ignoring.
+230=Error while closing pending, during connection shutdown - {0} : {1}. Ignoring.
+231=Error while cleanup, during connection shutdown - {0} : {1}. Ignoring.
 250=Failed to create TCP socket
 252=connect to host {0} port {1} timeout {2}
 260=setEnabledCiphers ciphers={0}
@@ -169,3 +174,7 @@
 855=starting
 856=Stopping, MQttException
 857=Unknown PubAck, PubComp or PubRec received. Ignoring.
+860=Interrupted while waiting to stop reading from web socket {0}. Continuing without waiting any longer.
+861=Socket timed out while reading from websocket  - {0} : {1}
+862=Error while reading from websocket - {0} : {1}. Stopping the websocket communication.
+863=Input/Output error while closing network connection stream - {0} : {1}. Ignoring and continuing.


### PR DESCRIPTION
    Full stack trace of the error is:
```
  Caused by: java.io.IOException: Already connected
      at java.io.PipedOutputStream.connect(PipedOutputStream.java:xxx
      at java.io.PipedInputStream.connect(PipedInputStream.java:xxx)
      at org.eclipse.paho.client.mqttv3.internal.websocket.WebSocketReceiver.<init>(WebSocketReceiver.java:xx)
      at org.eclipse.paho.client.mqttv3.internal.websocket.WebSocketSecureNetworkModule.start(WebSocketSecureNetworkModule.java:xx)
      at org.eclipse.paho.client.mqttv3.internal.ClientComms$ConnectBG.run(ClientComms.java:xx)
```
As vosible in the stack trace, that is not a connectivity issue between the MQTT client and the MQTT server.
Instead that is Pipis issue. Issue happens when trying to connect input stream and output stream of a process pipe.

Issue is caused by the fact that a PipedInputStream can be assigned to a PipedOutputStream just once.
What happens is that we are doing the association and then we consume the pipe, but if there is a failure,
we retry the connection and thus try the association once again.

Instead, we should try with a new pair of PipedInputStream and PipedOutputStream.

Please make sure that the following boxes are checked before submitting your Pull Request, thank you!
