### PR TITLE
Allowing shared subscriber group topics to match

### DIFF
--- a/org.eclipse.paho.mqttv5.client.test/src/test/java/org/eclipse/paho/mqttv5/common/utils/MqttTopicTest.java
+++ b/org.eclipse.paho.mqttv5.client.test/src/test/java/org/eclipse/paho/mqttv5/common/utils/MqttTopicTest.java
@@ -46,6 +46,18 @@ public class MqttTopicTest {
 	}
 
 	@Test
+	public void testShareMatchTopicFilterWildcards() throws Exception {
+		String[][] matchingTopics = new String[][] {{ "$share/group/sport/tennis/player1/#", "sport/tennis/player1" },
+				{ "$share/group/sport/tennis/player1/#", "sport/tennis/player1/ranking" },
+				{ "$share/group/sport/tennis/player1/#", "sport/tennis/player1/score/wimbledon" }, { "$share/group/sport/#", "sport" },
+				{ "$share/group/#", "sport/tennis/player1" }, { "$share/group/sport", "sport"} };
+
+		for (String[] pair : matchingTopics) {
+			Assert.assertTrue(pair[0] + " should match " + pair[1], MqttTopicValidator.isMatched(pair[0], pair[1]));
+		}
+	}
+
+	@Test
 	public void testNonMatchedTopicFilterWildcards() throws Exception {
 		String[][] matchingTopics = new String[][] { { "sport/tennis/player1/#", "sport/tennis/player2" },
 				{ "sport1/#", "sport2" }, { "sport/tennis1/player/#", "sport/tennis2/player" } };

--- a/org.eclipse.paho.mqttv5.client/src/main/java/org/eclipse/paho/mqttv5/common/util/MqttTopicValidator.java
+++ b/org.eclipse.paho.mqttv5.client/src/main/java/org/eclipse/paho/mqttv5/common/util/MqttTopicValidator.java
@@ -163,6 +163,11 @@ public class MqttTopicValidator {
 		MqttTopicValidator.validate(topicFilter, true, true);
 		MqttTopicValidator.validate(topicName, false, true);
 
+		// remove $share/groupname from $share/groupname/topic to topic
+		if (topicFilter.startsWith("$share/")) {
+			topicFilter = topicFilter.substring(topicFilter.indexOf("/", topicFilter.indexOf("/") + 1) + 1);
+		}
+
 		if (topicFilter.equals(topicName)) {
 			return true;
 		}


### PR DESCRIPTION
This looked to be a bug to me.

When I was configuring a client, and used `$share/groupname/topic` as the topic, no messages would be delivered.

I traced it down to here: https://github.com/eclipse/paho.mqtt.java/blob/master/org.eclipse.paho.mqttv5.client/src/main/java/org/eclipse/paho/mqttv5/client/internal/CommsCallback.java#L611

At that point, the message would have come from `topic`, which does not match `$share/groupname/topic`, and the message would be left undelivered. 

possibly related https://github.com/eclipse/paho.mqtt.java/issues/827

Thank you for your time!

Please make sure that the following boxes are checked before submitting your Pull Request, thank you!

- [x] This change is against the develop branch, **not** master.
- [x] You have signed the [Eclipse ECA](https://wiki.eclipse.org/ECA)
- [x] All of your commits have been signed-off with the correct email address (the same one that you 
      used to sign the CLA) _Hint: use the -s argument when committing_.
- [x] If This PR fixes an issue, that you reference the issue below. OR if this is a new issue that 
      you are fixing straight away that you add some Description about the bug and how this will fix it.
- [x] If this is new functionality, You have added the appropriate Unit tests.
