### PR TITLE
Add workflow to generate and upload SBOMs for new releases

### DIFF
--- a/.github/workflows/generate-maven-sbom.yml
+++ b/.github/workflows/generate-maven-sbom.yml
@@ -1,0 +1,67 @@
+name: Generate Maven SBOM
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version'
+        default: 'master'
+        required: true
+
+env:
+  JAVA_VERSION: '8'
+  JAVA_DISTRO: 'temurin'
+  PRODUCT_PATH: './'
+  PLUGIN_VERSION: '2.7.8'
+  SBOM_TYPE: 'makeAggregateBom'
+
+permissions:
+  contents: read
+
+jobs:
+  generate-sbom:
+    runs-on: ubuntu-latest
+    outputs:
+      project-version: ${{ steps.version.outputs.PROJECT_VERSION }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.inputs.version }}
+
+      - name: Setup Java SDK
+        uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12 # v4.7.0
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: ${{ env.JAVA_DISTRO }}
+
+      - name: Generate sbom
+        run: |
+          mvn org.cyclonedx:cyclonedx-maven-plugin:$PLUGIN_VERSION:$SBOM_TYPE -f "$PRODUCT_PATH/pom.xml"
+
+      - name: Extract product version
+        id: version
+        shell: bash
+        run: |
+          VERSION="$(jq -r '.metadata.component.version' < ./${{ env.PRODUCT_PATH }}/target/bom.json)"
+          echo "PROJECT_VERSION=$VERSION" >> $GITHUB_OUTPUT
+          echo "Product version: $VERSION"
+
+      - name: Upload sbom
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
+        with:
+          name: sbom
+          path: ${{ env.PRODUCT_PATH }}/target/bom.json
+
+  store-sbom-data: # stores sbom and metadata in a predefined format for otterdog to pick up
+    needs: ['generate-sbom']
+    uses: eclipse-csi/workflows/.github/workflows/store-sbom-data.yml@main
+    with:
+      projectName: 'paho.mqtt.java'
+      projectVersion: ${{ needs.generate-sbom.outputs.project-version }}
+      bomArtifact: 'sbom'
+      bomFilename: 'bom.json'
+      parentProject: '27463a59-b016-4fa1-8741-7cf4fc61c760'


### PR DESCRIPTION
This PR aims to bootstrap the EF Security Team initiative of supporting projects in implementing automated SBOM generation and upload workflows, with the goal of enhancing software supply chain security.

We wanted this to seamlessly integrate with your existing release processes, so we implemented 1 workflow meant to generate an SBOM for the [paho.mqtt.java](https://github.com/eclipse-paho/paho.mqtt.java) product.

Currently the workflow is triggered by new releases being published. A maven cyclonedx plugin (cyclonedx-maven-plugin) is used to generate the SBOM, which is then uploaded as an artifact. The "store-sbom-data" reusable workflow stores additional metadata about the project and upon completion, the self service system downloads the SBOM from artifacts and uploads it to our DependencyTrack [instance](https://sbom.eclipse.org/).

We have tested the SBOM generation separately and everything worked successfully. However, due to limited permissions and inability to simulate the trigger event, if the changes get merged, we'd ask if you could manually run it once so we can confirm the upload to our instance works as expected (for the version input feel free to use the existing latest tag).

Otherwise however feel free to update the workflow as needed, edits by maintainers are enabled. Please let us know if you have any questions we can help with.

- [X] This change is against the develop branch, **not** master.
- [X] You have signed the [Eclipse ECA](https://wiki.eclipse.org/ECA)
- [X] All of your commits have been signed-off with the correct email address (the same one that you 
      used to sign the CLA) _Hint: use the -s argument when committing_.
- [ ] If This PR fixes an issue, that you reference the issue below. OR if this is a new issue that 
      you are fixing straight away that you add some Description about the bug and how this will fix it.
- [ ] If this is new functionality, You have added the appropriate Unit tests.
