### PR TITLE
Fix recursive call in mqtt v5 MqttClient  subscription and IOOBE in and MqttAsyncClient

### DIFF
--- a/org.eclipse.paho.mqttv5.client/src/main/java/org/eclipse/paho/mqttv5/client/MqttAsyncClient.java
+++ b/org.eclipse.paho.mqttv5.client/src/main/java/org/eclipse/paho/mqttv5/client/MqttAsyncClient.java
@@ -1273,8 +1273,12 @@ public class MqttAsyncClient implements MqttClientInterface, IMqttAsyncClient {
 	public IMqttToken subscribe(MqttSubscription[] subscriptions, Object userContext, MqttActionListener callback,
 			IMqttMessageListener messageListener, MqttProperties subscriptionProperties) throws MqttException {
 
-		int subId = subscriptionProperties.getSubscriptionIdentifiers().get(0);
-
+		int subId = 0;
+		try {
+			subId = subscriptionProperties.getSubscriptionIdentifiers().get(0);
+		} catch (IndexOutOfBoundsException e) {
+			log.fine(CLASS_NAME, serverURI, CLASS_NAME);
+		}
 		// Automatic Subscription Identifier Assignment is enabled
 		if (connOpts.useSubscriptionIdentifiers() && this.mqttConnection.isSubscriptionIdentifiersAvailable()) {
 

--- a/org.eclipse.paho.mqttv5.client/src/main/java/org/eclipse/paho/mqttv5/client/MqttClient.java
+++ b/org.eclipse.paho.mqttv5.client/src/main/java/org/eclipse/paho/mqttv5/client/MqttClient.java
@@ -516,8 +516,13 @@ public class MqttClient implements IMqttClient {
 	 * @see org.eclipse.paho.mqttv5.client.IMqttClient#subscribe(java.lang.String,
 	 * int)
 	 */
-	public IMqttToken subscribe(String topicFilter, int qos, IMqttMessageListener messageListener) throws MqttException {
-		return this.subscribe(new String[] { topicFilter }, new int[] { qos }, new IMqttMessageListener[] { messageListener });
+	public IMqttToken subscribe(String topicFilter, int qos, IMqttMessageListener messageListener)
+			throws MqttException {
+		MqttSubscription subscription = new MqttSubscription(topicFilter);
+		subscription.setQos(qos);
+		IMqttToken token = aClient.subscribe(subscription, messageListener);
+		token.waitForCompletion();
+		return token;
 	}
 
 	public IMqttToken subscribe(String[] topicFilters, int[] qos, IMqttMessageListener[] messageListeners)


### PR DESCRIPTION
Please make sure that the following boxes are checked before submitting your Pull Request, thank you!

- [yes ] This change is against the develop branch, **not** master.
- [ yes] You have signed the [Eclipse ECA](https://wiki.eclipse.org/ECA)
- [yes ] All of your commits have been signed-off with the correct email address (the same one that you 
      used to sign the CLA) _Hint: use the -s argument when committing_.
- [ Yes] If This PR fixes an issue, that you reference the issue below. OR if this is a new issue that 
      you are fixing straight away that you add some Description about the bug and how this will fix it.
- [N/A ] If this is new functionality, You have added the appropriate Unit tests.

Issue 1: public **`IMqttToken subscribe(String topicFilter, int qos, IMqttMessageListener messageListener) method in org.eclipse.paho.mqttv5.client.MqttClient cause StackOverFlowError`** 
Issue 2: After fixing issue 1 , the method "**`public IMqttToken subscribe(MqttSubscription[] subscriptions, Object userContext, MqttActionListener callback, IMqttMessageListener messageListener, MqttProperties subscriptionProperties) throws MqttException"`**  was causing and IOOBE  due to empty subscriptionProperties list.
Please review.
