### PR TITLE
Develop

### DIFF
--- a/org.eclipse.paho.client.mqttv3/src/main/java-templates/org/eclipse/paho/client/mqttv3/internal/ClientComms.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java-templates/org/eclipse/paho/client/mqttv3/internal/ClientComms.java
@@ -22,8 +22,7 @@ package org.eclipse.paho.client.mqttv3.internal;
 import java.util.Enumeration;
 import java.util.Properties;
 import java.util.Vector;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.*;
 
 import org.eclipse.paho.client.mqttv3.BufferedMessage;
 import org.eclipse.paho.client.mqttv3.IMqttActionListener;
@@ -271,9 +270,8 @@ public class ClientComms {
 	 * @param token The {@link MqttToken} to track the connection
 	 * @throws MqttException if an error occurs when connecting
 	 */
-	public void connect(MqttConnectOptions options, MqttToken token) throws MqttException {
+	public synchronized void connect(MqttConnectOptions options, MqttToken token) throws MqttException {
 		final String methodName = "connect";
-		synchronized (conLock) {
 			if (isDisconnected() && !closePending) {
 				//@TRACE 214=state=CONNECTING
 				log.fine(CLASS_NAME,methodName,"214");
@@ -297,7 +295,11 @@ public class ClientComms {
 
 				tokenStore.open();
 				ConnectBG conbg = new ConnectBG(this, token, connect, executorService);
-				conbg.start();
+				try {
+					conbg.start();
+				} catch (MqttException e){
+					throw e;
+				}
 			}
 			else {
 				// @TRACE 207=connect failed: not disconnected {0}
@@ -312,7 +314,6 @@ public class ClientComms {
 					throw ExceptionHelper.createMqttException(MqttException.REASON_CODE_CLIENT_CONNECTED);
 				}
 			}
-		}
 	}
 
 	public void connectComplete( MqttConnack cack, MqttException mex) throws MqttException {
@@ -400,7 +401,8 @@ public class ClientComms {
 			// Clean session handling and tidy up
 			clientState.disconnected(reason);
 			if (clientState.getCleanSession())
-				callback.removeMessageListeners();
+
+			callback.removeMessageListeners();
 		}catch(Exception ex) {
 			// Ignore as we are shutting down
 		}
@@ -417,8 +419,10 @@ public class ClientComms {
 			}
 			
 		}catch(Exception ex) {
+
 			// Ignore as we are shutting down
 		}
+
 		// All disconnect logic has been completed allowing the
 		// client to be marked as disconnected.
 		synchronized(conLock) {
@@ -427,6 +431,7 @@ public class ClientComms {
 
 			conState = DISCONNECTED;
 			stoppingComms = false;
+
 		}
 
 		// Internal disconnect processing has completed.  If there
@@ -436,6 +441,7 @@ public class ClientComms {
 		// any outstanding tokens and unblock any waiters
 		if (endToken != null && callback != null) {
 			callback.asyncOperationComplete(endToken);
+
 		}
 
 		if (wasConnected && callback != null) {
@@ -449,6 +455,7 @@ public class ClientComms {
 				try {
 					close(true);
 				} catch (Exception e) { // ignore any errors as closing
+
 				}
 			}
 		}
@@ -692,11 +699,17 @@ public class ClientComms {
 			threadName = "MQTT Con: "+getClient().getClientId();
 		}
 
-		void start() {
+		void start() throws MqttException {
+			Future<?> test = null;
 			if (executorService == null) {
-				new Thread(this).start();
+				test = Executors.newSingleThreadExecutor().submit(this);
 			} else {
-				executorService.execute(this);
+				test = executorService.submit(this);
+			}
+			try {
+				Object g = test.get();;
+			} catch (Exception e) {
+				throw new MqttException(MqttException.REASON_CODE_SERVER_CONNECT_ERROR);
 			}
 		}
 
@@ -734,6 +747,7 @@ public class ClientComms {
 				//@TRACE 212=connect failed: unexpected exception
 				log.fine(CLASS_NAME, methodName, "212", null, ex);
 				mqttEx = ex;
+
 			} catch (Exception ex) {
 				//@TRACE 209=connect failed: unexpected exception
 				log.fine(CLASS_NAME, methodName, "209", null, ex);
@@ -741,6 +755,8 @@ public class ClientComms {
 			}
 
 			if (mqttEx != null) {
+				if(mqttEx.getReasonCode() == MqttException.REASON_CODE_SERVER_CONNECT_ERROR)
+					throw new RuntimeException(mqttEx);
 				shutdownConnection(conToken, mqttEx);
 			}
 		}

--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/MqttAsyncClient.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/MqttAsyncClient.java
@@ -763,7 +763,11 @@ public class MqttAsyncClient implements IMqttAsyncClient {
 		}
 
 		comms.setNetworkModuleIndex(0);
-		connectActionListener.connect();
+		try {
+			connectActionListener.connect();
+		} catch (MqttException e) {
+			throw e;
+		}
 
 		return userToken;
 	}

--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/ConnectActionListener.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/ConnectActionListener.java
@@ -136,7 +136,7 @@ public class ConnectActionListener implements IMqttActionListener {
       try {
         connect();
       }
-      catch (MqttPersistenceException e) {
+      catch (MqttException e) {
         onFailure(token, e); // try the next URI in the list
       }
     }
@@ -166,7 +166,7 @@ public class ConnectActionListener implements IMqttActionListener {
    * Start the connect processing
    * @throws MqttPersistenceException if an error is thrown whilst setting up persistence 
    */
-  public void connect() throws MqttPersistenceException {
+  public void connect() throws MqttException {
     MqttToken token = new MqttToken(client.getClientId());
     token.setActionCallback(this);
     token.setUserContext(this);
@@ -185,6 +185,8 @@ public class ConnectActionListener implements IMqttActionListener {
       comms.connect(options, token);
     }
     catch (MqttException e) {
+      if(e.getReasonCode() == MqttException.REASON_CODE_SERVER_CONNECT_ERROR)
+        throw e;
       onFailure(token, e);
     }
   }

--- a/org.eclipse.paho.mqttv5.client.test/src/test/java/org/eclipse/paho/mqttv5/common/utils/MqttTopicTest.java
+++ b/org.eclipse.paho.mqttv5.client.test/src/test/java/org/eclipse/paho/mqttv5/common/utils/MqttTopicTest.java
@@ -38,7 +38,7 @@ public class MqttTopicTest {
 		String[][] matchingTopics = new String[][] { { "sport/tennis/player1/#", "sport/tennis/player1" },
 				{ "sport/tennis/player1/#", "sport/tennis/player1/ranking" },
 				{ "sport/tennis/player1/#", "sport/tennis/player1/score/wimbledon" }, { "sport/#", "sport" },
-				{ "#", "sport/tennis/player1" } };
+				{ "#", "sport/tennis/player1" } , {"sport/+/player1/ranking/#","sport/tennis/player1/ranking"} };
 
 		for (String[] pair : matchingTopics) {
 			Assert.assertTrue(pair[0] + " should match " + pair[1], MqttTopicValidator.isMatched(pair[0], pair[1]));

--- a/org.eclipse.paho.mqttv5.client/src/main/java/org/eclipse/paho/mqttv5/common/util/MqttTopicValidator.java
+++ b/org.eclipse.paho.mqttv5.client/src/main/java/org/eclipse/paho/mqttv5/common/util/MqttTopicValidator.java
@@ -4,214 +4,222 @@ import java.io.UnsupportedEncodingException;
 
 public class MqttTopicValidator {
 
-	/**
-	 * The forward slash (/) is used to separate each level within a topic tree and
-	 * provide a hierarchical structure to the topic space. The use of the topic
-	 * level separator is significant when the two wildcard characters are
-	 * encountered in topics specified by subscribers.
-	 */
-	public static final String TOPIC_LEVEL_SEPARATOR = "/";
+  /**
+   * The forward slash (/) is used to separate each level within a topic tree and provide a hierarchical structure to
+   * the topic space. The use of the topic level separator is significant when the two wildcard characters are
+   * encountered in topics specified by subscribers.
+   */
+  public static final String TOPIC_LEVEL_SEPARATOR = "/";
 
-	/**
-	 * Multi-level wildcard The number sign (#) is a wildcard character that matches
-	 * any number of levels within a topic.
-	 */
-	public static final String MULTI_LEVEL_WILDCARD = "#";
+  /**
+   * Multi-level wildcard The number sign (#) is a wildcard character that matches any number of levels within a topic.
+   */
+  public static final String MULTI_LEVEL_WILDCARD = "#";
 
-	/**
-	 * Single-level wildcard The plus sign (+) is a wildcard character that matches
-	 * only one topic level.
-	 */
-	public static final String SINGLE_LEVEL_WILDCARD = "+";
+  /**
+   * Single-level wildcard The plus sign (+) is a wildcard character that matches only one topic level.
+   */
+  public static final String SINGLE_LEVEL_WILDCARD = "+";
 
-	/**
-	 * Multi-level wildcard pattern(/#)
-	 */
-	public static final String MULTI_LEVEL_WILDCARD_PATTERN = TOPIC_LEVEL_SEPARATOR + MULTI_LEVEL_WILDCARD;
+  /**
+   * Multi-level wildcard pattern(/#)
+   */
+  public static final String MULTI_LEVEL_WILDCARD_PATTERN = TOPIC_LEVEL_SEPARATOR + MULTI_LEVEL_WILDCARD;
 
-	/**
-	 * Topic wildcards (#+)
-	 */
-	public static final String TOPIC_WILDCARDS = MULTI_LEVEL_WILDCARD + SINGLE_LEVEL_WILDCARD;
+  /**
+   * Topic wildcards (#+)
+   */
+  public static final String TOPIC_WILDCARDS = MULTI_LEVEL_WILDCARD + SINGLE_LEVEL_WILDCARD;
 
-	// topic name and topic filter length range defined in the spec
-	private static final int MIN_TOPIC_LEN = 1;
-	private static final int MAX_TOPIC_LEN = 65535;
-	private static final char NUL = '\u0000';
+  // topic name and topic filter length range defined in the spec
+  private static final int MIN_TOPIC_LEN = 1;
+  private static final int MAX_TOPIC_LEN = 65535;
+  private static final char NUL = '\u0000';
 
-	/**
-	 * Validate the topic name or topic filter
-	 *
-	 * @param topicString
-	 *            topic name or filter
-	 * @param wildcardAllowed
-	 *            true if validate topic filter, false otherwise
-	 * @param sharedSubAllowed
-	 *            true if shared subscription is allowed, false otherwise
-	 * @throws IllegalArgumentException
-	 *             if the topic is invalid
-	 */
-	public static void validate(String topicString, boolean wildcardAllowed, boolean sharedSubAllowed)
-			throws IllegalArgumentException {
-		int topicLen = 0;
-		try {
-			topicLen = topicString.getBytes("UTF-8").length;
-		} catch (UnsupportedEncodingException e) {
-			throw new IllegalStateException(e.getMessage());
-		}
+  /**
+   * Validate the topic name or topic filter
+   *
+   * @param topicString
+   *          topic name or filter
+   * @param wildcardAllowed
+   *          true if validate topic filter, false otherwise
+   * @param sharedSubAllowed
+   *          true if shared subscription is allowed, false otherwise
+   * @throws IllegalArgumentException
+   *           if the topic is invalid
+   */
+  public static void validate(String topicString, boolean wildcardAllowed, boolean sharedSubAllowed)
+      throws IllegalArgumentException {
+    int topicLen = 0;
+    try {
+      topicLen = topicString.getBytes("UTF-8").length;
+    } catch (UnsupportedEncodingException e) {
+      throw new IllegalStateException(e.getMessage());
+    }
 
-		// Spec: length check
-		// - All Topic Names and Topic Filters MUST be at least one character
-		// long
-		// - Topic Names and Topic Filters are UTF-8 encoded strings, they MUST
-		// NOT encode to more than 65535 bytes
-		if (topicLen < MIN_TOPIC_LEN || topicLen > MAX_TOPIC_LEN) {
-			throw new IllegalArgumentException(String.format("Invalid topic length, should be in range[%d, %d]!",
-					new Object[] { Integer.valueOf(MIN_TOPIC_LEN), Integer.valueOf(MAX_TOPIC_LEN) }));
-		}
+    // Spec: length check
+    // - All Topic Names and Topic Filters MUST be at least one character
+    // long
+    // - Topic Names and Topic Filters are UTF-8 encoded strings, they MUST
+    // NOT encode to more than 65535 bytes
+    if (topicLen < MIN_TOPIC_LEN || topicLen > MAX_TOPIC_LEN) {
+      throw new IllegalArgumentException(String.format("Invalid topic length, should be in range[%d, %d]!",
+          new Object[] { Integer.valueOf(MIN_TOPIC_LEN), Integer.valueOf(MAX_TOPIC_LEN) }));
+    }
 
-		// *******************************************************************************
-		// 1) This is a topic filter string that can contain wildcard characters
-		// *******************************************************************************
-		if (wildcardAllowed) {
-			// Only # or +
-			if (Strings.equalsAny(topicString, new String[] { MULTI_LEVEL_WILDCARD, SINGLE_LEVEL_WILDCARD })) {
-				return;
-			}
+    // *******************************************************************************
+    // 1) This is a topic filter string that can contain wildcard characters
+    // *******************************************************************************
+    if (wildcardAllowed) {
+      // Only # or +
+      if (Strings.equalsAny(topicString, new String[] { MULTI_LEVEL_WILDCARD, SINGLE_LEVEL_WILDCARD })) {
+        return;
+      }
 
-			// 1) Check multi-level wildcard
-			// Rule:
-			// The multi-level wildcard can be specified only on its own or next
-			// to the topic level separator character.
+      // 1) Check multi-level wildcard
+      // Rule:
+      // The multi-level wildcard can be specified only on its own or next
+      // to the topic level separator character.
 
-			// - Can only contains one multi-level wildcard character
-			// - The multi-level wildcard must be the last character used within
-			// the topic tree
-			if (Strings.countMatches(topicString, MULTI_LEVEL_WILDCARD) > 1
-					|| (topicString.contains(MULTI_LEVEL_WILDCARD)
-							&& !topicString.endsWith(MULTI_LEVEL_WILDCARD_PATTERN))) {
-				throw new IllegalArgumentException(
-						"Invalid usage of multi-level wildcard in topic string: " + topicString);
-			}
+      // - Can only contains one multi-level wildcard character
+      // - The multi-level wildcard must be the last character used within
+      // the topic tree
+      if (Strings.countMatches(topicString, MULTI_LEVEL_WILDCARD) > 1
+          || (topicString.contains(MULTI_LEVEL_WILDCARD) && !topicString.endsWith(MULTI_LEVEL_WILDCARD_PATTERN))) {
+        throw new IllegalArgumentException("Invalid usage of multi-level wildcard in topic string: " + topicString);
+      }
 
-			// 2) Check single-level wildcard
-			// Rule:
-			// The single-level wildcard can be used at any level in the topic
-			// tree, and in conjunction with the
-			// multilevel wildcard. It must be used next to the topic level
-			// separator, except when it is specified on
-			// its own.
-			validateSingleLevelWildcard(topicString);
+      // 2) Check single-level wildcard
+      // Rule:
+      // The single-level wildcard can be used at any level in the topic
+      // tree, and in conjunction with the
+      // multilevel wildcard. It must be used next to the topic level
+      // separator, except when it is specified on
+      // its own.
+      validateSingleLevelWildcard(topicString);
 
-			return;
-		}
+      return;
+    }
 
-		// Validate Shared Subscriptions
-		if (!sharedSubAllowed && topicString.startsWith("$share/")) {
-			throw new IllegalArgumentException("Shared Subscriptions are not allowed.");
-		}
+    // Validate Shared Subscriptions
+    if (!sharedSubAllowed && topicString.startsWith("$share/")) {
+      throw new IllegalArgumentException("Shared Subscriptions are not allowed.");
+    }
 
-		// *******************************************************************************
-		// 2) This is a topic name string that MUST NOT contains any wildcard characters
-		// *******************************************************************************
-		if (Strings.containsAny(topicString, TOPIC_WILDCARDS)) {
-			throw new IllegalArgumentException("The topic name MUST NOT contain any wildcard characters (#+)");
-		}
+    // *******************************************************************************
+    // 2) This is a topic name string that MUST NOT contains any wildcard characters
+    // *******************************************************************************
+    if (Strings.containsAny(topicString, TOPIC_WILDCARDS)) {
+      throw new IllegalArgumentException("The topic name MUST NOT contain any wildcard characters (#+)");
+    }
 
-	}
+  }
 
-	private static void validateSingleLevelWildcard(String topicString) {
-		char singleLevelWildcardChar = SINGLE_LEVEL_WILDCARD.charAt(0);
-		char topicLevelSeparatorChar = TOPIC_LEVEL_SEPARATOR.charAt(0);
+  private static void validateSingleLevelWildcard(String topicString) {
+    char singleLevelWildcardChar = SINGLE_LEVEL_WILDCARD.charAt(0);
+    char topicLevelSeparatorChar = TOPIC_LEVEL_SEPARATOR.charAt(0);
 
-		char[] chars = topicString.toCharArray();
-		int length = chars.length;
-		char prev = NUL, next = NUL;
-		for (int i = 0; i < length; i++) {
-			prev = (i - 1 >= 0) ? chars[i - 1] : NUL;
-			next = (i + 1 < length) ? chars[i + 1] : NUL;
+    char[] chars = topicString.toCharArray();
+    int length = chars.length;
+    char prev = NUL, next = NUL;
+    for (int i = 0; i < length; i++) {
+      prev = (i - 1 >= 0) ? chars[i - 1] : NUL;
+      next = (i + 1 < length) ? chars[i + 1] : NUL;
 
-			if (chars[i] == singleLevelWildcardChar) {
-				// prev and next can be only '/' or none
-				if (prev != topicLevelSeparatorChar && prev != NUL || next != topicLevelSeparatorChar && next != NUL) {
-					throw new IllegalArgumentException(
-							String.format("Invalid usage of single-level wildcard in topic string '%s'!",
-									new Object[] { topicString }));
+      if (chars[i] == singleLevelWildcardChar) {
+        // prev and next can be only '/' or none
+        if (prev != topicLevelSeparatorChar && prev != NUL || next != topicLevelSeparatorChar && next != NUL) {
+          throw new IllegalArgumentException(String
+              .format("Invalid usage of single-level wildcard in topic string '%s'!", new Object[] { topicString }));
 
-				}
-			}
-		}
-	}
+        }
+      }
+    }
+  }
 
-	/**
-	 * Check the supplied topic name and filter match
-	 *
-	 * @param topicFilter
-	 *            topic filter: wildcards allowed
-	 * @param topicName
-	 *            topic name: wildcards not allowed
-	 * @return true if the topic matches the filter
-	 * @throws IllegalArgumentException
-	 *             if the topic name or filter is invalid
-	 */
-	public static boolean isMatched(String topicFilter, String topicName) throws IllegalArgumentException {
-		int topicPos = 0;
-		int filterPos = 0;
-		int topicLen = topicName.length();
-		int filterLen = topicFilter.length();
+  /**
+   * Check the supplied topic name and filter match
+   *
+   * @param topicFilter
+   *          topic filter: wildcards allowed
+   * @param topicName
+   *          topic name: wildcards not allowed
+   * @return true if the topic matches the filter
+   * @throws IllegalArgumentException
+   *           if the topic name or filter is invalid
+   */
+  public static boolean isMatched(String topicFilter, String topicName) throws IllegalArgumentException {
+    int topicPos = 0;
+    int filterPos = 0;
+    int topicLen = topicName.length();
+    int filterLen = topicFilter.length();
 
-		MqttTopicValidator.validate(topicFilter, true, true);
-		MqttTopicValidator.validate(topicName, false, true);
+    MqttTopicValidator.validate(topicFilter, true, true);
+    MqttTopicValidator.validate(topicName, false, true);
 
-		if (topicFilter.equals(topicName)) {
-			return true;
-		}
+    if (topicFilter.equals(topicName)) {
+      return true;
+    }
 
-		while (filterPos < filterLen && topicPos < topicLen) {
-                        if (topicFilter.charAt(filterPos) == '#') {
-                                /*
-                                 * next 'if' will break when topicFilter = topic/# and topicName topic/A/,
-                                 * but they are matched
-                                 */
-                                topicPos = topicLen;
-                                filterPos = filterLen;
-                                break;
-                        }
-			if (topicName.charAt(topicPos) == '/' && topicFilter.charAt(filterPos) != '/')
-				break;
-			if (topicFilter.charAt(filterPos) != '+' && topicFilter.charAt(filterPos) != '#'
-					&& topicFilter.charAt(filterPos) != topicName.charAt(topicPos))
-				break;
-			if (topicFilter.charAt(filterPos) == '+') { // skip until we meet the next separator, or end of string
-				int nextpos = topicPos + 1;
-				while (nextpos < topicLen && topicName.charAt(nextpos) != '/')
-					nextpos = ++topicPos + 1;
-			} else if (topicFilter.charAt(filterPos) == '#')
-				topicPos = topicLen - 1; // skip until end of string
-			filterPos++;
-			topicPos++;
-		}
+    while (filterPos < filterLen && topicPos < topicLen) {
+      if (topicFilter.charAt(filterPos) == '#') {
+        /*
+         * next 'if' will break when topicFilter = topic/# and topicName topic/A/, but they are matched
+         */
+        topicPos = topicLen;
+        filterPos = filterLen;
+        break;
+      }
+      if (topicName.charAt(topicPos) == '/' && topicFilter.charAt(filterPos) != '/')
+        break;
+      if (topicFilter.charAt(filterPos) != '+' && topicFilter.charAt(filterPos) != '#'
+          && topicFilter.charAt(filterPos) != topicName.charAt(topicPos))
+        break;
+      if (topicFilter.charAt(filterPos) == '+') { // skip until we meet the next separator, or end of string
+        int nextpos = topicPos + 1;
+        while (nextpos < topicLen && topicName.charAt(nextpos) != '/')
+          nextpos = ++topicPos + 1;
+      } else if (topicFilter.charAt(filterPos) == '#')
+        topicPos = topicLen - 1; // skip until end of string
+      filterPos++;
+      topicPos++;
+    }
 
-		if ((topicPos == topicLen) && (filterPos == filterLen)) {
-			return true;
-		} else {
-			/*
-			 * https://github.com/eclipse/paho.mqtt.java/issues/418 Covers edge case to
-			 * match sport/# to sport
-			 */
-                       if ((topicFilter.length() - filterPos > 0) && (topicPos == topicLen)) {
-                               if (topicName.charAt(topicPos - 1) == '/' && topicFilter.charAt(filterPos) == '#')
-                                       return true;
-                               if (topicFilter.length() - filterPos > 1
-                                       && topicFilter.substring(filterPos, filterPos + 2).equals("/#")) {
-			               if ((topicFilter.length() - topicName.length()) == 2
-					        && topicFilter.substring(topicFilter.length() - 2, topicFilter.length()).equals("/#")) {
-					        return true;
-				        }
-                                }
-			}
-		}
-		return false;
-	}
+    if ((topicPos == topicLen) && (filterPos == filterLen)) {
+      return true;
+    } else {
+      /*
+       * https://github.com/eclipse/paho.mqtt.java/issues/418 Covers edge case to match sport/# to sport
+       */
+      if ((topicFilter.length() - filterPos > 0) && (topicPos == topicLen)) {
+        if (topicName.charAt(topicPos - 1) == '/' && topicFilter.charAt(filterPos) == '#')
+          return true;
+        if (topicFilter.length() - filterPos > 1 && topicFilter.substring(filterPos, filterPos + 2).equals("/#")) {
+          if ((topicFilter.length() - topicName.length()) == 2
+              && topicFilter.substring(topicFilter.length() - 2, topicFilter.length()).equals("/#")) {
+            return true;
+          }
+        }
+      }
+      /*
+       * https://github.com/eclipse/paho.mqtt.java/issues/918
+       * covers cases that include more then one wildcard
+       * sport/+/tennis/#
+       */
+        String[] topicFilterParts = topicFilter.split(TOPIC_LEVEL_SEPARATOR);
+        String[] topicParts = topicName.split(TOPIC_LEVEL_SEPARATOR);
+        if(topicFilterParts.length -1 == topicParts.length &&
+            topicFilterParts[topicFilterParts.length-1].equals( MULTI_LEVEL_WILDCARD)) {      
+          for (int i = 0; i<topicParts.length;i++) {
+            if(!topicParts[i].equals(topicFilterParts[i]) && !topicFilterParts[i].equals(SINGLE_LEVEL_WILDCARD)) {
+              return false;
+            }       
+          }
+          return true;
+        }  
+      
+    }
+    return false;
+  }
 
 }


### PR DESCRIPTION
fix : modify to throw MqttException if MqttAsyncClient.connect() is called when there is no message broker (message broker service is down due to a failure, or address is incorrect...)

For users who use the library, debugging is very difficult unless exceptions are thrown in such cases.
Currently, if the message broker attempts to connect to a situation that does not exist, there is a risk of performing the next logic without any exceptions being returned.
Of course, the getException() of the IMqttToken instance returned to the connect() call can be checked for an Exception, but it is difficult to use because it is not synchronized.
I think it's right to make an exception in this particular case.

issue #1020