### PR TITLE
Allow configurable hostname lookup

### DIFF
--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/IMqttDns.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/IMqttDns.java
@@ -1,0 +1,8 @@
+package org.eclipse.paho.client.mqttv3;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
+public interface IMqttDns {
+    InetAddress lookup(String host) throws UnknownHostException;
+}

--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/MqttConnectOptions.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/MqttConnectOptions.java
@@ -74,6 +74,7 @@ public class MqttConnectOptions {
 	private boolean automaticReconnect = false;
 	private int maxReconnectDelay = 128000;
 	private Properties customWebSocketHeaders = null;
+	private IMqttDns dns = null;
 
 	// Client Operation Parameters
 	private int executorServiceTimeout = 1; // How long to wait in seconds when terminating the executor service.
@@ -646,6 +647,14 @@ public class MqttConnectOptions {
 		return executorServiceTimeout;
 	}
 
+	public IMqttDns getDns() {
+		return dns;
+	}
+
+	public void setDns(IMqttDns dns) {
+		this.dns = dns;
+	}
+
 	/**
 	 * Set the time in seconds that the executor service should wait when
 	 * terminating before forcefully terminating. It is not recommended to change
@@ -678,6 +687,11 @@ public class MqttConnectOptions {
 			p.put("SSLProperties", strNull);
 		} else {
 			p.put("SSLProperties", getSSLProperties());
+		}
+		if (getDns() == null) {
+			p.put("Dns", strNull);
+		} else {
+			p.put("Dns", getDns());
 		}
 		return p;
 	}

--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/SSLNetworkModule.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/SSLNetworkModule.java
@@ -30,6 +30,7 @@ import javax.net.ssl.SSLSession;
 import javax.net.ssl.SSLSocket;
 import javax.net.ssl.SSLSocketFactory;
 
+import org.eclipse.paho.client.mqttv3.IMqttDns;
 import org.eclipse.paho.client.mqttv3.MqttException;
 import org.eclipse.paho.client.mqttv3.logging.Logger;
 import org.eclipse.paho.client.mqttv3.logging.LoggerFactory;
@@ -64,8 +65,8 @@ public class SSLNetworkModule extends TCPNetworkModule {
 	 * @param resourceContext
 	 *            Resource Context
 	 */
-	public SSLNetworkModule(SSLSocketFactory factory, String host, int port, String resourceContext) {
-		super(factory, host, port, resourceContext);
+	public SSLNetworkModule(SSLSocketFactory factory, String host, int port, String resourceContext, IMqttDns dns) {
+		super(factory, host, port, resourceContext, dns);
 		this.host = host;
 		this.port = port;
 		log.setResourceName(resourceContext);

--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/SSLNetworkModuleFactory.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/SSLNetworkModuleFactory.java
@@ -71,7 +71,7 @@ public class SSLNetworkModuleFactory implements NetworkModuleFactory {
 		}
 
 		// Create the network module...
-		SSLNetworkModule netModule = new SSLNetworkModule((SSLSocketFactory) factory, host, port, clientId);
+		SSLNetworkModule netModule = new SSLNetworkModule((SSLSocketFactory) factory, host, port, clientId, options.getDns());
 		netModule.setSSLhandshakeTimeout(options.getConnectionTimeout());
 		netModule.setSSLHostnameVerifier(options.getSSLHostnameVerifier());
 		netModule.setHttpsHostnameVerificationEnabled(options.isHttpsHostnameVerificationEnabled());

--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/TCPNetworkModule.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/TCPNetworkModule.java
@@ -22,9 +22,11 @@ import java.net.ConnectException;
 import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.net.SocketAddress;
+import java.net.InetAddress;
 
 import javax.net.SocketFactory;
 
+import org.eclipse.paho.client.mqttv3.IMqttDns;
 import org.eclipse.paho.client.mqttv3.MqttException;
 import org.eclipse.paho.client.mqttv3.logging.Logger;
 import org.eclipse.paho.client.mqttv3.logging.LoggerFactory;
@@ -41,6 +43,7 @@ public class TCPNetworkModule implements NetworkModule {
 	private String host;
 	private int port;
 	private int conTimeout;
+	private IMqttDns dns;
 
 	/**
 	 * Constructs a new TCPNetworkModule using the specified host and
@@ -50,13 +53,14 @@ public class TCPNetworkModule implements NetworkModule {
 	 * @param host The server hostname
 	 * @param port The server port
 	 * @param resourceContext The Resource Context
+	 * @param dns the {@link IMqttDns} to be used for hostname lookup
 	 */
-	public TCPNetworkModule(SocketFactory factory, String host, int port, String resourceContext) {
+	public TCPNetworkModule(SocketFactory factory, String host, int port, String resourceContext, IMqttDns dns) {
 		log.setResourceName(resourceContext);
 		this.factory = factory;
 		this.host = host;
 		this.port = port;
-
+		this.dns = dns;
 	}
 
 	/**
@@ -69,7 +73,13 @@ public class TCPNetworkModule implements NetworkModule {
 		try {
 			// @TRACE 252=connect to host {0} port {1} timeout {2}
 			log.fine(CLASS_NAME,methodName, "252", new Object[] {host, Integer.valueOf(port), Long.valueOf(conTimeout*1000)});
-			SocketAddress sockaddr = new InetSocketAddress(host, port);
+			final SocketAddress sockaddr;
+			if (dns != null) {
+				InetAddress inetAddr = dns.lookup(host);
+				sockaddr = new InetSocketAddress(inetAddr, port);
+			} else {
+				sockaddr = new InetSocketAddress(host, port); // default system resolver
+			}
 			socket = factory.createSocket();
 			socket.connect(sockaddr, conTimeout*1000);
 			socket.setSoTimeout(1000);

--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/TCPNetworkModuleFactory.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/TCPNetworkModuleFactory.java
@@ -56,7 +56,7 @@ public class TCPNetworkModuleFactory implements NetworkModuleFactory {
 		} else if (factory instanceof SSLSocketFactory) {
 			throw ExceptionHelper.createMqttException(MqttException.REASON_CODE_SOCKET_FACTORY_MISMATCH);
 		}
-		TCPNetworkModule networkModule = new TCPNetworkModule(factory, host, port, clientId);
+		TCPNetworkModule networkModule = new TCPNetworkModule(factory, host, port, clientId, options.getDns());
 		networkModule.setConnectTimeout(options.getConnectionTimeout());
 		return networkModule;
 	}

--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/websocket/WebSocketNetworkModule.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/websocket/WebSocketNetworkModule.java
@@ -25,6 +25,7 @@ import java.util.Properties;
 
 import javax.net.SocketFactory;
 
+import org.eclipse.paho.client.mqttv3.IMqttDns;
 import org.eclipse.paho.client.mqttv3.MqttException;
 import org.eclipse.paho.client.mqttv3.internal.TCPNetworkModule;
 import org.eclipse.paho.client.mqttv3.logging.Logger;
@@ -50,8 +51,8 @@ public class WebSocketNetworkModule extends TCPNetworkModule {
 	 */
 	private ByteArrayOutputStream outputStream = new ExtendedByteArrayOutputStream(this);
 
-	public WebSocketNetworkModule(SocketFactory factory, String uri, String host, int port, String resourceContext, Properties customWebsocketHeaders){
-		super(factory, host, port, resourceContext);
+	public WebSocketNetworkModule(SocketFactory factory, String uri, String host, int port, String resourceContext, Properties customWebsocketHeaders, IMqttDns dns){
+		super(factory, host, port, resourceContext, dns);
 		this.uri = uri;
 		this.host = host;
 		this.port = port;

--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/websocket/WebSocketNetworkModuleFactory.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/websocket/WebSocketNetworkModuleFactory.java
@@ -52,7 +52,7 @@ public class WebSocketNetworkModuleFactory implements NetworkModuleFactory {
 			throw ExceptionHelper.createMqttException(MqttException.REASON_CODE_SOCKET_FACTORY_MISMATCH);
 		}
 		WebSocketNetworkModule netModule = new WebSocketNetworkModule(factory, brokerUri.toString(), host, port,
-				clientId, options.getCustomWebSocketHeaders());
+				clientId, options.getCustomWebSocketHeaders(), options.getDns());
 		netModule.setConnectTimeout(options.getConnectionTimeout());
 		return netModule;
 	}

--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/websocket/WebSocketSecureNetworkModule.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/websocket/WebSocketSecureNetworkModule.java
@@ -24,6 +24,7 @@ import java.nio.ByteBuffer;
 import java.util.Properties;
 import javax.net.ssl.SSLSocketFactory;
 
+import org.eclipse.paho.client.mqttv3.IMqttDns;
 import org.eclipse.paho.client.mqttv3.MqttException;
 import org.eclipse.paho.client.mqttv3.internal.SSLNetworkModule;
 import org.eclipse.paho.client.mqttv3.logging.Logger;
@@ -49,8 +50,8 @@ public class WebSocketSecureNetworkModule extends SSLNetworkModule{
 	 */
 	private ByteArrayOutputStream outputStream = new ExtendedByteArrayOutputStream(this);
 
-	public WebSocketSecureNetworkModule(SSLSocketFactory factory, String uri, String host, int port, String clientId, Properties customWebSocketHeaders) {
-		super(factory, host, port, clientId);
+	public WebSocketSecureNetworkModule(SSLSocketFactory factory, String uri, String host, int port, String clientId, IMqttDns dns, Properties customWebSocketHeaders) {
+		super(factory, host, port, clientId, dns);
 		this.uri = uri;
 		this.host = host;
 		this.port = port;

--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/websocket/WebSocketSecureNetworkModuleFactory.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/websocket/WebSocketSecureNetworkModuleFactory.java
@@ -64,7 +64,7 @@ public class WebSocketSecureNetworkModuleFactory implements NetworkModuleFactory
 
 		// Create the network module...
 		WebSocketSecureNetworkModule netModule = new WebSocketSecureNetworkModule((SSLSocketFactory) factory,
-				brokerUri.toString(), host, port, clientId, options.getCustomWebSocketHeaders());
+				brokerUri.toString(), host, port, clientId, options.getDns(), options.getCustomWebSocketHeaders());
 		netModule.setSSLhandshakeTimeout(options.getConnectionTimeout());
 		netModule.setSSLHostnameVerifier(options.getSSLHostnameVerifier());
 		netModule.setHttpsHostnameVerificationEnabled(options.isHttpsHostnameVerificationEnabled());


### PR DESCRIPTION
Please make sure that the following boxes are checked before submitting your Pull Request, thank you!

- [x] This change is against the develop branch, **not** master.
- [x] You have signed the [Eclipse ECA](https://wiki.eclipse.org/ECA)
- [x] All of your commits have been signed-off with the correct email address (the same one that you 
      used to sign the CLA) _Hint: use the -s argument when committing_.
- [x] If This PR fixes an issue, that you reference the issue below. OR if this is a new issue that 
      you are fixing straight away that you add some Description about the bug and how this will fix it.
- [x] If this is new functionality, You have added the appropriate Unit tests.

We are using this interface to perform IPv4-only lookups. It may also help those looking for other hostname resolution behavior like  https://github.com/eclipse/paho.mqtt.java/issues/475 

If there's interest in merging this I am happy to add javadocs as well as clientv5 modifications