### PR TITLE
fix issues/873

### DIFF
--- a/org.eclipse.paho.mqttv5.client/src/main/java/org/eclipse/paho/mqttv5/client/MqttConnectionOptions.java
+++ b/org.eclipse.paho.mqttv5.client/src/main/java/org/eclipse/paho/mqttv5/client/MqttConnectionOptions.java
@@ -510,12 +510,15 @@ public class MqttConnectionOptions {
 	 * the maximum time that the broker will maintain the session for once the
 	 * client disconnects. Clients should only connect with a long Session Expiry
 	 * interval if they intend to connect to the server at some later point in time.
-	 * 
+	 *
 	 * <ul>
 	 * <li>By default this value is null and so will not be sent, in this case, the
 	 * session will not expire.</li>
-	 * <li>If a 0 is sent, the session will end immediately once the Network
+	 * <li>If a 0 is sent, or if is absent, the session will end immediately once the Network
 	 * Connection is closed.</li>
+	 * <li>If the Session Expiry Interval is 0xFFFFFFFF (UINT_MAX), the Session does not expire.</li>
+	 * <li>The Client and Server MUST store the Session State after the Network Connection is closed if
+	 * the Session Expiry Interval is greater than 0</li>
 	 * </ul>
 	 * 
 	 * When the client has determined that it has no longer any use for the session,


### PR DESCRIPTION
Please make sure that the following boxes are checked before submitting your Pull Request, thank you!

- [X] This change is against the develop branch, **not** master.
- [X] You have signed the [Eclipse ECA](https://wiki.eclipse.org/ECA)
- [X] All of your commits have been signed-off with the correct email address (the same one that you 
      used to sign the CLA) _Hint: use the -s argument when committing_.
- [X] If This PR fixes an issue, that you reference the issue below. OR if this is a new issue that 
      you are fixing straight away that you add some Description about the bug and how this will fix it.
- [ ] If this is new functionality, You have added the appropriate Unit tests.

fix #909 #873 #1005 

Fixing the java docs of the method
 org.eclipse.paho.mqttv5.client.setSessionExpiryInterval(long)

Without calling this method with parameters greater than 0 or different from null,
once the Network Connetion is closed, the broker will end immediatly the session even if the client 
is using cleanSession = false.