### PR TITLE
Issue #877 - Clear DisconnectedMessageBuffer when a clean session is made

### DIFF
--- a/org.eclipse.paho.client.mqttv3/src/main/java-templates/org/eclipse/paho/client/mqttv3/internal/ClientComms.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java-templates/org/eclipse/paho/client/mqttv3/internal/ClientComms.java
@@ -673,6 +673,9 @@ public class ClientComms {
 		return props;
 	}
 
+	public void clear() {
+		disconnectedMessageBuffer.clear();
+	}
 
 
 	// Kick off the connect processing in the background so that it does not block. For instance

--- a/org.eclipse.paho.client.mqttv3/src/main/java-templates/org/eclipse/paho/client/mqttv3/internal/ClientComms.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java-templates/org/eclipse/paho/client/mqttv3/internal/ClientComms.java
@@ -674,7 +674,9 @@ public class ClientComms {
 	}
 
 	public void clear() {
-		disconnectedMessageBuffer.clear();
+		if (disconnectedMessageBuffer != null) {
+			disconnectedMessageBuffer.clear();
+		}
 	}
 
 

--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/ClientState.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/ClientState.java
@@ -226,6 +226,7 @@ public class ClientState {
 		log.fine(CLASS_NAME, methodName,">");
 
 		persistence.clear();
+		clientComms.clear();
 		inUseMsgIds.clear();
 		pendingMessages.clear();
 		pendingFlows.clear();

--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/ConnectActionListener.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/ConnectActionListener.java
@@ -175,6 +175,7 @@ public class ConnectActionListener implements IMqttActionListener {
 
     if (options.isCleanSession()) {
       persistence.clear();
+      comms.clear();
     }
     
     if (options.getMqttVersion() == MqttConnectOptions.MQTT_VERSION_DEFAULT) {

--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/DisconnectedMessageBuffer.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/DisconnectedMessageBuffer.java
@@ -112,6 +112,12 @@ public class DisconnectedMessageBuffer implements Runnable {
 		}
 	}
 
+	public void clear() {
+		synchronized (bufLock) {
+			buffer.clear();
+		}
+	}
+
 	private int mycount = 0;
 	/**
 	 * Flushes the buffer of messages into an open connection
@@ -151,7 +157,7 @@ public class DisconnectedMessageBuffer implements Runnable {
 		return bufferOpts.isPersistBuffer();
 	}
 
-        public void setMessageDiscardedCallBack(IDiscardedBufferMessageCallback callback) {
+	public void setMessageDiscardedCallBack(IDiscardedBufferMessageCallback callback) {
 		this.messageDiscardedCallBack = callback;
 	}
 

--- a/org.eclipse.paho.mqttv5.client/src/main/java/org/eclipse/paho/mqttv5/client/internal/ClientComms.java
+++ b/org.eclipse.paho.mqttv5.client/src/main/java/org/eclipse/paho/mqttv5/client/internal/ClientComms.java
@@ -733,7 +733,13 @@ public class ClientComms {
 		return props;
 	}
 
-	// Kick off the connect processing in the background so that it does not block.
+	public void clear() {
+		if (disconnectedMessageBuffer != null) {
+			disconnectedMessageBuffer.clear();
+		}
+	}
+
+    // Kick off the connect processing in the background so that it does not block.
 	// For instance
 	// the socket could take time to create.
 	private class ConnectBG implements Runnable {

--- a/org.eclipse.paho.mqttv5.client/src/main/java/org/eclipse/paho/mqttv5/client/internal/ClientState.java
+++ b/org.eclipse.paho.mqttv5.client/src/main/java/org/eclipse/paho/mqttv5/client/internal/ClientState.java
@@ -215,6 +215,7 @@ public class ClientState implements MqttState {
 		log.fine(CLASS_NAME, methodName, ">");
 
 		persistence.clear();
+		clientComms.clear();
 		inUseMsgIds.clear();
 		pendingMessages.clear();
 		pendingFlows.clear();

--- a/org.eclipse.paho.mqttv5.client/src/main/java/org/eclipse/paho/mqttv5/client/internal/ConnectActionListener.java
+++ b/org.eclipse.paho.mqttv5.client/src/main/java/org/eclipse/paho/mqttv5/client/internal/ConnectActionListener.java
@@ -239,6 +239,7 @@ public class ConnectActionListener implements MqttActionListener {
 
 			if (options.isCleanStart()) {
 				persistence.clear();
+				comms.clear();
 			}
 		}
 

--- a/org.eclipse.paho.mqttv5.client/src/main/java/org/eclipse/paho/mqttv5/client/internal/DisconnectedMessageBuffer.java
+++ b/org.eclipse.paho.mqttv5.client/src/main/java/org/eclipse/paho/mqttv5/client/internal/DisconnectedMessageBuffer.java
@@ -95,6 +95,12 @@ public class DisconnectedMessageBuffer implements Runnable {
 			return buffer.size();
 		}
 	}
+
+	public void clear() {
+		synchronized (bufLock) {
+			buffer.clear();
+		}
+	}
 	
 	/**
 	 * Flushes the buffer of messages into an open connection


### PR DESCRIPTION
This change will clear the disconnected buffer when a clean session is made.

Please make sure that the following boxes are checked before submitting your Pull Request, thank you!

- [x] This change is against the develop branch, **not** master.
- [x] You have signed the [Eclipse ECA](https://wiki.eclipse.org/ECA)
- [x] All of your commits have been signed-off with the correct email address (the same one that you 
      used to sign the CLA) _Hint: use the -s argument when committing_.
- [x] If This PR fixes an issue, that you reference the issue below. OR if this is a new issue that 
      you are fixing straight away that you add some Description about the bug and how this will fix it.
- [x] If this is new functionality, You have added the appropriate Unit tests.
