### PR TITLE
fix javadoc error

### DIFF
--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/NetworkModule.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/NetworkModule.java
@@ -25,7 +25,7 @@ import org.eclipse.paho.client.mqttv3.MqttException;
  * A NetworkModule provides access to a specific transport to the broker. This may be a plain socket, a TLS secured
  * connection, a serial line, etc.
  *
- * <h3>Lifecycle</h3>
+ * <h2>Lifecycle</h2>
  * Each NetworkModule instance has a lifecycle with the following logical states:
  * <ul>
  * <li><b>CREATED</b> - the instance holds no connection to its broker, no network resources are allocated and the


### PR DESCRIPTION
NetworkModule.java:28: error: heading used out of sequence: <H3>, compared to implicit preceding heading: <H1>

Please make sure that the following boxes are checked before submitting your Pull Request, thank you!

- [x] This change is against the develop branch, **not** master.
- [x] You have signed the [Eclipse ECA](https://wiki.eclipse.org/ECA)
- [x] All of your commits have been signed-off with the correct email address (the same one that you 
      used to sign the CLA) _Hint: use the -s argument when committing_.
- [ ] If This PR fixes an issue, that you reference the issue below. OR if this is a new issue that 
      you are fixing straight away that you add some Description about the bug and how this will fix it.
- [ ] If this is new functionality, You have added the appropriate Unit tests.
