### PR TITLE
Update MqttAsyncClient.java

### DIFF
--- a/org.eclipse.paho.mqttv5.client/src/main/java/org/eclipse/paho/mqttv5/client/MqttAsyncClient.java
+++ b/org.eclipse.paho.mqttv5.client/src/main/java/org/eclipse/paho/mqttv5/client/MqttAsyncClient.java
@@ -1161,7 +1161,7 @@ public class MqttAsyncClient implements MqttClientInterface, IMqttAsyncClient {
 		token.setActionCallback(callback);
 		token.setUserContext(userContext);
 		// TODO - Somehow refactor this....
-		// token.internalTok.setTopics(topicFilters);
+		token.internalTok.setTopics(topicFilters);
 		// TODO - Build up MQTT Subscriptions properly here
 
 		MqttSubscribe register = new MqttSubscribe(subscriptions, subscriptionProperties);


### PR DESCRIPTION
set topics for the token which can cause a null pointer exception if not set, this was already there in version 3.1.1, commenting this caused problems if checking over the length of the getTopics against the length of QOSGranted

