### PR TITLE
Socket created by (SSL)SocketFactory may have already been connected

### DIFF
--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/TCPNetworkModule.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/TCPNetworkModule.java
@@ -71,7 +71,7 @@ public class TCPNetworkModule implements NetworkModule {
 			log.fine(CLASS_NAME,methodName, "252", new Object[] {host, Integer.valueOf(port), Long.valueOf(conTimeout*1000)});
 			SocketAddress sockaddr = new InetSocketAddress(host, port);
 			socket = factory.createSocket();
-			socket.connect(sockaddr, conTimeout*1000);
+			if (!socket.isConnected()) {socket.connect(sockaddr, conTimeout*1000);}
 			socket.setSoTimeout(1000);
 		}
 		catch (ConnectException ex) {

--- a/org.eclipse.paho.mqttv5.client/src/main/java/org/eclipse/paho/mqttv5/client/internal/TCPNetworkModule.java
+++ b/org.eclipse.paho.mqttv5.client/src/main/java/org/eclipse/paho/mqttv5/client/internal/TCPNetworkModule.java
@@ -72,7 +72,7 @@ public class TCPNetworkModule implements NetworkModule {
 			log.fine(CLASS_NAME,methodName, "252", new Object[] {host, Integer.valueOf(port), Long.valueOf(conTimeout*1000)});
 			SocketAddress sockaddr = new InetSocketAddress(host, port);
 			socket = factory.createSocket();
-			socket.connect(sockaddr, conTimeout*1000);
+			if (!socket.isConnected()) {socket.connect(sockaddr, conTimeout*1000);}
 			socket.setSoTimeout(1000);
 		}
 		catch (ConnectException ex) {


### PR DESCRIPTION
Signed-off-by: Jean-François Guena <jeanfrancois.guena@orange.com>

Please make sure that the following boxes are checked before submitting your Pull Request, thank you!

- [ X] This change is against the develop branch, **not** master.
- [ X] You have signed the [Eclipse ECA](https://wiki.eclipse.org/ECA)
- [X ] All of your commits have been signed-off with the correct email address (the same one that you 
      used to sign the CLA) _Hint: use the -s argument when committing_.
- [X ] If This PR fixes an issue, that you reference the issue below. OR if this is a new issue that 
      you are fixing straight away that you add some Description about the bug and how this will fix it.

Hi,

This PR is about issue #854: **Unable to connect via SSL/WSS when no proxy is involved**.

Actually, behind a Proxy or not, there is no way to connect via SSL/WSS if we use an `SSLContext` and its `getSocketFactory` method, because the returned `SSLSocketFactory` does not have any `create` method allowing to obtain an **unconnected** `Socket`.

Therefore, following code from `start()` method in the `TCPNetworkModule` leads to an "Already connected" `SocketException`:

```
SocketAddress sockaddr = new InetSocketAddress(host, port);
socket = factory.createSocket();
socket.connect(sockaddr, conTimeout*1000);
```

This PR only adds a simple condition:

```
SocketAddress sockaddr = new InetSocketAddress(host, port);
socket = factory.createSocket();
if (!socket.isConnected()) { socket.connect(sockaddr, conTimeout*1000); }
```
I tested it locally and it worked like a charm...

Regards
