### PR TITLE
Fix MqttClient(v3) waits after sending a qos=0 message

### DIFF
--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/MqttClient.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/MqttClient.java
@@ -567,7 +567,11 @@ public class MqttClient implements IMqttClient {
 	 */
 	public void publish(String topic, MqttMessage message) throws MqttException,
 			MqttPersistenceException {
-		aClient.publish(topic, message, null, null).waitForCompletion(getTimeToWait());
+		if (message.getQos() == 0) {
+			getTopic(topic).publish(message);
+		} else {
+			aClient.publish(topic, message, null, null).waitForCompletion(getTimeToWait());
+		}
 	}
 
 	/**


### PR DESCRIPTION
issue [#1014](https://github.com/eclipse/paho.mqtt.java/issues/1014) MqttClient(v3) waits after sending a qos=0 message

Please make sure that the following boxes are checked before submitting your Pull Request, thank you!

- [x] This change is against the develop branch, **not** master.
- [x] You have signed the [Eclipse ECA](https://wiki.eclipse.org/ECA)
- [x] All of your commits have been signed-off with the correct email address (the same one that you 
      used to sign the CLA) _Hint: use the -s argument when committing_.
- [x] If This PR fixes an issue, that you reference the issue below. OR if this is a new issue that 
      you are fixing straight away that you add some Description about the bug and how this will fix it.
- [ ] If this is new functionality, You have added the appropriate Unit tests.
