### PR TITLE
在自动重连选项下，解决CommsCallback线程在连接上MQTT服务器，当服务器断开后，重连的线程一直会在line:109空转

### DIFF
--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/CommsCallback.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/CommsCallback.java
@@ -128,6 +128,7 @@ public class CommsCallback implements Runnable {
 			// @TRACE 700=stopping
 			log.fine(CLASS_NAME, methodName, "700");
 			synchronized (lifecycle) {
+				current_state = State.STOPPED;
 				target_state = State.STOPPED;
 			}
 			if (!Thread.currentThread().equals(callbackThread)) {


### PR DESCRIPTION
while (!isRunning()) {
                                                       			try { Thread.sleep(100); } catch (Exception e) { }
                                                       		}
如果重连断开的次数过多，最终造成CommsCallback线程无限增长的状况。

