### PR TITLE
Add enabledCipherSuites to MqttConnectOptions and Support to set provider for KeyStore.getInstance.

### DIFF
--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/MqttConnectOptions.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/MqttConnectOptions.java
@@ -74,6 +74,7 @@ public class MqttConnectOptions {
 	private boolean automaticReconnect = false;
 	private int maxReconnectDelay = 128000;
 	private Properties customWebSocketHeaders = null;
+	private String[] enabledCipherSuites = null;
 
 	// Client Operation Parameters
 	private int executorServiceTimeout = 1; // How long to wait in seconds when terminating the executor service.
@@ -700,5 +701,23 @@ public class MqttConnectOptions {
 	public String toString() {
 		return Debug.dumpProperties(getDebug(), "Connection options");
 	}
-	
+
+	/**
+	 * Returns the enabled cipher suites.
+	 *
+	 * @return a string array of enabled Cipher suites
+	 */
+	public String[] getEnabledCipherSuites() {
+		return enabledCipherSuites;
+	}
+
+	/**
+	 * Sets the enabled cipher suites on the underlying network socket.
+	 *
+	 * @param enabledCipherSuites
+	 *            a String array of cipher suites to enable
+	 */
+	public void setEnabledCipherSuites(String[] enabledCipherSuites) {
+		this.enabledCipherSuites = enabledCipherSuites;
+	}
 }

--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/SSLNetworkModuleFactory.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/SSLNetworkModuleFactory.java
@@ -75,11 +75,17 @@ public class SSLNetworkModuleFactory implements NetworkModuleFactory {
 		netModule.setSSLhandshakeTimeout(options.getConnectionTimeout());
 		netModule.setSSLHostnameVerifier(options.getSSLHostnameVerifier());
 		netModule.setHttpsHostnameVerificationEnabled(options.isHttpsHostnameVerificationEnabled());
+
 		// Ciphers suites need to be set, if they are available
 		if (factoryFactory != null) {
 			String[] enabledCiphers = factoryFactory.getEnabledCipherSuites(null);
 			if (enabledCiphers != null) {
 				netModule.setEnabledCiphers(enabledCiphers);
+			}
+		} else {
+			String[] cipherSuites = options.getEnabledCipherSuites();
+			if (cipherSuites != null) {
+				netModule.setEnabledCiphers(cipherSuites);
 			}
 		}
 		return netModule;

--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/security/SSLSocketFactoryFactory.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/security/SSLSocketFactoryFactory.java
@@ -1203,11 +1203,13 @@ public class SSLSocketFactoryFactory {
 				
 				if(keyStoreName!=null && keyStoreType!=null  && keyMgrAlgo!=null) {
 					try {
-						keyStore=KeyStore.getInstance(keyStoreType);
-						keyStore.load(new FileInputStream(keyStoreName), keyStorePwd);
-						if(keyMgrProvider!=null) {
+						if (keyMgrProvider != null) {
+							keyStore = KeyStore.getInstance(keyStoreType, keyMgrProvider);
+							keyStore.load(new FileInputStream(keyStoreName), keyStorePwd);
 							keyMgrFact = KeyManagerFactory.getInstance(keyMgrAlgo, keyMgrProvider);
 						} else {
+							keyStore = KeyStore.getInstance(keyStoreType);
+							keyStore.load(new FileInputStream(keyStoreName), keyStorePwd);
 							keyMgrFact = KeyManagerFactory.getInstance(keyMgrAlgo);
 						}
 						if (logger != null) {
@@ -1269,11 +1271,13 @@ public class SSLSocketFactoryFactory {
 					
 			if(trustStoreName!=null && trustStoreType!=null && trustMgrAlgo!=null) {
 				try {
-					trustStore=KeyStore.getInstance(trustStoreType);
-					trustStore.load(new FileInputStream(trustStoreName), trustStorePwd);
-					if(trustMgrProvider!=null) {
+					if (trustMgrProvider != null) {
+						trustStore = KeyStore.getInstance(trustStoreType, trustMgrProvider);
+						trustStore.load(new FileInputStream(trustStoreName), trustStorePwd);
 						trustMgrFact = TrustManagerFactory.getInstance(trustMgrAlgo, trustMgrProvider);
 					} else {
+						trustStore = KeyStore.getInstance(trustStoreType);
+						trustStore.load(new FileInputStream(trustStoreName), trustStorePwd);
 						trustMgrFact = TrustManagerFactory.getInstance(trustMgrAlgo);
 					}
 					if (logger != null) {


### PR DESCRIPTION
Adapt KeyStore.getInstance in getSSLContext();

Please make sure that the following boxes are checked before submitting your Pull Request, thank you!

- [x] This change is against the develop branch, **not** master.
- [x] You have signed the [Eclipse ECA](https://wiki.eclipse.org/ECA)
- [x] All of your commits have been signed-off with the correct email address (the same one that you 
      used to sign the CLA) _Hint: use the -s argument when committing_.
- [x] If This PR fixes an issue, that you reference the issue below. OR if this is a new issue that 
      you are fixing straight away that you add some Description about the bug and how this will fix it.
      https://github.com/eclipse/paho.mqtt.java/issues/893
- [ ] If this is new functionality, You have added the appropriate Unit tests.
