### PR TITLE
Fix StackOverflow in MQTTv5 MqttClient and resulting IOOBE in MqttAsyncClient

### DIFF
--- a/org.eclipse.paho.mqttv5.client/src/main/java/org/eclipse/paho/mqttv5/client/MqttAsyncClient.java
+++ b/org.eclipse.paho.mqttv5.client/src/main/java/org/eclipse/paho/mqttv5/client/MqttAsyncClient.java
@@ -1273,8 +1273,12 @@ public class MqttAsyncClient implements MqttClientInterface, IMqttAsyncClient {
 	public IMqttToken subscribe(MqttSubscription[] subscriptions, Object userContext, MqttActionListener callback,
 			IMqttMessageListener messageListener, MqttProperties subscriptionProperties) throws MqttException {
 
-		int subId = subscriptionProperties.getSubscriptionIdentifiers().get(0);
-
+		int subId = 0;
+		try {
+			subId = subscriptionProperties.getSubscriptionIdentifiers().get(0);
+		} catch (IndexOutOfBoundsException e) {
+			log.fine(CLASS_NAME, "subscribe", "No sub subscription property(s)");
+		}
 		// Automatic Subscription Identifier Assignment is enabled
 		if (connOpts.useSubscriptionIdentifiers() && this.mqttConnection.isSubscriptionIdentifiersAvailable()) {
 

--- a/org.eclipse.paho.mqttv5.client/src/main/java/org/eclipse/paho/mqttv5/client/MqttClient.java
+++ b/org.eclipse.paho.mqttv5.client/src/main/java/org/eclipse/paho/mqttv5/client/MqttClient.java
@@ -516,8 +516,13 @@ public class MqttClient implements IMqttClient {
 	 * @see org.eclipse.paho.mqttv5.client.IMqttClient#subscribe(java.lang.String,
 	 * int)
 	 */
-	public IMqttToken subscribe(String topicFilter, int qos, IMqttMessageListener messageListener) throws MqttException {
-		return this.subscribe(new String[] { topicFilter }, new int[] { qos }, new IMqttMessageListener[] { messageListener });
+	public IMqttToken subscribe(String topicFilter, int qos, IMqttMessageListener messageListener)
+			throws MqttException {
+		MqttSubscription subscription = new MqttSubscription(topicFilter);
+		subscription.setQos(qos);
+		IMqttToken token = aClient.subscribe(subscription, messageListener);
+		token.waitForCompletion();
+		return token;
 	}
 
 	public IMqttToken subscribe(String[] topicFilters, int[] qos, IMqttMessageListener[] messageListeners)


### PR DESCRIPTION
[✓] This change is against the develop branch, not master.
[ ✓] You have signed the Eclipse ECA
[ ✓] All of your commits have been signed-off with the correct email address (the same one that you
used to sign the CLA) Hint: use the -s argument when committing.
[✓ ] If This PR fixes an issue, that you reference the issue below. OR if this is a new issue that
you are fixing straight away that you add some Description about the bug and how this will fix it.
 If this is new functionality, You have added the appropriate Unit tests.
Fixes:
StackOverflow in MQTTv5 when subscribing with a topicfilter, qos and a IMqttMessageListener #863
The subscribe method is calling itself.

