### PR TITLE
Fix case where Recursively calling the same method causes StackOverFlow

### DIFF
--- a/org.eclipse.paho.mqttv5.client/src/main/java/org/eclipse/paho/mqttv5/client/MqttClient.java
+++ b/org.eclipse.paho.mqttv5.client/src/main/java/org/eclipse/paho/mqttv5/client/MqttClient.java
@@ -522,7 +522,16 @@ public class MqttClient implements IMqttClient {
 
 	public IMqttToken subscribe(String[] topicFilters, int[] qos, IMqttMessageListener[] messageListeners)
 			throws MqttException {
-		return this.subscribe(topicFilters, qos, messageListeners);
+		if (topicFilters.length != qos.length) {
+			throw new MqttException(MqttClientException.REASON_CODE_UNEXPECTED_ERROR);
+		}
+
+		MqttSubscription[] subscriptions = new MqttSubscription[topicFilters.length];
+		for (int i = 0; i < topicFilters.length; ++i) {
+			subscriptions[i] = new MqttSubscription(topicFilters[i], qos[i]);
+		}
+
+		return this.subscribe(subscriptions, messageListeners);
 	}
 
 	public IMqttToken subscribe(MqttSubscription[] subscriptions, IMqttMessageListener[] messageListeners) throws MqttException {


### PR DESCRIPTION
 - [x] This change is against the develop branch, not master.
 - [x] You have signed the Eclipse ECA
- [x] All of your commits have been signed-off with the correct email address (the same one that you
used to sign the CLA) Hint: use the -s argument when committing.
- [ ]  If This PR fixes an issue, that you reference the issue below. OR if this is a new issue that
- [ ] you are fixing straight away that you add some Description about the bug and how this will fix it.
 If this is new functionality, You have added the appropriate Unit tests.

![image](https://user-images.githubusercontent.com/47316511/137242213-a6652180-4571-4a55-9643-753eb4372d02.png)

Existing code was calling the same method over and over again. and it causes StackOverFlow.
