### PR TITLE
Fix NullPointerException trying to clear pending messages and flows

### DIFF
--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/ClientState.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/ClientState.java
@@ -1366,8 +1366,12 @@ public class ClientState {
 			// Quiesce time up or inflight messages delivered.  Ensure pending delivery
 			// vectors are cleared ready for disconnect to be sent as the final flow.
 			synchronized (queueLock) {
-				pendingMessages.clear();				
-				pendingFlows.clear();
+				if (pendingMessages != null) {
+					pendingMessages.clear();
+				}
+				if (pendingFlows != null) {
+					pendingFlows.clear();
+				}
 				quiescing = false;
 				actualInFlight = 0;
 			}


### PR DESCRIPTION
Fixes a `NullPointerException` when trying to clear `pendingMessages` and `pendingFlows` while they are `null`

Please make sure that the following boxes are checked before submitting your Pull Request, thank you!

- [x] This change is against the develop branch, **not** master.
- [x] You have signed the [Eclipse ECA](https://wiki.eclipse.org/ECA)
- [x] All of your commits have been signed-off with the correct email address (the same one that you 
      used to sign the CLA) _Hint: use the -s argument when committing_.
- [x] If This PR fixes an issue, that you reference the issue below. OR if this is a new issue that 
      you are fixing straight away that you add some Description about the bug and how this will fix it.
- [ ] If this is new functionality, You have added the appropriate Unit tests.
