### PR TITLE
Fix an issue with assigning PipedInputStream and PipedOutputStream fo…

### DIFF
--- a/org.eclipse.paho.client.mqttv3/src/main/java-templates/org/eclipse/paho/client/mqttv3/internal/ClientComms.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java-templates/org/eclipse/paho/client/mqttv3/internal/ClientComms.java
@@ -383,7 +383,8 @@ public class ClientComms {
 				}
 			}
 		} catch (Exception ioe) {
-			// Ignore as we are shutting down
+			// @TRACE 227=Error while stopping at least one of the network modules (protocol handlers), during connection shutdown - {0} : {1}. Ignoring.
+			log.fine(CLASS_NAME, methodName, "227", new String[] {ioe.getClass().getName(), ioe.getLocalizedMessage()});
 		}
 
 		// Stop any new tokens being saved by app and throwing an exception if they do
@@ -400,7 +401,8 @@ public class ClientComms {
 			if (clientState.getCleanSession())
 				callback.removeMessageListeners();
 		}catch(Exception ex) {
-			// Ignore as we are shutting down
+			// @TRACE 228=Error while cleaning sessions, during connection shutdown - {0} : {1}. Ignoring.
+			log.fine(CLASS_NAME, methodName, "228", new String[] {ex.getClass().getName(), ex.getLocalizedMessage()});
 		}
 
 		if (sender != null) { sender.stop(); }
@@ -415,7 +417,8 @@ public class ClientComms {
 			}
 			
 		}catch(Exception ex) {
-			// Ignore as we are shutting down
+			// @TRACE 229=Error while closing persistance objects, during connection shutdown - {0} : {1}. Ignoring.
+			log.fine(CLASS_NAME, methodName, "229", new String[] {ex.getClass().getName(), ex.getLocalizedMessage()});
 		}
 		// All disconnect logic has been completed allowing the
 		// client to be marked as disconnected.
@@ -447,6 +450,8 @@ public class ClientComms {
 				try {
 					close(true);
 				} catch (Exception e) { // ignore any errors as closing
+					// @TRACE 230=Error while closing pending, during connection shutdown - {0} : {1}. Ignoring.
+					log.fine(CLASS_NAME, methodName, "230", new String[] {e.getClass().getName(), e.getLocalizedMessage()});
 				}
 			}
 		}
@@ -490,6 +495,8 @@ public class ClientComms {
 			}
 		}catch(Exception ex) {
 			// Ignore as we are shutting down
+			// @TRACE 231=Error while cleanup, during connection shutdown - {0} : {1}. Ignoring.
+			log.fine(CLASS_NAME, methodName, "231", new String[] {ex.getClass().getName(), ex.getLocalizedMessage()});
 		}
 		return tokToNotifyLater;
 	}
@@ -536,6 +543,7 @@ public class ClientComms {
 	 * @throws MqttException if an error occurs whilst disconnecting
 	 */
 	public void disconnectForcibly(long quiesceTimeout, long disconnectTimeout, boolean sendDisconnectPacket) throws MqttException {
+		final String methodName = "disconnectForcibly";
 		conState = DISCONNECTING;
 		// Allow current inbound and outbound work to complete
 		if (clientState != null) {
@@ -553,6 +561,8 @@ public class ClientComms {
 		}
 		catch (Exception ex) {
 			// ignore, probably means we failed to send the disconnect packet.
+			// @TRACE 232=Error while forcibly disconnecting. Probable failure to send the disconnect packet. - {0} : {1}.
+			log.fine(CLASS_NAME, methodName, "232", new String[] {ex.getClass().getName(), ex.getLocalizedMessage()});
 		}
 		finally {
 			token.internalTok.markComplete(null, null);
@@ -722,7 +732,7 @@ public class ClientComms {
 				// packet.
 				NetworkModule networkModule = networkModules[networkModuleIndex];
 				networkModule.start();
-				receiver = new CommsReceiver(clientComms, clientState, tokenStore, networkModule.getInputStream());
+				receiver = new CommsReceiver(clientComms, clientState, tokenStore, networkModule);
 				receiver.start("MQTT Rec: "+getClient().getClientId(), executorService);
 				sender = new CommsSender(clientComms, clientState, tokenStore, networkModule.getOutputStream());
 				sender.start("MQTT Snd: "+getClient().getClientId(), executorService);
@@ -783,6 +793,8 @@ public class ClientComms {
 				}
 			}
 			catch (MqttException ex) {
+				//@TRACE 226=connect failed: unexpected exception
+				log.fine(CLASS_NAME, methodName, "226", null, ex);
 			}
 			finally {
 				token.internalTok.markComplete(null, null);

--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/CommsReceiver.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/CommsReceiver.java
@@ -48,12 +48,12 @@ public class CommsReceiver implements Runnable {
 	
 	private ClientState clientState = null;
 	private ClientComms clientComms = null;
-	private MqttInputStream in;
+	private NetworkModule networkModule = null;
 	private CommsTokenStore tokenStore = null;
 	private Thread recThread	= null;
 
-	public CommsReceiver(ClientComms clientComms, ClientState clientState,CommsTokenStore tokenStore, InputStream in) {
-		this.in = new MqttInputStream(clientState, in);
+	public CommsReceiver(ClientComms clientComms, ClientState clientState,CommsTokenStore tokenStore, NetworkModule networkModule) {
+		this.networkModule = networkModule;
 		this.clientComms = clientComms;
 		this.clientState = clientState;
 		this.tokenStore = tokenStore;
@@ -111,6 +111,7 @@ public class CommsReceiver implements Runnable {
 	 * Run loop to receive messages from the server.
 	 */
 	public void run() {
+
 		recThread = Thread.currentThread();
 		recThread.setName(threadName);
 		final String methodName = "run";
@@ -125,8 +126,9 @@ public class CommsReceiver implements Runnable {
 			synchronized (lifecycle) {
 				my_target = target_state;
 			}
-			while (my_target == State.RUNNING && (in != null)) {
+			while (my_target == State.RUNNING) {
 				try {
+					MqttInputStream in = new MqttInputStream(this.clientState, this.networkModule.getInputStream());
 					//@TRACE 852=network read message
 					log.fine(CLASS_NAME,methodName,"852");
 					if (in.available() > 0) {

--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/websocket/WebSocketNetworkModule.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/websocket/WebSocketNetworkModule.java
@@ -39,7 +39,6 @@ public class WebSocketNetworkModule extends TCPNetworkModule {
 	private String host;
 	private int port;
 	private Properties customWebsocketHeaders;
-	private PipedInputStream pipedInputStream;
 	private WebSocketReceiver webSocketReceiver;
 	ByteBuffer recievedPayload;
 	
@@ -56,7 +55,6 @@ public class WebSocketNetworkModule extends TCPNetworkModule {
 		this.host = host;
 		this.port = port;
 		this.customWebsocketHeaders = customWebsocketHeaders;
-		this.pipedInputStream = new PipedInputStream();
 		
 		log.setResourceName(resourceContext);
 	}
@@ -65,7 +63,7 @@ public class WebSocketNetworkModule extends TCPNetworkModule {
 		super.start();
 		WebSocketHandshake handshake = new WebSocketHandshake(getSocketInputStream(), getSocketOutputStream(), uri, host, port, customWebsocketHeaders);
 		handshake.execute();
-		this.webSocketReceiver = new WebSocketReceiver(getSocketInputStream(), pipedInputStream);
+		this.webSocketReceiver = new WebSocketReceiver(getSocketInputStream());
 		webSocketReceiver.start("webSocketReceiver");
 	}
 	
@@ -78,7 +76,7 @@ public class WebSocketNetworkModule extends TCPNetworkModule {
 	}
 	
 	public InputStream getInputStream() throws IOException {
-		return pipedInputStream;
+		return this.webSocketReceiver.getInputStream();
 	}
 	
 	public OutputStream getOutputStream() throws IOException {

--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/websocket/WebSocketSecureNetworkModule.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/websocket/WebSocketSecureNetworkModule.java
@@ -33,8 +33,7 @@ public class WebSocketSecureNetworkModule extends SSLNetworkModule{
 	
 	private static final String CLASS_NAME = WebSocketSecureNetworkModule.class.getName();
 	private Logger log = LoggerFactory.getLogger(LoggerFactory.MQTT_CLIENT_MSG_CAT, CLASS_NAME);
-	
-	private PipedInputStream pipedInputStream;
+
 	private WebSocketReceiver webSocketReceiver;
 	private String uri;
 	private String host;
@@ -55,7 +54,6 @@ public class WebSocketSecureNetworkModule extends SSLNetworkModule{
 		this.host = host;
 		this.port = port;
 		this.customWebSocketHeaders = customWebSocketHeaders;
-		this.pipedInputStream = new PipedInputStream();
 		log.setResourceName(clientId);
 	}
 
@@ -63,7 +61,7 @@ public class WebSocketSecureNetworkModule extends SSLNetworkModule{
 		super.start();
 		WebSocketHandshake handshake = new WebSocketHandshake(super.getInputStream(), super.getOutputStream(), uri, host, port, customWebSocketHeaders);
 		handshake.execute();
-		this.webSocketReceiver = new WebSocketReceiver(getSocketInputStream(), pipedInputStream);
+		this.webSocketReceiver = new WebSocketReceiver(getSocketInputStream());
 		webSocketReceiver.start("WssSocketReceiver");
 
 	}
@@ -77,7 +75,7 @@ public class WebSocketSecureNetworkModule extends SSLNetworkModule{
 	}
 	
 	public InputStream getInputStream() throws IOException {
-		return pipedInputStream;
+		return this.webSocketReceiver.getInputStream();
 	}
 	
 	public OutputStream getOutputStream() throws IOException {

--- a/org.eclipse.paho.client.mqttv3/src/main/resources/org/eclipse/paho/client/mqttv3/internal/nls/logcat.properties
+++ b/org.eclipse.paho.client.mqttv3/src/main/resources/org/eclipse/paho/client/mqttv3/internal/nls/logcat.properties
@@ -36,6 +36,11 @@
 222=>
 223=failed: in closed state
 224=failed: not disconnected
+227=Error while stopping at least one of the network modules (protocol handlers), during connection shutdown - {0} : {1}. Ignoring.
+228=Error while cleaning sessions, during connection shutdown - {0} : {1}. Ignoring.
+229=Error while closing persistance objects, during connection shutdown - {0} : {1}. Ignoring.
+230=Error while closing pending, during connection shutdown - {0} : {1}. Ignoring.
+231=Error while cleanup, during connection shutdown - {0} : {1}. Ignoring.
 250=Failed to create TCP socket
 252=connect to host {0} port {1} timeout {2}
 260=setEnabledCiphers ciphers={0}
@@ -169,3 +174,7 @@
 855=starting
 856=Stopping, MQttException
 857=Unknown PubAck, PubComp or PubRec received. Ignoring.
+860=Interrupted while waiting to stop reading from web socket {0}. Continuing without waiting any longer.
+861=Socket timed out while reading from websocket  - {0} : {1}
+862=Error while reading from websocket - {0} : {1}. Stopping the websocket communication.
+863=Input/Output error while closing network connection stream - {0} : {1}. Ignoring and continuing.


### PR DESCRIPTION
…r the second time.

Previously this was throwing:
```
    Caused by: MqttException (0) - java.io.IOException: Already connected
            at org.eclipse.paho.client.mqttv3.internal.ExceptionHelper.createMqttException(ExceptionHelper.java:38)
            at org.eclipse.paho.client.mqttv3.internal.ClientComms$ConnectBG.run(ClientComms.java:738)
            at java.lang.Thread.run(Thread.java:748)
        Caused by: java.io.IOException: Already connected
            at java.io.PipedOutputStream.connect(PipedOutputStream.java:100)
            at java.io.PipedInputStream.connect(PipedInputStream.java:188)
            at org.eclipse.paho.client.mqttv3.internal.websocket.WebSocketReceiver.<init>(WebSocketReceiver.java:43)
            at org.eclipse.paho.client.mqttv3.internal.websocket.WebSocketSecureNetworkModule.start(WebSocketSecureNetworkModule.java:68)
            at org.eclipse.paho.client.mqttv3.internal.ClientComms$ConnectBG.run(ClientComms.java:724)
```
This is potentially also related with https://github.com/aws/aws-iot-device-sdk-java/issues/67

Failure message (Already connected) is not directly related to the paho client connection status with the paho server.
Instead that corresponds to the connection status between Java PipedInputStream and Java PipedOutputStream that form a programming pipe
when readin information from the MQTT server when there is a connection already open.

Reason is that initially, we create a PipedInputStream in the beginning and on a connection request (start) we associate an PipedOutputStream to it.
That is find the first time. However if we need to retry that operation - let's say because of connection lost and automatic reconnect, or because of
some other reason, then we reuse the existing PipedInputStream and try to connect/associate it with a brand new PipedOutputStream.
PipedInputStream is however already connected as initially done - thus it throws an 'Already connected' IOException.

PipedInputStream and PipedOutputStream should always be coupoled togethere - they should be created and destroyed together.
Thus we can avoid the above inconsistency.
This is what this Pull Request fixes.

Signed-off-by: Yordan Nedelchev <yordan.nedelchev@hotmail.com>

Please make sure that the following boxes are checked before submitting your Pull Request, thank you!

- [V] This change is against the develop branch, **not** master.
- [V] You have signed the [Eclipse ECA](https://wiki.eclipse.org/ECA)
- [V] All of your commits have been signed-off with the correct email address (the same one that you 
      used to sign the CLA) _Hint: use the -s argument when committing_.
- [V] If This PR fixes an issue, that you reference the issue below. OR if this is a new issue that 
      you are fixing straight away that you add some Description about the bug and how this will fix it.
- [V] If this is new functionality, You have added the appropriate Unit tests.
