### PR TITLE
在自动重连选项下，解决CommsCallback线程在连接上MQTT服务器，当服务器断开后，重连的线程一直会在line:109空转

### DIFF
--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/CommsCallback.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/CommsCallback.java
@@ -128,6 +128,7 @@ public class CommsCallback implements Runnable {
 			// @TRACE 700=stopping
 			log.fine(CLASS_NAME, methodName, "700");
 			synchronized (lifecycle) {
+				current_state = State.STOPPED;
 				target_state = State.STOPPED;
 			}
 			if (!Thread.currentThread().equals(callbackThread)) {


### PR DESCRIPTION
while (!isRunning()) {
                                                       			try { Thread.sleep(100); } catch (Exception e) { }
                                                       		}
如果重连断开的次数过多，最终造成CommsCallback线程无限增长的状况。

stack log：

 "MQTT Con: collector-5aab5013" #5913 daemon prio=5 os_prio=0 tid=0x9e9f3000 nid=0x229b waiting on condition [0x86f6e000]
   java.lang.Thread.State: TIMED_WAITING (sleeping)
	at java.lang.Thread.sleep(Native Method)
	at org.eclipse.paho.client.mqttv3.internal.CommsCallback.start(CommsCallback.java:110)
	at org.eclipse.paho.client.mqttv3.internal.ClientComms$ConnectBG.run(ClientComms.java:729)
	at java.lang.Thread.run(Thread.java:748)

   Locked ownable synchronizers:
	- None

"MQTT Con: collector-5aab5013" #5910 daemon prio=5 os_prio=0 tid=0x8a506000 nid=0x2297 waiting on condition [0x8719e000]
   java.lang.Thread.State: TIMED_WAITING (sleeping)
	at java.lang.Thread.sleep(Native Method)
	at org.eclipse.paho.client.mqttv3.internal.CommsCallback.start(CommsCallback.java:110)
	at org.eclipse.paho.client.mqttv3.internal.ClientComms$ConnectBG.run(ClientComms.java:729)
	at java.lang.Thread.run(Thread.java:748)

   Locked ownable synchronizers:
	- None

"MQTT Con: collector-5aab5013" #5906 daemon prio=5 os_prio=0 tid=0x9de0b400 nid=0x2277 waiting on condition [0x8700e000]
   java.lang.Thread.State: TIMED_WAITING (sleeping)
	at java.lang.Thread.sleep(Native Method)
	at org.eclipse.paho.client.mqttv3.internal.CommsCallback.start(CommsCallback.java:110)
	at org.eclipse.paho.client.mqttv3.internal.ClientComms$ConnectBG.run(ClientComms.java:729)
	at java.lang.Thread.run(Thread.java:748)

   Locked ownable synchronizers:
	- None

"MQTT Con: collector-5aab5013" #5903 daemon prio=5 os_prio=0 tid=0x8a505800 nid=0x2274 waiting on condition [0x8705e000]
   java.lang.Thread.State: TIMED_WAITING (sleeping)
	at java.lang.Thread.sleep(Native Method)
	at org.eclipse.paho.client.mqttv3.internal.CommsCallback.start(CommsCallback.java:110)
	at org.eclipse.paho.client.mqttv3.internal.ClientComms$ConnectBG.run(ClientComms.java:729)
	at java.lang.Thread.run(Thread.java:748)