### PR TITLE
Adds 'Automatic-Module-Name' to the client modules

### DIFF
--- a/org.eclipse.paho.client.mqttv3/META-INF/MANIFEST.MF
+++ b/org.eclipse.paho.client.mqttv3/META-INF/MANIFEST.MF
@@ -1,4 +1,5 @@
 Manifest-Version: 1.0
+Automatic-Module-Name: org.eclipse.paho.client.mqttv3
 Bundle-ManifestVersion: 2
 Bundle-Name: org.eclipse.paho.client.mqttv3
 Bundle-SymbolicName: org.eclipse.paho.client.mqttv3

--- a/org.eclipse.paho.mqttv5.client/META-INF/MANIFEST.MF
+++ b/org.eclipse.paho.mqttv5.client/META-INF/MANIFEST.MF
@@ -1,4 +1,5 @@
 Manifest-Version: 1.0
+Automatic-Module-Name: org.eclipse.paho.mqttv5.client
 Bundle-ManifestVersion: 2
 Bundle-Name: Paho Mqtt Client
 Bundle-SymbolicName: org.eclipse.paho.mqttv5.client


### PR DESCRIPTION
Fixes #585

Adding the 'Automatic-Module-Name' is the preferred way to specify  modules for the Java module system when no 'module-info.java' can be  used.

- [x] This change is against the develop branch, **not** master.
- [x] You have signed the [Eclipse ECA](https://wiki.eclipse.org/ECA)
- [x] All of your commits have been signed-off with the correct email address (the same one that you 
      used to sign the CLA) _Hint: use the -s argument when committing_.
- [x] If This PR fixes an issue, that you reference the issue below. OR if this is a new issue that 
      you are fixing straight away that you add some Description about the bug and how this will fix it.
- [x] If this is new functionality, You have added the appropriate Unit tests.