### PR TITLE
Fix AUTH packet fixed header

### DIFF
--- a/org.eclipse.paho.mqttv5.client/src/main/java/org/eclipse/paho/mqttv5/client/internal/ClientComms.java
+++ b/org.eclipse.paho.mqttv5.client/src/main/java/org/eclipse/paho/mqttv5/client/internal/ClientComms.java
@@ -41,6 +41,7 @@ import org.eclipse.paho.mqttv5.client.logging.LoggerFactory;
 import org.eclipse.paho.mqttv5.common.MqttException;
 import org.eclipse.paho.mqttv5.common.MqttMessage;
 import org.eclipse.paho.mqttv5.common.MqttPersistenceException;
+import org.eclipse.paho.mqttv5.common.packet.MqttAuth;
 import org.eclipse.paho.mqttv5.common.packet.MqttConnAck;
 import org.eclipse.paho.mqttv5.common.packet.MqttConnect;
 import org.eclipse.paho.mqttv5.common.packet.MqttDisconnect;
@@ -176,8 +177,9 @@ public class ClientComms {
 	public void sendNoWait(MqttWireMessage message, MqttToken token) throws MqttException {
 		final String methodName = "sendNoWait";
 
-		if (isConnected() || (!isConnected() && message instanceof MqttConnect)
-				|| (isDisconnecting() && message instanceof MqttDisconnect)) {
+		if (isConnected() ||
+				(!isConnected() && (message instanceof MqttConnect || message instanceof MqttAuth)) ||
+				(isDisconnecting() && message instanceof MqttDisconnect)) {
 
 			if (disconnectedMessageBuffer != null && disconnectedMessageBuffer.getMessageCount() != 0) {
 				// @TRACE 507=Client Connected, Offline Buffer available, but not empty. Adding

--- a/org.eclipse.paho.mqttv5.client/src/main/java/org/eclipse/paho/mqttv5/client/internal/ClientState.java
+++ b/org.eclipse.paho.mqttv5.client/src/main/java/org/eclipse/paho/mqttv5/client/internal/ClientState.java
@@ -841,8 +841,15 @@ public class ClientState implements MqttState {
 				// Handle the case where not connected. This should only be the case if:
 				// - in the process of disconnecting / shutting down
 				// - in the process of connecting
-				if (pendingFlows == null || (!connected && (pendingFlows.isEmpty()
-						|| !((MqttWireMessage) pendingFlows.elementAt(0) instanceof MqttConnect)))) {
+				if (pendingFlows == null ||
+						(!connected &&
+								(pendingFlows.isEmpty() ||
+										!( ( pendingFlows.elementAt(0) instanceof MqttConnect) ||
+												( pendingFlows.elementAt(0) instanceof MqttAuth)
+										)
+								)
+						)
+				){
 					// @TRACE 621=no outstanding flows and not connected
 					log.fine(CLASS_NAME, methodName, "621");
 

--- a/org.eclipse.paho.mqttv5.client/src/main/java/org/eclipse/paho/mqttv5/common/packet/MqttAuth.java
+++ b/org.eclipse.paho.mqttv5.client/src/main/java/org/eclipse/paho/mqttv5/common/packet/MqttAuth.java
@@ -104,7 +104,7 @@ public class MqttAuth extends MqttWireMessage {
 
 	@Override
 	protected byte getMessageInfo() {
-		return (byte) (1);
+		return (byte) (0);
 	}
 
 	public int getReturnCode() {


### PR DESCRIPTION
Please make sure that the following boxes are checked before submitting your Pull Request, thank you!

- [x] This change is against the develop branch, **not** master.
- [x] You have signed the [Eclipse ECA](https://wiki.eclipse.org/ECA)
- [x] All of your commits have been signed-off with the correct email address (the same one that you 
      used to sign the CLA) _Hint: use the -s argument when committing_.
- [x] If This PR fixes an issue, that you reference the issue below. OR if this is a new issue that 
      you are fixing straight away that you add some Description about the bug and how this will fix it.
- [x] If this is new functionality, You have added the appropriate Unit tests.

Analyze AUTH packet, the reserved part of the fixed header:
<img width="1655" height="517" alt="Clipboard_Screenshot_1754711986" src="https://github.com/user-attachments/assets/373772d1-d561-438b-9708-c641cdfbe8f8" />

According to [MQTT protocol 5.0 AUTH packet](https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901217), fixed header, byte 1, reserved part shall be all 0:
<img width="1685" height="391" alt="Clipboard_Screenshot_1754712087" src="https://github.com/user-attachments/assets/8e6b2b05-75a1-4b3e-9a75-3df0d06c1bf6" />

1.2.5 client, when talking to netty-mqtt-codec server, an error reports:

> io.netty.handler.codec.DecoderException: Illegal BIT 0 in fixed header of AUTH message, must be 0, found 1

This pull request fixes:
   
https://github.com/eclipse-paho/paho.mqtt.java/issues/980
    
https://github.com/eclipse-paho/paho.mqtt.java/issues/981

